### PR TITLE
Fix/standardize gr rules

### DIFF
--- a/INIT/getINITModel.m
+++ b/INIT/getINITModel.m
@@ -336,7 +336,7 @@ else
 end
 
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model);
+[grRules,rxnGeneMat] = standardizeGrRules(model,true);
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 end

--- a/core/addGenes.m
+++ b/core/addGenes.m
@@ -123,7 +123,7 @@ end
 
 if isfield(newModel,'rxnGeneMat')
     %Fix grRules and reconstruct rxnGeneMat
-    [grRules,rxnGeneMat] = standardizeGrRules(newModel);
+    [grRules,rxnGeneMat] = standardizeGrRules(newModel,true);
     newModel.grRules = grRules;
     newModel.rxnGeneMat = rxnGeneMat;
 end

--- a/core/addRxns.m
+++ b/core/addRxns.m
@@ -536,7 +536,7 @@ for i=1:nRxns
 end
 
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(newModel);
+[grRules,rxnGeneMat] = standardizeGrRules(newModel,true);
 newModel.grRules = grRules;
 newModel.rxnGeneMat = rxnGeneMat;
 end

--- a/core/changeGeneAssoc.m
+++ b/core/changeGeneAssoc.m
@@ -45,7 +45,7 @@ else % Add gene associations, add new gene rules after 'OR'.
     model.rxnGeneMat(idxRxn,idxGene)=1;
 end
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model);
+[grRules,rxnGeneMat] = standardizeGrRules(model,true);
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 end

--- a/core/contractModel.m
+++ b/core/contractModel.m
@@ -116,7 +116,7 @@ removedRxns=removedRxns(index);
 
 if isfield(reducedModel,'rxnGeneMat')
     %Fix grRules and reconstruct rxnGeneMat
-    [grRules,rxnGeneMat] = standardizeGrRules(reducedModel);
+    [grRules,rxnGeneMat] = standardizeGrRules(reducedModel,true);
     reducedModel.grRules = grRules;
     reducedModel.rxnGeneMat = rxnGeneMat;
 end

--- a/core/expandModel.m
+++ b/core/expandModel.m
@@ -126,7 +126,7 @@ else
 end
 
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(newModel);
+[grRules,rxnGeneMat] = standardizeGrRules(newModel,true);
 newModel.grRules = grRules;
 newModel.rxnGeneMat = rxnGeneMat;
 end

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -425,8 +425,8 @@ for i=1:numel(models)
     if isfield(models{useOrderIndexes(i)},'geneComps')
         geneComps=models{useOrderIndexes(i)}.geneComps(1);
         models{useOrderIndexes(i)}.geneComps=zeros(numel(models{useOrderIndexes(i)}.genes),1);
-        % Assume that all genes are in the same compartment, and this
-        % compartment is specified for the first gene
+        %Assume that all genes are in the same compartment, and this
+        %compartment is specified for the first gene
         models{useOrderIndexes(i)}.geneComps(:)=geneComps;
     end
 end
@@ -450,9 +450,11 @@ draftModel.rxnNotes=cell(length(draftModel.rxns),1);
 draftModel.rxnNotes(:)={'Reaction included by getModelFromHomology'};
 draftModel.rxnConfidenceScores=NaN(length(draftModel.rxns),1);
 draftModel.rxnConfidenceScores(:)=2;
-% Gene short names are often different between species, safer not to
-% include them.
+%Gene short names are often different between species, safer not to
+%include them.
 if isfield(draftModel,'geneShortNames');
     draftModel = rmfield(draftModel,'geneShortNames');
 end
+%Standardize grRules and notify if problematic grRules are found
+[draftModel.grRules,draftModel.rxnGeneMat] = standardizeGrRules(draftModel,false);
 end

--- a/core/mergeModels.m
+++ b/core/mergeModels.m
@@ -510,7 +510,7 @@ for i=2:numel(models)
     end
 end
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model);
+[grRules,rxnGeneMat] = standardizeGrRules(model,true);
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 end

--- a/core/predictLocalization.m
+++ b/core/predictLocalization.m
@@ -734,7 +734,7 @@ end
 outModel.rxnGeneMat(:,I)=[];
 
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(outModel);
+[grRules,rxnGeneMat] = standardizeGrRules(outModel,true);
 outModel.grRules = grRules;
 outModel.rxnGeneMat = rxnGeneMat;
 end

--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -34,7 +34,7 @@ end
 
 %Format grRules and rxnGeneMatrix:
 if standardizeRules
-    [grRules,rxnGeneMat] = standardizeGrRules(model);
+    [grRules,rxnGeneMat] = standardizeGrRules(model,true);
     model.grRules = grRules;
     model.rxnGeneMat = rxnGeneMat;
 end

--- a/core/standardizeGrRules.m
+++ b/core/standardizeGrRules.m
@@ -123,9 +123,14 @@ end
 %Function that gets the model field grRules and returns the indexes of the
 %rules in which the pattern ") and (" is present. 
 function indexes2check = findPotentialErrors(grRules,embedded)
-indexes_l     = find(~cellfun(@isempty,strfind(grRules,') and (')));
-indexes_U     = find(~cellfun(@isempty,strfind(grRules,') AND (')));
-indexes2check = union(indexes_l,indexes_U);
+indxs_l       = find(~cellfun(@isempty,strfind(grRules,') and (')));
+indxs_U       = find(~cellfun(@isempty,strfind(grRules,') AND (')));
+indxs_l_L     = find(~cellfun(@isempty,strfind(grRules,') and')));
+indxs_U_L     = find(~cellfun(@isempty,strfind(grRules,') AND')));
+indxs_l_R     = find(~cellfun(@isempty,strfind(grRules,'and (')));
+indxs_U_R     = find(~cellfun(@isempty,strfind(grRules,'AND (')));
+indexes2check = vertcat(indxs_l,indxs_U,indxs_l_L,indxs_U_L,indxs_l_R,indxs_U_R);
+indexes2check = unique(indexes2check);
 
 if ~isempty(indexes2check)
 
@@ -138,12 +143,13 @@ if ~isempty(indexes2check)
         STR = [STR,':\n\n  [~,~,indexes2check]=standardizeGrRules(model)\n'];
         warning(sprintf(STR))
     else
-        STR = 'Potentially problematic ") AND (" relationships found in\n\n';
+        STR = 'Potentially problematic ") AND (", ") AND" or "AND ("relat';
+        STR = [STR,'ionships found in\n\n'];
         for i=1:length(indexes2check)
             index = indexes2check(i);
             STR = [STR '  - grRule #' num2str(index) grRules{index} '\n'];
         end
-        STR = [STR,'\n This kind of relationship should only be present '];
+        STR = [STR,'\n This kind of relationships should only be present '];
         STR = [STR,'in  reactions catalysed by complexes of isoenzymes e'];
         STR = [STR,'.g.\n\n  - (G1 or G2) and (G3 or G4)\n\n For these c'];
         STR = [STR,'ases modify the grRules manually, writing all the po'];

--- a/core/standardizeGrRules.m
+++ b/core/standardizeGrRules.m
@@ -1,21 +1,27 @@
-function [grRules,rxnGeneMat] = standardizeGrRules(model)
+function [grRules,rxnGeneMat,indexes2check] = standardizeGrRules(model,embeded)
 % standardizeGrRules
 %   Standardizes gene-rxn rules in a model according to the following
 %       - No overall containing brackets
 %       - Just enzyme complexes are enclosed into brackets
 %       - ' and ' & ' or ' strings are strictly set to lowercases
 %
-%   A rxnGeneMat matrix consistent with the standardized grRules is created
+%   A rxnGeneMat matrix consistent with the standardized grRules is created.
 %
 %   model        a model structure
+%   embeded      TRUE if this function is called inside of another 
+%                RAVEN function, default FALSE
 %
 %   grRules      [nRxns x 1] cell array with the standardized grRules
 %   rxnGeneMat   [nRxns x nGenes]Sparse matrix consitent with the
 %                standardized grRules
+%   
+%   If this function is going to be used in a model reconstruction or
+%   modification pipeline it is recommended to run this function just
+%   at the beginning of the process.
 %
-%   Usage: [grRules,rxnGeneMat] = standardizeGrRules(model)
+%   Usage: [grRules,rxnGeneMat,indexes2check]=standardizeGrRules(model,embeded)
 %
-%   Ivan Domenzain, 2018-03-29
+%   Ivan Domenzain, 2018-04-10
 %
 
 %Preallocate fields
@@ -24,40 +30,46 @@ function [grRules,rxnGeneMat] = standardizeGrRules(model)
 rxnGeneMat = sparse(n,g);
 grRules    = cell(n,1);
 
+if nargin<2
+    embeded = false;
+end
+
 if isfield(model,'grRules')
-    %Search logical errors in the grRules field
-    findLogicalErrors(model)
+    %Search for potential logical errors in the grRules field
+    indexes2check = findPotentialErrors(model.grRules,embeded);
     
     for i=1:length(model.grRules)
         originalSTR = model.grRules{i};
