### PR TITLE
feat: addRavenToUserPath

### DIFF
--- a/installation/addRavenToUserPath.m
+++ b/installation/addRavenToUserPath.m
@@ -1,0 +1,45 @@
+function addRavenToUserPath(overwrite)
+% This function writes a startup.m file in the userpath, adding RAVEN (and
+% all subdirectories) to the path each time Matlab is started.
+% This function is useful if the user has no rights to save paths to the
+% pathdef.m file in the matlabroot, for instance due to a lack of admin
+% rights. As the startup.m file in the userpath automatically runs with
+% each Matlab start, the paths are automatically loaded.
+%
+%   overwrite       logical, whether startup.m in the userpath should
+%                   overwritten (otherwise the RAVEN paths are appended)
+%                   (opt, default true)
+%
+%   2018-04-26  Eduard Kerkhoven
+
+if nargin1
+    overwrite=true;
+end
+
+% Get current RAVEN directory
+[ST, I]=dbstack('-completenames');
+[ravenDir,~,~]=fileparts(fileparts(ST(I).file));
+
+% Lists all subdirectories
+subpath=regexp(genpath(ravenDir),pathsep,'split');
+% Remove .git and doc folders
+pathsToKeep=cellfun(@(x) isempty(strfind(x,'.git')),subpath) & cellfun(@(x) isempty(strfind(x,'doc')),subpath);
+% Only keep useful paths
+subpath = subpath(pathsToKeep);
+subpath = subpath(1:end-1); % Remove last entry, is empty field
+
+% Write startup.m file
+if overwrite
+    fid=fopen(fullfile(userpath,'startup.m'),'w');
+    fprintf(fid,'%sn','%%% RAVEN path');
+else
+    fid=fopen(fullfile(userpath,'startup.m'),'a');
+    fprintf(fid,'n%sn','%%% RAVEN path');
+end
+fprintf(fid,'%sn',strcat('addpath(''',subpath{1},''',...'));
+for i=2(length(subpath)-1)
+    fprintf(fid,'t%sn',strcat('''',subpath{i},''',...'));
+end
+fprintf(fid,'t%s',strcat('''',subpath{length(subpath)},''');'));
+fclose(fid);
+end

--- a/installation/checkFunctionUniqueness.m
+++ b/installation/checkFunctionUniqueness.m
@@ -17,6 +17,9 @@ temp_res1=dir([ravenDir '/*/*.m']);
 temp_res2=dir([ravenDir '/*/*/*.m']);
 
 ravenFunctions={temp_res1.name,temp_res2.name}';
+%startup.m is not a normal function, any startup.m in the path should run
+%during startup, so duplicate use of this name is fine
+ravenFunctions=ravenFunctions(~ismember(ravenFunctions,'startup.m'));
 
 %Getting all the paths added to Matlab
 if ispc


### PR DESCRIPTION
when users has no admin right, it cannot write to `pathdef.m` in matlabroot. Alternatively, this function writes `startup.m` in the userpath, which loads RAVEN to the path every time Matlab is started