### PR TITLE
fix: blastStructure format in getBlast

### DIFF
--- a/external/getBlast.m
+++ b/external/getBlast.m
@@ -24,7 +24,7 @@ function blastStructure=getBlast(organismID,fastaFile,modelIDs,refFastaFiles)
 %   Usage: blastStructure=getBlast(organismID,fastaFile,modelIDs,...
 %           refFastaFiles)
 %
-%   Simonas Marcisauskas, 2018-07-20
+%   Simonas Marcisauskas, 2018-07-25
 %
 
 %Everything should be cell arrays
@@ -127,11 +127,11 @@ for i=1:numel(refFastaFiles)*2
     end
     tempStruct.fromGenes=A{:,1};
     tempStruct.toGenes=A{:,2};
-    tempStruct.evalue=A(:,3);
-    tempStruct.identity=A(:,4);
-    tempStruct.aligLen=A(:,5);
-    tempStruct.bitscore=A(:,6);
-    tempStruct.ppos=A(:,7);
+    tempStruct.evalue=table2array(A(:,3));
+    tempStruct.identity=table2array(A(:,4));
+    tempStruct.aligLen=table2array(A(:,5));
+    tempStruct.bitscore=table2array(A(:,6));
+    tempStruct.ppos=table2array(A(:,7));
     blastStructure=[blastStructure tempStruct];
 end
 


### PR DESCRIPTION
### Main improvements in this PR:
- fixed a bug regarding the second problem mentioned in issue #128. That is, `blastStructure` obtained from `getBlast` had incorrect data format for numeric fields (e-value, identity, bitscore, etc.). The incorrect format caused problems when `blastStructure` was used in `getModelFromHomology`.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR