### PR TITLE
feat: compatibility libSBML 5.17.0

### DIFF
--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -7,7 +7,7 @@ function checkInstallation()
 %
 %   Usage: checkInstallation()
 %
-%	Eduard Kerkhoven, 2017-12-15
+%	Eduard Kerkhoven, 2018-05-22
 %
 
 fprintf('\n*** THE RAVEN TOOLBOX v. 2.0 ***\n\n');
@@ -54,7 +54,14 @@ end
 %Check if it is possible to import an SBML model using libSBML
 try
     importModel(xmlFile);
-    fprintf('Checking if it is possible to import an SBML model using libSBML... PASSED\n');
+    try
+        libSBMLver=OutputSBML; % Only works in libSBML 5.17.0+
+        fprintf('Checking if it is possible to import an SBML model using libSBML... PASSED\n');
+    catch
+        fprintf(['Checking if it is possible to import an SBML model using libSBML... PASSED\n\n'...
+            'An older libSBML version was found, update to version 5.17.0 or higher\n'...
+            'for a significant improvement of model import.\n\n']);
+    end
 catch
     fprintf('Checking if it is possible to import an SBML model using libSBML... FAILED\nTo import SBML models, download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n');
 end

--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -16,7 +16,7 @@ function out=exportForGit(model,prefix,path,formats)
 %
 %   Usage: exportForGit(model,prefix,path,formats)
 %
-%   Eduard Kerkhoven, 2018-05-14
+%   Eduard Kerkhoven, 2018-05-22
 %
 if nargin<4
     formats={'mat', 'txt', 'xlsx', 'xml', 'yml'};
@@ -103,11 +103,12 @@ else
     disp('COBRA version cannot be found')
 end
 %Retrieve libSBML version:
-fid = fopen('tempModelForLibSBMLversion.xml','w+');
-fclose(fid);
-evalc('[~,~,libSBMLver]=TranslateSBML(''tempModelForLibSBMLversion.xml'',0,0)');
-libSBMLver=libSBMLver.libSBML_version_string;
-delete('tempModelForLibSBMLversion.xml');
+try
+    libSBMLver=OutputSBML;
+    libSBMLver=libSBMLver.libSBML_version_string;
+catch
+    error('Make sure libSBML 5.17.0 is installed')
+end
 
 %Save file with versions:
 fid = fopen('dependencies.txt','wt');


### PR DESCRIPTION
### Main improvements in this PR:
- `checkInstallation` confirm that libSBML 5.17.0 is installed (recommended, due to significant speed increase)
- `exportForGit` uses libSBML built-in support to show libSBML version (works from 5.17.0, which is now required for this function. Having this requirement is probably fair, as Git-tracked models should ideally be saved with recent libSBML)

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch