### PR TITLE
Fix/remove genes

### DIFF
--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -310,7 +310,7 @@ for i=1:numel(models)
     %deleted. This approach works fine for 'and' complexes, but there
     %should be a check that it doesn't keep 'or' genes if it doesn't have
     %to!
-    models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},~a,true,true);
+    models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},~a,true,true,false);
 end
 
 %Since I want to use mergeModels in the end, I simplify the models further

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -310,7 +310,7 @@ for i=1:numel(models)
     %deleted. This approach works fine for 'and' complexes, but there
     %should be a check that it doesn't keep 'or' genes if it doesn't have
     %to!
-    models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},~a,true,false);
+    models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},~a,true,true);
 end
 
 %Since I want to use mergeModels in the end, I simplify the models further

--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -34,7 +34,9 @@ end
 
 %Format grRules and rxnGeneMatrix:
 if standardizeRules
-    model = standardizeGrRules(model);
+    [grRules,rxnGeneMat] = standardizeGrRules(model);
+    model.grRules = grRules;
+    model.rxnGeneMat = rxnGeneMat;
 end
 
 reducedModel = model;

--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -91,6 +91,9 @@ function geneRule = removeGeneFromRule(geneRule,geneToRemove)
     hasGene  = ~cellfun(@isempty,strfind(geneSets,geneToRemove));
     geneSets = geneSets(~hasGene);
     geneRule = strjoin(geneSets,' or ');
+    if length(geneSets) == 1 && ~isempty(strfind(geneRule,'('))
+        geneRule = geneRule(2:end-1);
+    end
 end
 
 

--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -1,83 +1,98 @@
-function [reducedModel,notDeleted]=removeGenes(model,genesToRemove, removeUnusedMets, removeRxnsWithComplexes)
+function reducedModel = removeGenes(model,genesToRemove,removeUnusedMets,removeBlockedRxns)
 % removeGenes
-%   Deletes a set of genes and all reactions corresponding to them from a model
+%   Deletes a set of genes from a model
 %
-%   model                     a model structure
-%   genesToRemove             either a cell array of gene IDs, a logical vector
-%                             with the same number of elements as genes in the model,
-%                             or a vector of indexes to remove
-%   removeUnusedMets          remove metabolites that are no longer in use (opt, default
-%                             false)
-%   removeRxnsWithComplexes   remove reactions that are dependent on a
-%                             complex if only part of the complex is in genesToRemove
-%                             (opt, default false)
+%   model                   a model structure
+%   genesToRemove           either a cell array of gene IDs, a logical vector
+%                           with the same number of elements as genes in the model,
+%                           or a vector of indexes to remove
+%   removeUnusedMets        remove metabolites that are no longer in use (opt, default
+%                           false)
+%   removeBlockedRxns       remove reactions that get blocked after deleting the genes
+%                           (opt, default false)
 %
-%   reducedModel              an updated model structure
-%   notDeleted                a cell array with the genes that couldn't be
-%                             deleted. This is an empty cell if removeRxnsWithComplexes
-%                             is true
+%   reducedModel            an updated model structure
 %
-%   Usage: [reducedModel,notDeleted]=removeGenes(model,genesToRemove,
-%           removeUnusedMets, removeRxnsWithComplexes)
+%   Usage: reducedModel = removeGenes(model,genesToRemove,removeUnusedMets,removeBlockedRxns)
 %
-%   Rasmus Agren, 2014-01-08
+%   Benjamín J. Sánchez, 2018-03-28
 %
 
 if nargin<3
-    removeUnusedMets=false;
+    removeUnusedMets = false;
 end
 
 if nargin<4
-    removeRxnsWithComplexes=false;
+    removeBlockedRxns = false;
 end
 
-notDeleted={};
-
-reducedModel=model;
+reducedModel = model;
 
 if ~isempty(genesToRemove)
-    indexesToDelete=getIndexes(reducedModel,genesToRemove,'genes');
-
-    %Find all reactions for these genes
-    if ~isempty(indexesToDelete) && isfield(reducedModel,'rxnGeneMat')
-        [a, ~]=find(reducedModel.rxnGeneMat(:,indexesToDelete));
-        a=unique(a);
-        if removeRxnsWithComplexes==true
-            %Delete those reactions even if they use complexes
-            reducedModel=removeReactions(reducedModel,a,removeUnusedMets,true);
-        else
-            %First check that all part of the complex should be removed
-            rxnsToRemove=false(numel(a),1);
-
-            %Loop through the reactions that could possibly be removed
-            for i=1:numel(a)
-                [~, geneIndexes]=find(reducedModel.rxnGeneMat(a(i),:));
-
-                %Check to see if all should be removed
-                if numel(geneIndexes)>1
-                    if all(ismember(geneIndexes,indexesToDelete))
-                        rxnsToRemove(i)=true;
-                    else
-                        %Don't remove the reaction
-                    end
-                else
-                   %Only one gene, remove the reaction
-                   rxnsToRemove(i)=true;
+    indexesToRemove = getIndexes(model,genesToRemove,'genes');
+    if ~isempty(indexesToRemove)
+        %Make 0 corresponding columns from rxnGeneMat:
+        reducedModel.rxnGeneMat(:,indexesToRemove) = 0;
+        
+        genes        = model.genes(indexesToRemove);
+        canCarryFlux = true(size(model.rxns));
+        
+        %Loop through genes and adapt rxns:
+        for i = 1:length(genes)
+            %Find all reactions for this gene and loop through them:
+            isGeneInRxn = ~cellfun(@isempty,strfind(reducedModel.grRules,genes{i}));
+            for j = 1:length(reducedModel.grRules)
+                if isGeneInRxn(j) && canCarryFlux(j)
+                    grRule = reducedModel.grRules{j};
+                    
+                    %Check if rxn can carry flux without this gene:
+                    canCarryFlux(j) = canRxnCarryFlux(reducedModel,grRule,genes{i});
+                    
+                    %Adapt gene rule & gene matrix:
+                    grRule = removeGeneFromRule(grRule,genes{i});
+                    reducedModel.grRules{j} = grRule;
                 end
             end
