### PR TITLE
fix: use of 'cobra' as solver

### DIFF
--- a/core/fillGaps.m
+++ b/core/fillGaps.m
@@ -100,7 +100,7 @@ if isempty(rxnScores)
     end
 end
 if nargin<7
-    params=[];
+    params=struct();
 end
 
 if ~iscell(rxnScores)

--- a/core/getMinNrFluxes.m
+++ b/core/getMinNrFluxes.m
@@ -42,7 +42,7 @@ end
 
 %For passing parameters to the solver
 if nargin<3
-    params=[];
+    params=struct();
 end
 
 if nargin<4
@@ -141,7 +141,7 @@ xx=res.sol.int.xx(1:numel(irrevModel.rxns));
 I=res.sol.int.xx(numel(xx)+1:end);
 
 %Check if Mosek aborted because it reached the time limit
-if strcmp('MSK_RES_TRM_MAX_TIME',res.rcodestr)
+if strcmp('MSK_RES_TRM_MAX_TIME',res.rcode)
     exitFlag=-2;
 end
 

--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -12,7 +12,7 @@ function res = optimizeProb(prob,params)
 %
 
 if nargin<2
-    params=[];
+    params=struct();
 end
 
 


### PR DESCRIPTION
### Main improvements in this PR:
Fixes a bug reported on [Gitter](https://gitter.im/SysBioChalmers/RAVEN?at=5b28e67014805602858e44d3), when 'cobra' was set as solver. User confirmed that this fix solved the problem.
- correctly parse empty list of parameters

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR