### PR TITLE
Set choice of solver as Matlab preference

### DIFF
--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -6,7 +6,7 @@ function checkInstallation()
 %   Usage: checkInstallation()
 %
 %   Rasmus Agren, 2014-01-06
-%
+%	Eduard Kerkhoven, 2016-10-23 - Use Matlab preferences for solver selection
 
 fprintf('*** RAVEN TOOLBOX v. 1.9\n');
 
@@ -21,7 +21,12 @@ paths=paths{1};
 [ravenDir,crap1,crap2]=fileparts(fileparts(ST(I).file));
 
 % get current solver
-global RAVENSOLVER;
+if ~ispref('RAVEN','solver')
+	fprintf('Solver found in preferences... NONE\n');
+else
+	curSolv=getpref('RAVEN','solver');
+	fprintf(['Solver found in preferences... ',curSolv,'\n']);
+end
 
 if ismember(ravenDir,paths)
     fprintf('Checking if RAVEN is in the Matlab path... PASSED\n');
@@ -61,7 +66,7 @@ solver={'mosek','gurobi'};
 
 for i=[1:numel(solver)]
     try
-        setRavenSolver(solver{i},false);
+        setRavenSolver(solver{i});
         solveLP(smallModel);
         lastWorking=solver{i};
         fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'... PASSED\n']);
@@ -74,6 +79,12 @@ if (~isempty(lastWorking))
     setRavenSolver(lastWorking);
 end
 
+if isempty(curSolv)
+	fprintf(['Prefered solver... NEW\nSolver saved as preference... ',lastWorking,'\n']);
+elseif strcmp(curSolv,lastWorking)
+	fprintf(['Prefered solver... KEPT\nSolver saved as preference... ',lastWorking,'\n']);
+else
+	fprintf(['Prefered solver... CHANGED\nSolver saved as preference... ',lastWorking,'\n']);
+end
+
 %function lastWorking=checkSolver(solver)
-
-

--- a/solver/setRavenSolver.m
+++ b/solver/setRavenSolver.m
@@ -1,79 +1,17 @@
-function out = setRavenSolver(solver,saveSolver)
+function out = setRavenSolver(solver)
 % setRavenSolver
 %   Sets the solver for RAVEN and optionally saves a default value
 %	to MATLAB startup.
 %
-%   solver		a string ('gurobi','mosek', ...)
-%   saveSolver	option to save the choice as default to startup.m
+%   solver		a string ('gurobi','mosek', 'cobra', ...)
 %
-%   Usage: setRavenSolver('gurobi',true)
+%   Usage: setRavenSolver('gurobi')
 %
 %   Daniel Hermansson, 2016-10-10
+%   Eduard Kerkhoven, 2016-10-22 - Use Matlab preferences for solver selection
 
-	if nargin<2
-		saveSolver='none';
-	end
-
-	if (~ischar(solver)) dispEM('Input should be a string.'); end
+if (~ischar(solver)) dispEM('Input should be a string.'); end
 	
-	if (isempty(userpath))
-		userpath('reset')
-	end
-	
-	up=pathdef;
-	up=regexp(up,':','split');
-	up=up{1};
+setpref('RAVEN','solver',solver)
 
-	% copy setRavenSolver to userpath	
-	if (exist(fullfile(up,'setRavenSolver.m'), 'file') ~= 2)
-		p = mfilename('fullpath');
-		copyfile([p,'.m'],up);
-	end
-
-	global RAVENSOLVER;
-	RAVENSOLVER=solver;
-
-	try
-		ravenSet=false;
-		startupInd=1;
-
-		% Read txt into cell
-		lines = regexp( fileread(fullfile(up,'startup.m')), '\n', 'split');
-		for i = 1:numel(lines)
-			if (regexp(lines{i},'setRavenSolver('))
-				ravenSet=true;
-				startupInd=i;
-			end
-		end
-	catch Ex
-		%
-	end
-
-	if (~saveSolver) return; end
-
-	% if we reached this far we are interested in saving the choice to startup
-	if (~ravenSet && strcmp(saveSolver,'none'))
-		m=input(['You have no default RAVEN solver defined. Should we append ', solver ,' to MATLAB startup? y/n [y]: '],'s');
-		if (m=='n') return; end
-	end
-	
-	try
-		if (ravenSet)
-			fid = fopen(fullfile(up,'startup.m'),'w');
-			lines{startupInd} = sprintf('setRavenSolver(''%s'');', solver);
-
-			% Write cell into txt
-			for i = 1:numel(lines)
-		        if (~strcmp(lines{i},'')) fprintf(fid,'%s\n', lines{i}); end
-			end
-		else
-			fid = fopen(fullfile(up,'startup.m'),'a+');
-			fprintf(fid,'\nsetRavenSolver(''%s'');\n', solver);
-		end
-	catch Ex
-		if (fid~=-1) fclose(fid); end
-		dispEM('Could not save to startup.m');
-	end
-
-	if (fid~=-1) fclose(fid); end
 end


### PR DESCRIPTION
The choice of solver is stored as Matlab preference, which is persistent (no need for saveSolver) and stored in a system dependent location (fixes issues #2).

Additional RAVEN preferences should then also be stored in setpref('RAVEN',...).