### PR TITLE
fix: convertToIrrev

### DIFF
--- a/core/convertToIrrev.m
+++ b/core/convertToIrrev.m
@@ -14,6 +14,7 @@ function irrevModel=convertToIrrev(model,rxns)
 %   Usage: irrevModel=convertToIrrev(model,rxns)
 %
 %   Rasmus Agren, 2013-08-01
+%	Benjamín J. Sánchez, 2018-08-06
 %
 
 if nargin<2
@@ -88,6 +89,9 @@ if any(revIndexesBool)
     end
     if isfield(irrevModel,'rxnConfidenceScores')
         irrevModel.rxnConfidenceScores=[irrevModel.rxnConfidenceScores;irrevModel.rxnConfidenceScores(revIndexes)];
+    end
+    if isfield(irrevModel,'rxnReferences')
+        irrevModel.rxnReferences=[irrevModel.rxnReferences;irrevModel.rxnReferences(revIndexes)];
     end
 end
 end


### PR DESCRIPTION
### Main improvements in this PR:
In `convertToIrrev.m`, the field `rxnReferences` was not being extended as the other fields, creating model errors later on with functions such as `removeReactions.m`. This is now fixed.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR