### PR TITLE
fix/exportModel and mergeModel; feat/ravenCobraWrapper

### DIFF
--- a/core/mergeModels.m
+++ b/core/mergeModels.m
@@ -308,8 +308,7 @@ for i=2:numel(models)
             if isfield(model,'metCharges')
                 model.metCharges=[model.metCharges;models{i}.metCharges(metsToAdd)];
             else
-                emptyMetCharge=cell(numel(model.mets)-numel(metsToAdd),1);
-                emptyMetCharge(:)={''};
+                emptyMetCharge=nan(numel(model.mets)-numel(metsToAdd),1);
                 model.metCharges=[emptyMetCharge;models{i}.metCharges(metsToAdd)];
             end
         else

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -510,7 +510,11 @@ tmpStruct=modelSBML.groups_group;
 rxns=strcat('R_',model.rxns);
 if isfield(model, 'subSystems')
     if ~any(cellfun(@iscell,model.subSystems))
-        subSystems = setdiff(model.subSystems,'');
+        if ~any(~cellfun(@isempty,model.subSystems))
+            subSystems = {};
+        else
+            subSystems = setdiff(model.subSystems,'');
+        end
     else
         orderedSubs = cellfun(@(x) columnVector(x),model.subSystems,'UniformOUtput',false);
         subSystems = setdiff(vertcat(orderedSubs{:}),'');
@@ -520,7 +524,7 @@ if isfield(model, 'subSystems')
     end
     if ~isempty(subSystems)
         %Build the groups for the group package
-        groupIDs = strcat('group',cellfun(@num2str, num2cell(1:length(subSystems))','UniformOutput',false));
+        groupIDs = strcat('group',cellfun(@num2str, num2cell(1:length(subSystems)),'UniformOutput',false));
         for i = 1:length(subSystems)
             cgroup = tmpStruct;
             if ~any(cellfun(@iscell,model.subSystems))

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -28,7 +28,7 @@ function newModel=ravenCobraWrapper(model)
 %
 %   Usage: newModel=ravenCobraWrapper(model)
 %
-%   Eduard Kerkhoven, 2018-06-21
+%   Simonas Marcisauskas, 2018-07-12
 %
 
 if isfield(model,'rules')
@@ -67,7 +67,7 @@ if isRaven
     if isfield(model,'rxnMiriams')
         [miriams,extractedMiriamNames]=extractMiriam(model.rxnMiriams);
         miriams=regexprep(miriams,'^[A-Za-z\.]*\/','');
-        i=contains(extractedMiriamNames,'kegg.reaction');
+        i=ismember(extractedMiriamNames,'kegg.reaction');
         if any(i)
             newModel.rxnKEGGID=miriams(:,i);
         end
@@ -87,47 +87,66 @@ if isRaven
     if isfield(model,'metMiriams')
         [miriams,extractedMiriamNames]=extractMiriam(model.metMiriams);
         miriams=regexprep(miriams,'^[A-Za-z\.]*\/','');
-        i=contains(extractedMiriamNames,'kegg');
+        %Shorten miriam names for KEGG and PubChem. These shorter names
+        %will be used later to concatenate KEGG COMPOUND/GLYCAN and PubChem
+        %Compound/Substance, into corresponding COBRA model fields
+        extractedMiriamNames=regexprep(extractedMiriamNames,'^kegg\..+','kegg');
+        extractedMiriamNames=regexprep(extractedMiriamNames,'^pubchem\..+','pubchem');
+        i=ismember(extractedMiriamNames,'kegg');
         if any(i) % Combine KEGG compounds and glycans
-            newModel.metKEGGID=regexprep(join(miriams(:,i),';',2),'^;|;$','');
+            for j=1:length(i)
+                if i(j) && isfield(newModel,'metKEGGID')~=1
+                    newModel.metKEGGID=miriams(:,j);
+                elseif i(j)
+                    newModel.metKEGGID=strcat(newModel.metKEGGID,';',miriams(:,j));
+                end
+            end
+            newModel.metKEGGID=regexprep(newModel.metKEGGID,'^;|;$','');
         end
-        i=contains(extractedMiriamNames,'chebi');
+        i=ismember(extractedMiriamNames,'chebi');
         if any(i)
             newModel.metChEBIID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'pubchem');
+        i=ismember(extractedMiriamNames,'pubchem');
         if any(i) % Combine Pubchem compounds and substances
-            newModel.metPubChemID=regexprep(join(miriams(:,i),';',2),'^;|;$','');
-        end        
-        i=contains(extractedMiriamNames,'bigg.metabolite');
+            for j=1:length(i)
+                if i(j) && isfield(newModel,'metPubChemID')~=1
+                    newModel.metPubChemID=miriams(:,j);
+                elseif i(j)
+                    newModel.metPubChemID=strcat(newModel.metPubChemID,';',miriams(:,j));
+                end
+            end
+            newModel.metPubChemID=regexprep(newModel.metPubChemID,'^;|;$','');
+        end
+        i=ismember(extractedMiriamNames,'bigg.metabolite');
         if any(i)
             newModel.metBiGGID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'hmdb');
