### PR TITLE
fix: changeGeneAssoc rely on standardizeGrRules

### DIFF
--- a/core/changeGeneAssoc.m
+++ b/core/changeGeneAssoc.m
@@ -3,7 +3,7 @@ function model = changeGeneAssoc(model,rxnID,geneAssoc,replace)
 %   Changes gene association for a defined reaction
 %
 %   model       a model structure to change the gene association
-%   rxnID       string of reaction ID
+%   rxnID       string or cell array of reaction IDs
 %   geneAssoc   string of additional or replacement gene association.
 %               Should be written with ' and ' to indicate subunits, ' or '
 %               to indicate isoenzymes, and brackets '()' to separate
@@ -16,11 +16,20 @@ function model = changeGeneAssoc(model,rxnID,geneAssoc,replace)
 %
 %   Usage: changeGeneAssoc(model,rxnID,geneAssoc,replace)
 %
-%   Simonas Marcisauskas, 2018-04-03
+%   Eduard Kerkhoven, 2018-04-24
 %
 
 if nargin==3
     replace=true;
+end
+
+if isstr(rxnID)
+    rxnID={rxnID};
+end
+
+if ~isstr(geneAssoc)
+    EM='geneAssoc has to be string';
+    error(sprintf(EM))
 end
 
 % Add genes to model
@@ -29,21 +38,15 @@ genesToAdd.genes=setdiff(geneList(2:length(geneList)),model.genes); % Only keep 
 model=addGenes(model,genesToAdd); % Add genes
 
 % Find reaction and gene indices
-[~,idxRxn]=ismember(rxnID,model.rxns); % Find indices of rxnID in model.rxns
-idxGene=zeros(length(geneList)-1,1); % Prepare an empty list to be filed with indices, and subsequently fill it.
-for n=2:length(geneList)
-    idxGene(n-1)=find(strcmp(model.genes,geneList(n)));
-end
+idx=getIndexes(model,rxnID,'rxns');
 
 % Change gene associations
 if replace==true % Replace old gene associations
-    model.grRules(idxRxn)=cellstr(geneAssoc);
-    model.rxnGeneMat(idxRxn,:)=0;
-    model.rxnGeneMat(idxRxn,idxGene)=1;
+    model.grRules(idx)=cellstr(geneAssoc);
 else % Add gene associations, add new gene rules after 'OR'.
-    model.grRules(idxRxn)=cellstr([model.grRules{idxRxn},' or ',geneAssoc]);
-    model.rxnGeneMat(idxRxn,idxGene)=1;
+    model.grRules(idx)=cellstr('(',[model.grRules{idx},') or (',geneAssoc,')']);
 end
+
 %Fix grRules and reconstruct rxnGeneMat
 [grRules,rxnGeneMat] = standardizeGrRules(model,true);
 model.grRules = grRules;


### PR DESCRIPTION
function used to first adjust rxnGeneMat before overwriting this with rxnGeneMat from standardizeGrRules. This initial step is removed. This also renders the function compatible with setting the same grRule for multiple reactions.