-
-            %Get the genes that will be deleted (any involved in the
-            %reactions to be deleted
-            [~, geneIndexes]=find(reducedModel.rxnGeneMat(a(rxnsToRemove),:));
-            if ~isempty(setdiff(indexesToDelete,geneIndexes))
-                notDeleted=reducedModel.genes(setdiff(indexesToDelete,geneIndexes));
-            end
-
-            %Delete the reactions
-            reducedModel=removeReactions(reducedModel,a(rxnsToRemove),removeUnusedMets,true);
+        end
+        
+        %Delete or block the reactions that cannot carry flux:
+        if removeBlockedRxns
+            rxnsToRemove = reducedModel.rxns(~canCarryFlux);
+            reducedModel = removeReactions(reducedModel,rxnsToRemove,removeUnusedMets,true);
+        else
+            reducedModel = removeReactions(reducedModel,[],removeUnusedMets,true);
+            reducedModel.lb(~canCarryFlux) = 0;
+            reducedModel.ub(~canCarryFlux) = 0;
         end
     end
-else
-    reducedModel=model;
 end
+
 end
+
+function canIt = canRxnCarryFlux(model,geneRule,geneToRemove)
+    %This function converts a gene rule to a logical statement, and then asseses
+    % if the rule is true (i.e. rxn can still carry flux) or not (cannot carry flux).
+    for i = 1:length(model.genes)
+        if strcmp(model.genes{i},geneToRemove)
+            geneRule = strrep(geneRule,model.genes{i},'false');
+        else
+            geneRule = strrep(geneRule,model.genes{i},'true');
+        end
+    end
+    geneRule = strrep(geneRule,'and','&&');
+    geneRule = strrep(geneRule,'or','||');
+    canIt    = eval(geneRule);
+end
+
+function geneRule = removeGeneFromRule(geneRule,geneToRemove)
+    %This function receives a standard gene rule and it returns it without the
+    %chosen gene.
+    geneSets = strsplit(geneRule,' or ');
+    hasGene  = ~cellfun(@isempty,strfind(geneSets,geneToRemove));
+    geneSets = geneSets(~hasGene);
+    geneRule = strjoin(geneSets,' or ');
+end
+
+
+
+

--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -1,4 +1,4 @@
-function reducedModel = removeGenes(model,genesToRemove,removeUnusedMets,removeBlockedRxns)
+function reducedModel = removeGenes(model,genesToRemove,removeUnusedMets,removeBlockedRxns,standardizeRules)
 % removeGenes
 %   Deletes a set of genes from a model
 %
@@ -10,12 +10,14 @@ function reducedModel = removeGenes(model,genesToRemove,removeUnusedMets,removeB
 %                           false)
 %   removeBlockedRxns       remove reactions that get blocked after deleting the genes
 %                           (opt, default false)
+%   standardizeRules        format gene rules to be compliant with standard format
+%                           (opt, default true)
 %
 %   reducedModel            an updated model structure
 %
 %   Usage: reducedModel = removeGenes(model,genesToRemove,removeUnusedMets,removeBlockedRxns)
 %
-%   Benjamín J. Sánchez, 2018-03-28
+%   Benjamín J. Sánchez, 2018-03-29
 %
 
 if nargin<3
@@ -24,6 +26,15 @@ end
 
 if nargin<4
     removeBlockedRxns = false;
+end
+
+if nargin<5
+    standardizeRules = true;
+end
+
+%Format grRules and rxnGeneMatrix:
+if standardizeRules
+    model = standardizeGrRules(model);
 end
 
 reducedModel = model;

--- a/core/standardizeGeneRules.m
+++ b/core/standardizeGeneRules.m
@@ -1,0 +1,85 @@
+function newModel = standardizeGeneRules(model)
+% standardizeGeneRules
+%   Standardizes gene-rxn rules in a model and modifies rxnGeneMat for 
+%   providing consistency with the grRules field
+%
+%   model        a model structure
+%
+%   newModel     an updated model structure
+%
+%   Usage: newModel = standardizeGeneRules(model)
+%
+%   Ivan Domenzain, 2018-03-28
+%
+newModel = model;
+% Preallocate rxnGeneMat
+[~,n]    = size(model.S);
+[g,~]    = size(model.genes);
+RGMat    = sparse(n,g);
+
+if isfield(model,'grRules')
+    for i=1:length(model.grRules)
+        originalSTR = model.grRules{i};
+        newSTR      = [];
+        % Non-empty grRules are splitted in all their different isoenzymes
+        genesSets = getSimpleGeneSets(originalSTR);
+        if ~isempty(genesSets)
+            for j=1:length(genesSets)
+                simpleSet  = genesSets{j};
+                RGMat = modifyRxnGeneMat(simpleSet,model.genes,RGMat,i);
+                % Enclose simpleSet in brackets
+                if length(genesSets)>1
+                    simpleSet = horzcat('(',simpleSet,')');
+                end
+                % Separate genesSets in the substring (in case of
+                % isoenzymes)
+                if j<length(genesSets)
+                    newSTR = [newSTR, simpleSet, ' or '];
+                    % Add the last simpleSet
+                else
+                    newSTR = [newSTR, simpleSet];
+                end
+                
+            end
+            newModel.grRules{i} = newSTR;
+        end
+    end
+end
+newModel.rxnGeneMat = RGMat;
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% function that gets a cell array with all the simple geneSets in a given 
+% grRule string 
+function genesSets = getSimpleGeneSets(originalSTR)
+    genesSets  = [];
+    % If gene rule is not empty split in all its different isoenzymes
+    if ~isempty(originalSTR)
+        originalSTR = strtrim(originalSTR);
+        originalSTR = strrep(originalSTR,' OR ',' or ');
+        originalSTR = strrep(originalSTR,' AND ',' and ');
+        %Remove all brackets
+        originalSTR = strrep(originalSTR,'(','');
+        originalSTR = strrep(originalSTR,')','');
+        %Split all the different genesSets
+        genesSets  = transpose(strsplit(originalSTR,' or '));
+    end
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% function that gets a simple genes set (single gene or enzyme complex) and
+% a rxn index. The rxnGeneMat row (rxn) will be modified accordingly to the
+% provided genes
+function rxnGeneMat = modifyRxnGeneMat(genesSet,modelGenes,rxnGeneMat,i)
+    %Get individual genes
+    genes = strsplit(genesSet,' ');
+    for k=1:length(genes)
+        if ~strcmpi(genes(k),' and ')
+            genePos = find(strcmpi(modelGenes,genes(k)));
+            if ~isempty(genePos)
+                rxnGeneMat(i,genePos) = 1;
+                %else
+                % In this case the gene should be added to the
+                % genes field (and to all of its dependencies)
+            end
+        end
+    end
+end

--- a/core/standardizeGeneRules.m
+++ b/core/standardizeGeneRules.m
@@ -18,6 +18,8 @@ newModel = model;
 RGMat    = sparse(n,g);
 
 if isfield(model,'grRules')
+    % Search logical errors in the grRules field
+    findLogicalErrors(model)  
     for i=1:length(model.grRules)
         originalSTR = model.grRules{i};
         newSTR      = [];
@@ -83,5 +85,20 @@ function rxnGeneMat = modifyRxnGeneMat(genesSet,modelGenes,rxnGeneMat,i)
                 % genes field (and to all of its dependencies)
             end
         end
+    end
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% function that gets a simple genes set (single gene or enzyme complex) and
+% a rxn index. The rxnGeneMat row (rxn) will be modified accordingly to the
+function findLogicalErrors(model)  
+    errors_l = find(~cellfun(@isempty,strfind(model.grRules,') and (')));
+    errors_U = find(~cellfun(@isempty,strfind(model.grRules,') AND (')));
+    errors   = union(errors_l,errors_U);
+    if ~isempty(errors)
+        for i=1:length(errors)
+            index = errors(i);
+            disp(['     grRule #:',num2str(index),' ',model.grRules{index}])
+        end
+        error('Logical errors found on grRules') 
     end
 end

--- a/core/standardizeGeneRules.m
+++ b/core/standardizeGeneRules.m
@@ -29,7 +29,9 @@ if isfield(model,'grRules')
                 RGMat = modifyRxnGeneMat(simpleSet,model.genes,RGMat,i);
                 % Enclose simpleSet in brackets
                 if length(genesSets)>1
-                    simpleSet = horzcat('(',simpleSet,')');
+                    if ~isempty(strfind(simpleSet,' and '))
+                        simpleSet = horzcat('(',simpleSet,')');
+                    end
                 end
                 % Separate genesSets in the substring (in case of
                 % isoenzymes)

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -414,35 +414,6 @@ end
 
 function rxnGeneMat=getRxnGeneMat(model)
     %Check gene association for each reaction and populate rxnGeneMat
-    if ~isempty(model.genes)
-        rxnGeneMat=zeros(numel(model.rxns),numel(model.genes));
-    end
-    if ~isempty(model.grRules)
-        tempRules=model.grRules;
-        for i=1:length(model.rxns)
-           %Check that all gene associations have a match in the gene list
-           if ~isempty(model.grRules{i})          
-               tempRules{i}=regexprep(tempRules{i},' and | or ','>'); %New format: Genes are separated 'and' and 'or' strings with parentheses
-               tempRules{i}=regexprep(tempRules{i},'(',''); %New format: Genes are separated 'and' and 'or' strings with parentheses
-               tempRules{i}=regexprep(tempRules{i},')',''); %New format: Genes are separated 'and' and 'or' strings with parentheses
-               indexesNew=strfind(tempRules{i},'>'); %Old format: Genes are separated by ":" for AND and ";" for OR
-               indexes=strfind(tempRules{i},':'); %Old format: Genes are separated by ":" for AND and ";" for OR
-               indexes=unique([indexesNew indexes strfind(tempRules{i},';')]);
-               if isempty(indexes)
-                   %See if you have a match
-                   I=find(strcmp(tempRules{i},model.genes));
-                   rxnGeneMat(i,I)=1;
-               else
-                   temp=[0 indexes numel(tempRules{i})+1];
-                   for j=1:numel(indexes)+1
-                       %The reaction has several associated genes
-                       geneName=tempRules{i}(temp(j)+1:temp(j+1)-1);
-                       I=find(strcmp(geneName,model.genes));
-                       model.rxnGeneMat(i,I)=1;
-                   end
-               end
-           end
-        end
-    end
-    rxnGeneMat=sparse(rxnGeneMat);
+    modelTemp  = standardizeGeneRules(model);
+    rxnGeneMat = modelTemp.rxnGeneMat;
 end

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -157,12 +157,15 @@ if isRaven
     % It seems that grRules, rxnGeneMat and rev are disposable fields in COBRA
     % version, but we export them to make things faster, when converting
     % COBRA structure back to RAVEN;
-    if isfield(model,'grRules')
-        newModel.grRules=model.grRules;
-    end;
     if isfield(model,'rxnGeneMat')
         newModel.rxnGeneMat=model.rxnGeneMat;
     end;
+    if isfield(model,'grRules')
+        [grRules, rxnGeneMat] = standardizeGrRules(model);
+        newModel.grRules      = grRules;
+        %Incorporate a rxnGeneMat consistent with standardized grRules
+        newModel.rxnGeneMat   = rxnGeneMat;
+    end
     newModel.rev=model.rev;
  else
     fprintf('Converting COBRA structure to RAVEN..\n');
@@ -229,15 +232,14 @@ if isRaven
         newModel.rxnNames=model.rxnNames;
     end;
     if isfield(model,'grRules')
-        newModel.grRules=model.grRules;
+        [grRules,rxnGeneMat] = standardizeGrRules(model);
+        newModel.grRules     = grRules;
+        newModel.rxnGeneMat  = rxnGeneMat;
     else
-        model.grRules=rulesTogrrules(model);
-        newModel.grRules=model.grRules;
-    end;
-    if isfield(model,'rxnGeneMat')
-        newModel.rxnGeneMat=model.rxnGeneMat;
-    elseif isfield(model,'grRules')
-        newModel.rxnGeneMat=getRxnGeneMat(model);
+        model.grRules        = rulesTogrrules(model);
+        [grRules,rxnGeneMat] = standardizeGrRules(model);
+        newModel.grRules     = grRules;
+        newModel.rxnGeneMat  = rxnGeneMat;
     end;
     if isfield(model,'subSystems')
         newModel.subSystems=model.subSystems;
@@ -410,10 +412,4 @@ function grRules=rulesTogrrules(model)
     grRules = strrep(grRules,' )',')');
     grRules = regexprep(grRules,'^(','');   %rules that start with a "("
     grRules = regexprep(grRules,')$','');   %rules that end with a ")"
-end
-
-function rxnGeneMat=getRxnGeneMat(model)
-    %Check gene association for each reaction and populate rxnGeneMat
-    modelTemp  = standardizeGeneRules(model);
-    rxnGeneMat = modelTemp.rxnGeneMat;
 end


### PR DESCRIPTION
**Problem this branch addreses:**
Refer to issue #69. It has been partly fixed by adapting `removeGenes.m` to block/not block reactions based on `grRules` and not `rxnGeneMatrix`. It performs the following steps:
* If needed, standardize `grRules` with the function `standardizeGrRules.m`
* Decide if the corresponding reactions can or cannot carry flux with the subfunction `canRxnCarryFlux`, which takes a gene rule and evaluates if the corresponding KO will produce a blocked reaction by **replacing the gene IDs with booleans and assessing the resulting expression**.
* If the gene rule changes in any way, reflect it in the output model, e.g. if an isozyme was deleted from the model, then the corresponding rule will not have that isozyme.

**Case study:**
Loading the yeast model and testing `removeGenes.m` with:
1. A single rule (`r_0003 <- YAL060W`)
2. An isozyme rule (`r_0005 <- YGR032W or YLR342W`)
3. A complex rule (`r_0013 <- YEL038W and YMR009W`)
4. A mixed rule (`r_0002 <- (YDL178W and YEL039C) or (YDL178W and YJR048W)`

* **Expected output - output with this fix:**
Works as it should; reactions get properly blocked (flag `removeBlockedRxns=FALSE`, default) or deleted (flag `removeBlockedRxns=TRUE`) when no gene is left to express for the reaction, and `grRules` updates accordingly in the `reducedModel`.

* **Obtained output in `devel`:**
The only deletion that works is the one for the single rule (`YAL060W`).

* **Reproducing these results:** 
Available in the private repo [gem-scripts](https://github.com/SysBioChalmers/gem-scripts/blob/master/Ben/checkDeletions.m) or [here](https://github.com/SysBioChalmers/RAVEN/files/1872552/checkDeletions.zip).

**Note:** This PR fixes 2/3 to-do's in issue #69. Function `findGeneDeletions.m` has not been adapted yet to use `removeGenes.m`. This will be done in a separate branch.

**Note 2:** The function `ravenCobraWrapper.m` has also been modified to call `standardizeGrRules.m` (both in the direction RAVEN->COBRA and COBRA->RAVEN) and avoid code redundancy. 

**Note 3:** Even though `rxnGeneMatrix` is not used anymore, it is still created by `standardizeGrRules.m` & `ravenCobraWrapper.m` for legacy reasons.

**Note 4:** The available flags for this function have changed. `removeUnusedMets` is still available as first flag, but `removeRxnsWithComplexes` is no longer an available flag, as it should be always be true (can't see a reason to turn it to false now that the function actually works). As function `getModelFromHomology.m` was using the function with the flag set on false, a different output could be expected (but if anything now the results should improve). There are 2 new flags now: `removeBlockedRxns` with a default of false (the behavior of the old version)  and `standardizeRules`  with a default of true (should be skipped when performing intense calculations to avoid too much computation time).