### PR TITLE
Small fix in checkInstallation

### DIFF
--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -79,7 +79,7 @@ if (~isempty(lastWorking))
     setRavenSolver(lastWorking);
 end
 
-if isempty(curSolv)
+if ~exist(curSolv,'var')
 	fprintf(['Prefered solver... NEW\nSolver saved as preference... ',lastWorking,'\n']);
 elseif strcmp(curSolv,lastWorking)
 	fprintf(['Prefered solver... KEPT\nSolver saved as preference... ',lastWorking,'\n']);


### PR DESCRIPTION
The error is shown if curSolv is not defined. It is therefore better to
check, whether curSolv is defined rather than checking
whether it is empty.