### PR TITLE
Small fixes for importModel

### DIFF
--- a/io/importModel.m
+++ b/io/importModel.m
@@ -131,9 +131,9 @@ compartmentMiriams=cell(numel(modelSBML.compartment),1);
 for i=1:numel(modelSBML.compartment)
     compartmentNames{i}=modelSBML.compartment(i).name;
     if isCOBRA==true
-		if strcmpi(modelSBML.compartment(i).id(1:2),'C_')
+		try strcmpi(modelSBML.compartment(i).id(1:2),'C_')
 			compartmentIDs{i}=modelSBML.compartment(i).id(3:end);
-        else
+        catch
 			compartmentIDs{i}=modelSBML.compartment(i).id;
 		end
     else
@@ -340,9 +340,9 @@ else
         end
         
         metaboliteIDs{numel(metaboliteIDs)+1,1}=modelSBML.species(i).id(3:numel(modelSBML.species(i).id));
-		if strcmpi(modelSBML.species(i).compartment(1:2),'C_')
+		try strcmpi(modelSBML.species(i).compartment(1:2),'C_')
 			metaboliteCompartments{numel(metaboliteCompartments)+1,1}=modelSBML.species(i).compartment(3:end);
-		else
+        catch
 			metaboliteCompartments{numel(metaboliteCompartments)+1,1}=modelSBML.species(i).compartment;
 		end
 		

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -145,9 +145,12 @@ for i=1:numel(modelSBML.compartment)
     if isfield(modelSBML.compartment(i),'outside')
         if ~isempty(modelSBML.compartment(i).outside)
             if isCOBRA==true
-				if strcmpi(modelSBML.compartment(i).outside(1:2),'C_')
-					compartmentOutside{i}=modelSBML.compartment(i).outside(3:end);
-				else
+				try if strcmpi(modelSBML.compartment(i).outside(1:2),'C_')
+						compartmentOutside{i}=modelSBML.compartment(i).outside(3:end);
+					else
+						compartmentOutside{i}=modelSBML.compartment(i).outside;
+					end
+				catch
 					compartmentOutside{i}=modelSBML.compartment(i).outside;
 				end
             else

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -131,9 +131,12 @@ compartmentMiriams=cell(numel(modelSBML.compartment),1);
 for i=1:numel(modelSBML.compartment)
     compartmentNames{i}=modelSBML.compartment(i).name;
     if isCOBRA==true
-		try strcmpi(modelSBML.compartment(i).id(1:2),'C_')
-			compartmentIDs{i}=modelSBML.compartment(i).id(3:end);
-        catch
+		try if strcmpi(modelSBML.compartment(i).id(1:2),'C_')
+				compartmentIDs{i}=modelSBML.compartment(i).id(3:end);
+			else
+				compartmentIDs{i}=modelSBML.compartment(i).id;
+			end
+		catch
 			compartmentIDs{i}=modelSBML.compartment(i).id;
 		end
     else
@@ -340,9 +343,12 @@ else
         end
         
         metaboliteIDs{numel(metaboliteIDs)+1,1}=modelSBML.species(i).id(3:numel(modelSBML.species(i).id));
-		try strcmpi(modelSBML.species(i).compartment(1:2),'C_')
-			metaboliteCompartments{numel(metaboliteCompartments)+1,1}=modelSBML.species(i).compartment(3:end);
-        catch
+		try if strcmpi(modelSBML.species(i).compartment(1:2),'C_')
+				metaboliteCompartments{numel(metaboliteCompartments)+1,1}=modelSBML.species(i).compartment(3:end);
+			else
+				metaboliteCompartments{numel(metaboliteCompartments)+1,1}=modelSBML.species(i).compartment;
+			end
+		catch
 			metaboliteCompartments{numel(metaboliteCompartments)+1,1}=modelSBML.species(i).compartment;
 		end
 		


### PR DESCRIPTION
Compartment ID of length < 2 called an error after previous pull request.
First attempt to fix this introduced a problem when ID length was 2 or longer, but **not** starting with C_.
Second fix can now deal with comparment IDs like "C_e", "e" and "ext".
Third fix introduces these changes also for compOutside.
(I should probably not push so often...)