### PR TITLE
Fix: misc gene-related import/export of models

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -13,7 +13,7 @@ function exportModel(model,fileName,exportGeneComplexes,supressWarnings)
 %
 %   Usage: exportModel(model,fileName,exportGeneComplexes,supressWarnings)
 %
-%   Simonas Marcisauskas, 2018-05-08
+%   Eduard Kerkhoven, 2018-07-19
 
 if nargin<3
     exportGeneComplexes=false;

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -112,7 +112,9 @@ end
 model.rxns=regexprep(model.rxns,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 model.mets=regexprep(model.mets,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 model.comps=regexprep(model.comps,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
-model.genes=regexprep(model.genes,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
+if isfield(model,'genes')
+    model.genes=regexprep(model.genes,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
+end
 
 %Generate an empty SBML structure
 modelSBML=getSBMLStructure(sbmlLevel,sbmlVersion,sbmlPackages,sbmlPackageVersions);

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -844,7 +844,7 @@ if ~isempty(geneNames)
     [~, J]=ismember(geneCompartments,model.comps);
     model.geneComps=J;
 else
-    if ~isempty(grRules)
+    if ~all(cellfun(@isempty,grRules))
         %If fbc_geneProduct exists, follow the specified gene order, such
         %that matching geneShortNames in function below will work
         if isfield(modelSBML,'fbc_geneProduct')
@@ -1028,7 +1028,7 @@ if removeExcMets==true
     model=simplifyModel(model);
 end
 end
-
+ 
 function matchGenes=getGeneList(grRules)
 %Constructs the list of unique genes from grRules
 

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -71,7 +71,7 @@ function model=importModel(fileName,removeExcMets,isSBML2COBRA,supressWarnings)
 %
 %   Usage: model=importModel(fileName,removeExcMets,isSBML2COBRA,supressWarnings)
 %
-%   Eduard Kerkhoven, 2018-05-18
+%   Eduard Kerkhoven, 2018-07-19
 %
 
 if nargin<2
@@ -494,15 +494,15 @@ for i=1:numel(modelSBML.reaction)
     end
     
     %Find the associated gene if available
-        %If FBC, get gene association data from corresponding fields
+    %If FBC, get gene association data from corresponding fields
     if isfield(modelSBML.reaction(i),'fbc_geneProductAssociation')
         if ~isempty(modelSBML.reaction(i).fbc_geneProductAssociation) && ~isempty(modelSBML.reaction(i).fbc_geneProductAssociation.fbc_association)
             grRules{counter}=modelSBML.reaction(i).fbc_geneProductAssociation.fbc_association.fbc_association;
         end
     elseif isfield(modelSBML.reaction(i),'notes')
-    %This section was previously executed only if isSBML2COBRA is true. Now
-    %it will be executed, if 'GENE_ASSOCIATION' is found in
-    %modelSBML.reaction(i).notes
+        %This section was previously executed only if isSBML2COBRA is true. Now
+        %it will be executed, if 'GENE_ASSOCIATION' is found in
+        %modelSBML.reaction(i).notes
         if strfind(modelSBML.reaction(i).notes,'GENE_ASSOCIATION')
             geneAssociation=parseNote(modelSBML.reaction(i).notes,'GENE_ASSOCIATION');
         elseif strfind(modelSBML.reaction(i).notes,'GENE ASSOCIATION')
@@ -511,8 +511,8 @@ for i=1:numel(modelSBML.reaction)
             geneAssociation='';
         end
         if ~isempty(geneAssociation)
-        %This adds the grRules. The gene list and rxnGeneMat are created
-        %later
+            %This adds the grRules. The gene list and rxnGeneMat are created
+            %later
             grRules{counter}=geneAssociation;
         end
     elseif isfield(modelSBML.reaction(i),'modifier')
@@ -570,7 +570,7 @@ for i=1:numel(modelSBML.reaction)
             grRulesFromModifier{counter}=rules;%Backup copy for grRules, useful to parse Yeast 7.6
         end
     end
-   
+    
     %Add reaction compartment
     if isfield(modelSBML.reaction(i),'compartment')
         if ~isempty(modelSBML.reaction(i).compartment)
@@ -1024,7 +1024,7 @@ if removeExcMets==true
     model=simplifyModel(model);
 end
 end
- 
+
 function matchGenes=getGeneList(grRules)
 %Constructs the list of unique genes from grRules
 

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -494,7 +494,28 @@ for i=1:numel(modelSBML.reaction)
     end
     
     %Find the associated gene if available
-    if isfield(modelSBML.reaction(i),'modifier')
+        %If FBC, get gene association data from corresponding fields
+    if isfield(modelSBML.reaction(i),'fbc_geneProductAssociation')
+        if ~isempty(modelSBML.reaction(i).fbc_geneProductAssociation) && ~isempty(modelSBML.reaction(i).fbc_geneProductAssociation.fbc_association)
+            grRules{counter}=modelSBML.reaction(i).fbc_geneProductAssociation.fbc_association.fbc_association;
+        end
+    elseif isfield(modelSBML.reaction(i),'notes')
+    %This section was previously executed only if isSBML2COBRA is true. Now
+    %it will be executed, if 'GENE_ASSOCIATION' is found in
+    %modelSBML.reaction(i).notes
+        if strfind(modelSBML.reaction(i).notes,'GENE_ASSOCIATION')
+            geneAssociation=parseNote(modelSBML.reaction(i).notes,'GENE_ASSOCIATION');
+        elseif strfind(modelSBML.reaction(i).notes,'GENE ASSOCIATION')
+            geneAssociation=parseNote(modelSBML.reaction(i).notes,'GENE ASSOCIATION');
+        else
+            geneAssociation='';
+        end
+        if ~isempty(geneAssociation)
+        %This adds the grRules. The gene list and rxnGeneMat are created
+        %later
+            grRules{counter}=geneAssociation;
+        end
+    elseif isfield(modelSBML.reaction(i),'modifier')
         if ~isempty(modelSBML.reaction(i).modifier)
             rules='';
             for j=1:numel(modelSBML.reaction(i).modifier)
@@ -549,32 +570,7 @@ for i=1:numel(modelSBML.reaction)
             grRulesFromModifier{counter}=rules;%Backup copy for grRules, useful to parse Yeast 7.6
         end
     end
-    %This section was previously executed only if isSBML2COBRA is true. Now
-    %it will be executed, if 'GENE_ASSOCIATION' is found in
-    %modelSBML.reaction(i).notes
-    if isfield(modelSBML.reaction(i),'notes')
-        if strfind(modelSBML.reaction(i).notes,'GENE_ASSOCIATION')
-            geneAssociation=parseNote(modelSBML.reaction(i).notes,'GENE_ASSOCIATION');
-        elseif strfind(modelSBML.reaction(i).notes,'GENE ASSOCIATION')
-            geneAssociation=parseNote(modelSBML.reaction(i).notes,'GENE ASSOCIATION');
-        else
-            geneAssociation='';
-        end
-    end
-    
-    if ~isempty(geneAssociation)
-        %This adds the grRules. The gene list and rxnGeneMat are created
-        %later
-        grRules{counter}=geneAssociation;
-    end
-    
-    %If FBC, get gene association data from corresponding fields
-    if isfield(modelSBML.reaction(i),'fbc_geneProductAssociation')
-        if ~isempty(modelSBML.reaction(i).fbc_geneProductAssociation) && ~isempty(modelSBML.reaction(i).fbc_geneProductAssociation.fbc_association)
-            grRules{counter}=modelSBML.reaction(i).fbc_geneProductAssociation.fbc_association.fbc_association;
-        end
-    end
-    
+   
     %Add reaction compartment
     if isfield(modelSBML.reaction(i),'compartment')
         if ~isempty(modelSBML.reaction(i).compartment)


### PR DESCRIPTION
### Main improvements in this PR:
Issue #127 
- fix bugs where `importModel` and `exportModel` could not handle models without genes
- prioritized location of gene associations in `importModel`, to work around conflicting/problematic gene assocations in older models (prefefred method is the FBC standard)

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR