### PR TITLE
Making Java library addition dynamic

### DIFF
--- a/io/addJavaPaths.m
+++ b/io/addJavaPaths.m
@@ -19,28 +19,11 @@ function addJavaPaths()
         fullfile(poiPATH,'stax-api-1.0.1.jar')};
 
     %Open the javaclasspath.txt file or create it
-    %otherwise
-    fid=fopen(fullfile(prefdir,'javaclasspath.txt'),'r');
-    if fid>0
-        current=textscan(fid,'%s','Delimiter','\n');
-        current=current{1};
-        fclose(fid);
-    else
-        current={};
-    end
+    %otherwise   
 
-    %Get the ones to add
-    [~,I]=setdiff(upper(toAdd),upper(current));
-    if any(I)
-        fid=fopen(fullfile(prefdir,'javaclasspath.txt'),'at');
-        fprintf(fid,'\n');
-        for i=1:numel(I)
-            fprintf(fid,[strrep(toAdd{I(i)},'\','\\') '\n']);
-        end
-        fclose(fid);
-
-        %Throw an error to say that Matlab has to be restarted
-        EM='RAVEN has added the Apache POI classes to the static Java path. Please restart Matlab to have these changes take effect';
-        dispEM(EM);
+    %Get the ones to add    
+    for i=1:numel(toAdd)
+        javaaddpath(toAdd{i});
     end
+    %Throw an error to say that Matlab has to be restarted
 end

--- a/io/startup.m
+++ b/io/startup.m
@@ -1,0 +1,2 @@
+%Add the Java Pathes at startup in order to be ready for use if the Toolbox is on the path
+addJavaPaths()


### PR DESCRIPTION
Just as a suggestion for a solution to #75. 
This change will automatically add the java libraries to the dynamic path is the toolbox is on the path. 
It will no longer require a restart of Matlab at first init and the addition will no longer depend on the actual path of the libraries (as they are added dynamically). 

It might also (potentially) solve #55 , if the issue there was that matlabs POI libraries were used instead of the supplied ones. 