+        i=ismember(extractedMiriamNames,'hmdb');
         if any(i)
             newModel.metHMDBID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'lipidmaps');
+        i=ismember(extractedMiriamNames,'lipidmaps');
         if any(i)
             newModel.metLIPIDMAPSID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'metacyc.compound');
+        i=ismember(extractedMiriamNames,'metacyc.compound');
         if any(i)
             newModel.metMetaCycID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'reactome');
+        i=ismember(extractedMiriamNames,'reactome');
         if any(i)
             newModel.metREACTOMEID=miriams(:,i);
         end   
-        i=contains(extractedMiriamNames,'seed.compound');
+        i=ismember(extractedMiriamNames,'seed.compound');
         if any(i)
             newModel.metSEEDID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'slm');
+        i=ismember(extractedMiriamNames,'slm');
         if any(i)
             newModel.metSLMID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'metanetx.chemical');
+        i=ismember(extractedMiriamNames,'metanetx.chemical');
         if any(i)
             newModel.metMetaNetXID=miriams(:,i);
         end        
@@ -155,19 +174,19 @@ if isRaven
     if isfield(model,'geneMiriams')
        [miriams,extractedMiriamNames]=extractMiriam(model.geneMiriams);
         miriams=regexprep(miriams,'^[A-Za-z\.]*\/','');
-        i=contains(extractedMiriamNames,'kegg.genes');
+        i=ismember(extractedMiriamNames,'kegg.genes');
         if any(i)
             newModel.geneiskegg__46__genesID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'kegg.genes');
+        i=ismember(extractedMiriamNames,'kegg.genes');
         if any(i)
             newModel.geneiskegg__46__genesID=miriams(:,i);
         end
-        i=contains(extractedMiriamNames,'sgd');
+        i=ismember(extractedMiriamNames,'sgd');
         if any(i)
             newModel.geneissgdID=miriams(:,i);
         end      
-        i=contains(extractedMiriamNames,'uniprot');
+        i=ismember(extractedMiriamNames,'uniprot');
         if any(i)
             newModel.proteinisuniprotID=miriams(:,i);
         end      

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -28,7 +28,7 @@ function newModel=ravenCobraWrapper(model)
 %
 %   Usage: newModel=ravenCobraWrapper(model)
 %
-%   Simonas Marcisauskas, 2018-05-07
+%   Eduard Kerkhoven, 2018-05-31
 %
 
 if isfield(model,'rules')
@@ -96,6 +96,34 @@ if isRaven
         tmp_pubchem_2=strrep(extractMiriam(model.metMiriams,'pubchem.substance'),'pubchem.substance/','');
         if ~all(cellfun(@isempty,tmp_pubchem_1)) || ~all(cellfun(@isempty,tmp_pubchem_2))
             newModel.metPubChemID=regexprep(strcat(tmp_pubchem_1, ';',tmp_pubchem_2),'^;|;$','');
+        end
+        tmp=strrep(extractMiriam(model.metMiriams,'bigg.metabolite'),'bigg.metabolite','');
+        if ~all(cellfun(@isempty,tmp))
+            newModel.metBiGGID=tmp;
+        end
+        tmp=strrep(extractMiriam(model.metMiriams,'hmdb'),'hmdb','');
+        if ~all(cellfun(@isempty,tmp))
+            newModel.metHMDBID=tmp;
+        end
+        tmp=strrep(extractMiriam(model.metMiriams,'lipidmaps'),'lipidmaps','');
+        if ~all(cellfun(@isempty,tmp))
+            newModel.metLIPIDMAPSID=tmp;
+        end
+        tmp=strrep(extractMiriam(model.metMiriams,'metacyc.compound'),'metacyc.compound','');
+        if ~all(cellfun(@isempty,tmp))
+            newModel.metMetaCycID=tmp;
+        end
+        tmp=strrep(extractMiriam(model.metMiriams,'reactome'),'reactome','');
+        if ~all(cellfun(@isempty,tmp))
+            newModel.metREACTOMEID=tmp;
+        end
+        tmp=strrep(extractMiriam(model.metMiriams,'seed.compound'),'seed.compound','');
+        if ~all(cellfun(@isempty,tmp))
+            newModel.metSEEDID=tmp;
+        end
+        tmp=strrep(extractMiriam(model.metMiriams,'slm'),'slm','');
+        if ~all(cellfun(@isempty,tmp))
+            newModel.metSLMID=tmp;
         end
     end
     if isfield(model,'inchis')
@@ -326,7 +354,7 @@ else
     if isfield(model,'metFormulas')
         newModel.metFormulas=model.metFormulas;
     end
-    if isfield(model,'metChEBIID') || isfield(model,'metHMDBID') || isfield(model,'metKEGGID') || isfield(model,'metPubChemID') || isfield(model,'metMetaNetXID')
+    if isfield(model,'metChEBIID') || isfield(model,'metHMDBID') || isfield(model,'metKEGGID') || isfield(model,'metPubChemID') || isfield(model,'metMetaNetXID') || isfield(model,'metBiGGID') || isfield(model,'metLIPIDMAPSID') || isfield(model,'metMetaCycID') || isfield(model,'metREACTOMEID') || isfield(model,'metSEEDID') || isfield(model,'metSLMID')
         for i=1:numel(model.mets)
             counter=1;
             newModel.metMiriams{i,1}=[];
@@ -379,6 +407,48 @@ else
                 if ~isempty(model.metMetaNetXID{i})
                     newModel.metMiriams{i,1}.name{counter,1} = 'metanetx.chemical';
                     newModel.metMiriams{i,1}.value{counter,1} = model.metMetaNetXID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'metBiGGID')
+                if ~isempty(model.metBiGGID{i})
+                    newModel.metMiriams{i,1}.name{counter,1} = 'bigg.metabolite';
+                    newModel.metMiriams{i,1}.value{counter,1} = model.metBiGGID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'metLIPIDMAPSID')
+                if ~isempty(model.metLIPIDMAPSID{i})
+                    newModel.metMiriams{i,1}.name{counter,1} = 'lipidmaps';
+                    newModel.metMiriams{i,1}.value{counter,1} = model.metLIPIDMAPSID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'metMetaCycID')
+                if ~isempty(model.metMetaCycID{i})
+                    newModel.metMiriams{i,1}.name{counter,1} = 'metacyc.compound';
+                    newModel.metMiriams{i,1}.value{counter,1} = model.metMetaCycID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'metREACTOMEID')
+                if ~isempty(model.metREACTOMEID{i})
+                    newModel.metMiriams{i,1}.name{counter,1} = 'reactome';
+                    newModel.metMiriams{i,1}.value{counter,1} = model.metREACTOMEID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'metSEEDID')
+                if ~isempty(model.metSEEDID{i})
+                    newModel.metMiriams{i,1}.name{counter,1} = 'seed.compound';
+                    newModel.metMiriams{i,1}.value{counter,1} = model.metSEEDID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'metSLMID')
+                if ~isempty(model.metSLMID{i})
+                    newModel.metMiriams{i,1}.name{counter,1} = 'swisslipid';
+                    newModel.metMiriams{i,1}.value{counter,1} = model.metSLMID{i};
                     counter=counter+1;
                 end
             end


### PR DESCRIPTION
### Main improvements in this PR:
- `ravenCobraWrapper` support for more types of metMiriams
- `exportModel` deals with empty (but existing) subSystems field
- `mergeModels` : if the first model does not have metCharges field, it should make a vector of NaN of length(mets) , not a vector of empty cells.


**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch