### PR TITLE
Deal with NA Pvalues and Fold Changes in reporterMetabolites

### DIFF
--- a/core/reporterMetabolites.m
+++ b/core/reporterMetabolites.m
@@ -64,7 +64,17 @@ end
 
 %Remove the genes which are not in the model
 genePValues(~ismember(genes,model.genes))=[];
+if any(geneFoldChanges)
+    geneFoldChanges(~ismember(genes,model.genes))=[];
+end
 genes(~ismember(genes,model.genes))=[];
+
+%Remove the genes that has NA P-value
+genes(isnan(genePValues))=[];
+if any(geneFoldChanges)
+    geneFoldChanges(isnan(genePValues))=[];
+end
+genePValues(isnan(genePValues))=[];
 
 %Convert p-values to Z-scores
 geneZScores=norminv(genePValues)*-1;


### PR DESCRIPTION
Hi,

I found two little bugs for the "reporterMetabolites" function:
1. The P-Value and Z-score is showing "NA" in the printed result and result file. This happened due to "NA" in the input P-values, that is causing problem during the usage of "mean" and "std" when correcting for background. "mean" and "std" in Matlab doesn't work well with NA.
2. When geneFoldChanges is provided, it showed "Index exceeds matrix dimensions". It is because there's a mismatch between the size of genes, genesPValues and geneFoldChanges, because genes that are not in model.genes are still there in geneFoldChanges.

I tried to provide small fixes, and it works. Let me know your thoughts.

Thanks!!