### PR TITLE
Fix/import model

### DIFF
--- a/io/importModel.m
+++ b/io/importModel.m
@@ -71,7 +71,7 @@ function model=importModel(fileName,removeExcMets,isSBML2COBRA,supressWarnings)
 %
 %   Usage: model=importModel(fileName,removeExcMets,isSBML2COBRA,supressWarnings)
 %
-%   Simonas Marcisauskas, 2017-11-22
+%   Eduard Kerkhoven, 2018-02-09
 
 if nargin<2
     removeExcMets=true;
@@ -1140,11 +1140,10 @@ targetString=regexprep(targetString,midString,'/','once');
 
 counter=0;
 for i=1:numel(targetString)
-    if ~regexp(targetString{1,i},'inchi')
-        if ~regexp(targetString{1,i},'ec-code')
-            counter=counter+1;
-            miriamStruct.name{counter,1} = regexprep(targetString{1,i},'/.+','','once');   
-            miriamStruct.value{counter,1} = regexprep(targetString{1,i},[miriamStruct.name{counter,1} midString],'','once');
+    if ~isempty(regexp(targetString{1,i},'inchi|ec-code'))
+        counter=counter+1;
+        miriamStruct.name{counter,1} = regexprep(targetString{1,i},'/.+','','once');
+        miriamStruct.value{counter,1} = regexprep(targetString{1,i},[miriamStruct.name{counter,1} midString],'','once');
         end;
     end;
 end;

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -1140,11 +1140,10 @@ targetString=regexprep(targetString,midString,'/','once');
 
 counter=0;
 for i=1:numel(targetString)
-    if ~isempty(regexp(targetString{1,i},'inchi|ec-code'))
+    if isempty(regexp(targetString{1,i},'inchi|ec-code'))
         counter=counter+1;
         miriamStruct.name{counter,1} = regexprep(targetString{1,i},'/.+','','once');
         miriamStruct.value{counter,1} = regexprep(targetString{1,i},[miriamStruct.name{counter,1} midString],'','once');
-        end;
     end;
 end;
 end


### PR DESCRIPTION
~regexp of a cell array does not give required logical (true/false). This was introduced when avoiding the contains() function, not sure if this problem also persists in other RAVEN functions.