-        grRules{i}  = originalSTR;
-        newSTR      = [];
-        %Non-empty grRules are splitted in all their different isoenzymes
-        genesSets = getSimpleGeneSets(originalSTR);
-        
-        if ~isempty(genesSets)
-            for j=1:length(genesSets)
-                simpleSet  = genesSets{j};
-                rxnGeneMat = modifyRxnGeneMat(simpleSet,model.genes,rxnGeneMat,i);
-                %Enclose simpleSet in brackets
-                if length(genesSets)>1
-                    if ~isempty(strfind(simpleSet,' and '))
-                        simpleSet = horzcat('(',simpleSet,')');
+        %standardize the non-conflicting grRules
+        if ~ismember(originalSTR,indexes2check)
+            grRules{i}  = originalSTR;
+            newSTR      = [];
+            %Non-empty grRules are splitted in all their different isoenzymes
+            genesSets = getSimpleGeneSets(originalSTR);
+
+            if ~isempty(genesSets)
+                for j=1:length(genesSets)
+                    simpleSet  = genesSets{j};
+                    rxnGeneMat = modifyRxnGeneMat(simpleSet,model.genes,rxnGeneMat,i);
+                    %Enclose simpleSet in brackets
+                    if length(genesSets)>1
+                        if ~isempty(strfind(simpleSet,' and '))
+                            simpleSet = horzcat('(',simpleSet,')');
+                        end
                     end
+                    %Separate genesSets in the substring (in case of
+                    %isoenzymes)
+                    if j<length(genesSets)
+                        newSTR = [newSTR, simpleSet, ' or '];
+                        %Add the last simpleSet
+                    else
+                        newSTR = [newSTR, simpleSet];
+                    end
+
                 end
-                %Separate genesSets in the substring (in case of
-                %isoenzymes)
-                if j<length(genesSets)
-                    newSTR = [newSTR, simpleSet, ' or '];
-                    %Add the last simpleSet
-                else
-                    newSTR = [newSTR, simpleSet];
-                end
-                
+                grRules{i} = newSTR;
             end
-            grRules{i} = newSTR;
         end
-        
     end
 end
 
@@ -80,12 +92,13 @@ if ~isempty(originalSTR)
 end
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%Function that gets a simple genes set (single gene or enzyme complex) and
-%a rxn index. The rxnGeneMat row (rxn) will be modified accordingly to the
-%provided genes
+%Function that gets a simple genes set (single gene or enzyme complex)
+%associated with the i-th reaction and modifies the correspondent row in the 
+%rxnGeneMat accordingly.
 function rxnGeneMat = modifyRxnGeneMat(genesSet,modelGenes,rxnGeneMat,i)
 %Get individual genes
-genes = strsplit(genesSet,' ');
+STR   = strrep(genesSet,') and (',' and ');
+genes = strsplit(STR,' ');
 for k=1:length(genes)
     if ~strcmpi(genes(k),' and ')
         genePos = find(strcmpi(modelGenes,genes(k)));
@@ -99,17 +112,40 @@ for k=1:length(genes)
 end
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%Function that gets a simple genes set (single gene or enzyme complex) and
-%a rxn index. The rxnGeneMat row (rxn) will be modified accordingly to the
-function findLogicalErrors(model)
-errors_l = find(~cellfun(@isempty,strfind(model.grRules,') and (')));
-errors_U = find(~cellfun(@isempty,strfind(model.grRules,') AND (')));
-errors   = union(errors_l,errors_U);
-if ~isempty(errors)
-    for i=1:length(errors)
-        index = errors(i);
-        disp(['     grRule #:',num2str(index),' ',model.grRules{index}])
+%Function that gets the model field grRules and returns the indexes of the
+%rules in which the pattern ") and (" is present. 
+function indexes2check = findPotentialErrors(grRules,embeded)
+indexes_l     = find(~cellfun(@isempty,strfind(grRules,') and (')));
+indexes_U     = find(~cellfun(@isempty,strfind(grRules,') AND (')));
+indexes2check = union(indexes_l,indexes_U);
+
+if ~isempty(indexes2check)
+    STR = ['") AND (" relationships found in' '\n' '\n'];
+    for i=1:length(indexes2check)
+        index = indexes2check(i);
+        STR = [STR '  - grRule #' num2str(index) ': ' grRules{index} '\n'];
     end
-    error('Logical errors found on grRules')
+    STR = [STR '\n'];
+    if embeded
+        STR = [STR,' If these grRules have been already curated then please'];
+        STR = [STR,' ignore this message, otherwise run standardizeGrRules'];
+        STR = [STR,' in the next way for getting further instructions:\n'];
+        STR = [STR,'\n [~,~,indexes2check] = standardizeGrRules(model)\n'];
+        warning(sprintf(STR))
+    else
+        STR = [STR,' This kind of relationship should only be present in'];
+        STR = [STR,' reactions catalysed by complexes of isoenzymes e.g.\n\n'];
+        STR = [STR,'  - (G1 or G2) and (G3 or G4)\n\n If this is the case'];
+        STR = [STR,' please modify those grRules manually, writing all the'];
+        STR = [STR,'  possible combinations e.g.\n\n'];
+        STR = [STR,'  - (G1 and G3) or (G1 and G4) or (G2 and G3) or (G2 and G4)\n\n'];
+        STR = [STR,' For other cases please modify the correspondent grRules'];
+        STR = [STR,' avoiding:\n'];
+        STR = [STR,'  1) Overall container brackets\n'];
+        STR = [STR,'  2) Single unit enzymes enclosed into brackets\n'];
+        STR = [STR,'  3) The usage of uppercases out of the gene names','\n'];
+        STR = [STR,'  4) Unbalanced brackets','\n\n'];
+        warning(sprintf(STR))
+    end
 end
 end

--- a/core/standardizeGrRules.m
+++ b/core/standardizeGrRules.m
@@ -8,8 +8,8 @@ function [grRules,rxnGeneMat,indexes2check] = standardizeGrRules(model,embedded)
 %   A rxnGeneMat matrix consistent with the standardized grRules is created.
 %
 %   model        a model structure
-%   embedded     TRUE if this function is called inside of another 
-%                RAVEN function, default FALSE
+%   embedded     true if this function is called inside of another 
+%                RAVEN function (opt, default false)
 %
 %   grRules      [nRxns x 1] cell array with the standardized grRules
 %   rxnGeneMat   [nRxns x nGenes]Sparse matrix consitent with the
@@ -66,7 +66,7 @@ if isfield(model,'grRules')
                         newSTR = [newSTR, simpleSet];
                     end
                 end
-                %Update grRule 
+                %Update grRule
                 grRules{i} = char(newSTR);
             end
         end
@@ -92,15 +92,15 @@ if ~isempty(originalSTR)
 end
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%Function that gets a cell array of simple genes sets (single genes or 
-% enzyme complexes) associated with the i-th reaction and modifies the 
+%Function that gets a cell array of simple genes sets (single genes or
+%enzyme complexes) associated with the i-th reaction and modifies the
 %correspondent row in the rxnGeneMat accordingly.
 function rxnGeneMat = modifyRxnGeneMat(genesSets,modelGenes,rxnGeneMat,i)
 
 if ~isempty(genesSets)
     for j=1:length(genesSets)
-    	simpleSet  = genesSets{j};
-%        rxnGeneMat = modifyRxnGeneMat(simpleSet,model.genes,rxnGeneMat,i);
+        simpleSet  = genesSets{j};
+        %        rxnGeneMat = modifyRxnGeneMat(simpleSet,model.genes,rxnGeneMat,i);
         %Get individual genes
         STR   = strrep(simpleSet,') and (',' and ');
         genes = strsplit(STR,' ');
@@ -121,7 +121,7 @@ end
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %Function that gets the model field grRules and returns the indexes of the
-%rules in which the pattern ") and (" is present. 
+%rules in which the pattern ") and (" is present.
 function indexes2check = findPotentialErrors(grRules,embedded)
 indxs_l       = find(~cellfun(@isempty,strfind(grRules,') and (')));
 indxs_U       = find(~cellfun(@isempty,strfind(grRules,') AND (')));
@@ -133,13 +133,13 @@ indexes2check = vertcat(indxs_l,indxs_U,indxs_l_L,indxs_U_L,indxs_l_R,indxs_U_R)
 indexes2check = unique(indexes2check);
 
 if ~isempty(indexes2check)
-
+    
     if embedded
         STR = ' Some ") AND (" relationships were found in grRules, this ';
         STR = [STR,'might lead to ambiguous genes-rxn asssociations.\n\n'];
         STR = [STR,'If this field has been already curated then  please i'];
         STR = [STR,'gnore this message, otherwise run the function standa'];
-        STR = [STR,'rdizeGrRules in the next way for further instructions']; 
+        STR = [STR,'rdizeGrRules in the next way for further instructions'];
         STR = [STR,':\n\n  [~,~,indexes2check]=standardizeGrRules(model)\n'];
         warning(sprintf(STR))
     else
@@ -158,7 +158,7 @@ if ~isempty(indexes2check)
         STR = [STR,'ases modify the correspondent grRules avoiding:\n\n '];
         STR = [STR,' 1) Overall container brackets, e.g.\n        "(G1 a'];
         STR = [STR,'nd G2)" should be "G1 and G2"\n\n  2) Single unit en'];
-        STR = [STR,'zymes enclosed into brackets, e.g.\n        "(G1)" s']; 
+        STR = [STR,'zymes enclosed into brackets, e.g.\n        "(G1)" s'];
         STR = [STR,'hould be "G1"\n\n  3) The use of uppercases for logi'];
         STR = [STR,'cal operators, e.g.\n        "G1 OR G2" should be "G'];
         STR = [STR,'1 or G2"\n\n  4) Unbalanced brackets, e.g.\n        '];

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -849,7 +849,7 @@ for i=1:numel(model.rxns)
 end
 
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model,true);
+[grRules,rxnGeneMat] = standardizeGrRules(model,false); %Give detailed output
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 end

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -849,7 +849,7 @@ for i=1:numel(model.rxns)
 end
 
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model);
+[grRules,rxnGeneMat] = standardizeGrRules(model,true);
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 end

--- a/external/metacyc/getMetaCycModelForOrganism.m
+++ b/external/metacyc/getMetaCycModelForOrganism.m
@@ -230,7 +230,7 @@ model.metNames(I)=model.mets(I);
 model=rmfield(model,{'proteins','bitscore','ppos'});
 
 %In the end fix grRules and rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model,true);
+[grRules,rxnGeneMat] = standardizeGrRules(model,false); %Get detailed output
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 end

--- a/external/metacyc/getMetaCycModelForOrganism.m
+++ b/external/metacyc/getMetaCycModelForOrganism.m
@@ -230,7 +230,7 @@ model.metNames(I)=model.mets(I);
 model=rmfield(model,{'proteins','bitscore','ppos'});
 
 %In the end fix grRules and rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model);
+[grRules,rxnGeneMat] = standardizeGrRules(model,true);
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 end

--- a/io/importExcelModel.m
+++ b/io/importExcelModel.m
@@ -754,7 +754,7 @@ dispEM(EM,false,model.rxns(badRxns));
 model.b=zeros(numel(model.mets),1);
 
 %Fix grRules and reconstruct rxnGeneMat
-[grRules,rxnGeneMat] = standardizeGrRules(model);
+[grRules,rxnGeneMat] = standardizeGrRules(model,true);
 model.grRules = grRules;
 model.rxnGeneMat = rxnGeneMat;
 

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -819,7 +819,7 @@ if ~isempty(geneNames)
     end;              
     model.genes=geneNames;
     model.grRules=grRules;
-    [grRules,rxnGeneMat] = standardizeGrRules(model);
+    [grRules,rxnGeneMat] = standardizeGrRules(model,true);
     model.grRules = grRules;
     model.rxnGeneMat = rxnGeneMat;
 
@@ -863,7 +863,7 @@ else
        end
        model.genes=genes;
        model.grRules=grRules;
-       [grRules,rxnGeneMat] = standardizeGrRules(model);
+       [grRules,rxnGeneMat] = standardizeGrRules(model,true);
        model.grRules = grRules;
        model.rxnGeneMat = rxnGeneMat;
     end

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -161,7 +161,7 @@ if isRaven
         newModel.rxnGeneMat=model.rxnGeneMat;
     end;
     if isfield(model,'grRules')
-        [grRules, rxnGeneMat] = standardizeGrRules(model);
+        [grRules, rxnGeneMat] = standardizeGrRules(model,true);
         newModel.grRules      = grRules;
         %Incorporate a rxnGeneMat consistent with standardized grRules
         newModel.rxnGeneMat   = rxnGeneMat;
@@ -232,12 +232,12 @@ if isRaven
         newModel.rxnNames=model.rxnNames;
     end;
     if isfield(model,'grRules')
-        [grRules,rxnGeneMat] = standardizeGrRules(model);
+        [grRules,rxnGeneMat] = standardizeGrRules(model,true);
         newModel.grRules     = grRules;
         newModel.rxnGeneMat  = rxnGeneMat;
     else
         model.grRules        = rulesTogrrules(model);
-        [grRules,rxnGeneMat] = standardizeGrRules(model);
+        [grRules,rxnGeneMat] = standardizeGrRules(model,true);
         newModel.grRules     = grRules;
         newModel.rxnGeneMat  = rxnGeneMat;
     end;


### PR DESCRIPTION
Related to issue #69, `standardizeGrRules` now provides more detailed warnings if potential problematic grRules are found when the function is run stand-alone. When running embedded in other RAVEN functions, only a brief warning will be shown.