### PR TITLE
Fix/ravenCobraWrapper

### DIFF
--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -78,6 +78,14 @@ if isRaven
         if any(i)
             newModel.rxnKEGGID=miriams(:,i);
         end
+        i=ismember(extractedMiriamNames,'metanetx.reaction');
+        if any(i)
+            newModel.rxnMetaNetXID=miriams(:,i);
+        end
+        i=ismember(extractedMiriamNames,'sbo');
+        if any(i)
+            newModel.rxnSBOTerms=miriams(:,i);
+        end
     end
     if isfield(model,'rxnReferences')
         newModel.rxnReferences=model.rxnReferences;
@@ -144,7 +152,11 @@ if isRaven
         i=ismember(extractedMiriamNames,'reactome');
         if any(i)
             newModel.metREACTOMEID=miriams(:,i);
-        end   
+        end
+        i=ismember(extractedMiriamNames,'sbo');
+        if any(i)
+            newModel.metSBOTerms=miriams(:,i);
+        end
         i=ismember(extractedMiriamNames,'seed.compound');
         if any(i)
             newModel.metSEEDID=miriams(:,i);
@@ -309,7 +321,7 @@ else
     if isfield(model,'rxnECNumbers')
         newModel.eccodes=regexprep(model.rxnECNumbers,'EC|EC:','');
     end
-    if isfield(model,'rxnKEGGID') || isfield(model,'rxnReferences')
+    if isfield(model,'rxnKEGGID') || isfield(model,'rxnMetaNetXID') || isfield(model,'rxnSBOTerms') || isfield(model,'rxnReferences')
         for i=1:numel(model.rxns)
             counter=1;
             newModel.rxnMiriams{i,1}=[];
@@ -317,6 +329,20 @@ else
                 if ~isempty(model.rxnKEGGID{i})
                     newModel.rxnMiriams{i,1}.name{counter,1} = 'kegg.reaction';
                     newModel.rxnMiriams{i,1}.value{counter,1} = model.rxnKEGGID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'rxnMetaNetXID')
+                if ~isempty(model.rxnMetaNetXID{i})
+                    newModel.rxnMiriams{i,1}.name{counter,1} = 'metanetx.reaction';
+                    newModel.rxnMiriams{i,1}.value{counter,1} = model.rxnMetaNetXID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'rxnSBOTerms')
+                if ~isempty(model.rxnSBOTerms{i})
+                    newModel.rxnMiriams{i,1}.name{counter,1} = 'sbo';
+                    newModel.rxnMiriams{i,1}.value{counter,1} = model.rxnSBOTerms{i};
                     counter=counter+1;
                 end
             end
@@ -388,7 +414,7 @@ else
     if isfield(model,'metFormulas')
         newModel.metFormulas=model.metFormulas;
     end
-    if isfield(model,'metChEBIID') || isfield(model,'metHMDBID') || isfield(model,'metKEGGID') || isfield(model,'metPubChemID') || isfield(model,'metMetaNetXID') || isfield(model,'metBiGGID') || isfield(model,'metLIPIDMAPSID') || isfield(model,'metMetaCycID') || isfield(model,'metREACTOMEID') || isfield(model,'metSEEDID') || isfield(model,'metSLMID')
+    if isfield(model,'metChEBIID') || isfield(model,'metHMDBID') || isfield(model,'metKEGGID') || isfield(model,'metPubChemID') || isfield(model,'metMetaNetXID') || isfield(model,'metBiGGID') || isfield(model,'metLIPIDMAPSID') || isfield(model,'metMetaCycID') || isfield(model,'metREACTOMEID') || isfield(model,'metSBOTerms') || isfield(model,'metSEEDID') || isfield(model,'metSLMID')
         for i=1:numel(model.mets)
             counter=1;
             newModel.metMiriams{i,1}=[];
@@ -469,6 +495,13 @@ else
                 if ~isempty(model.metREACTOMEID{i})
                     newModel.metMiriams{i,1}.name{counter,1} = 'reactome';
                     newModel.metMiriams{i,1}.value{counter,1} = model.metREACTOMEID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'metSBOTerms')
+                if ~isempty(model.metSBOTerms{i})
+                    newModel.metMiriams{i,1}.name{counter,1} = 'sbo';
+                    newModel.metMiriams{i,1}.value{counter,1} = model.metSBOTerms{i};
                     counter=counter+1;
                 end
             end

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -11,8 +11,8 @@ function newModel=ravenCobraWrapper(model)
 %   existense, which is only found in COBRA Toolbox structure.
 %
 %   NOTE: During RAVEN -> COBRA -> RAVEN conversion cycle the following
-%   fields are lost: id, description, annotation, compOutside, compMiriams,
-%   rxnComps, geneComps, unconstrained. Boundary metabolites are lost,
+%   fields are lost: annotation, compOutside, compMiriams, rxnComps,
+%   geneComps, unconstrained. Boundary metabolites are lost,
 %   because COBRA structure does not involve boundary metabolites, so they
 %   are removed using simplifyModel before RAVEN -> COBRA conversion. The
 %   field 'rev' is also partially lost, but during COBRA -> RAVEN
@@ -29,7 +29,7 @@ function newModel=ravenCobraWrapper(model)
 %   Usage: newModel=ravenCobraWrapper(model)
 %
 %   Simonas Marcisauskas, 2018-07-12
-%   Benjamín J. Sánchez, 2018-08-07
+%   Benjamín J. Sánchez, 2018-08-13
 %
 
 if isfield(model,'rules')
@@ -56,6 +56,12 @@ if isRaven
     %later to match the order of fields
     
     %Optional COBRA fields
+    if isfield(model,'id')
+        newModel.modelID=model.id;
+    end
+    if isfield(model,'description')
+        newModel.modelName=model.description;
+    end
     if isfield(model,'rxnNames')
         newModel.rxnNames=model.rxnNames;
     end
@@ -275,6 +281,12 @@ else
     %anyway, so there is no point to add this information here
     
     %Optional RAVEN fields
+    if isfield(model,'modelID')
+        newModel.id=model.modelID;
+    end
+    if isfield(model,'modelName')
+        newModel.description=model.modelName;
+    end
     if isfield(model,'compNames')
         newModel.compNames=model.compNames;
     end

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -29,6 +29,7 @@ function newModel=ravenCobraWrapper(model)
 %   Usage: newModel=ravenCobraWrapper(model)
 %
 %   Simonas Marcisauskas, 2018-07-12
+%   Benjamín J. Sánchez, 2018-08-07
 %
 
 if isfield(model,'rules')
@@ -79,7 +80,7 @@ if isRaven
         newModel.rxnNotes=model.rxnNotes;
     end
     if isfield(model,'metNames')
-        newModel.metNames=model.metNames;
+        newModel.metNames=strcat(model.metNames,' [',model.compNames(model.metComps),']');
     end
     if isfield(model,'metFormulas')
         newModel.metFormulas=model.metFormulas;

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -536,15 +536,18 @@ function rules=grrulesToRules(model)
 %'x(geneNumber)' and also changes 'or' and 'and' relations to corresponding
 %symbols
 replacingGenes=cell([size(model.genes,1) 1]);
-rules=cell([size(model.grRules,1) 1]);
 for i=1:numel(replacingGenes)
     replacingGenes{i}=strcat('x(',num2str(i),')');
 end
-for i=1:numel(model.grRules)
-    rules{i}=regexprep(model.grRules{i},model.genes,replacingGenes);
-    rules{i}=regexprep(rules{i},' and ',' & ');
-    rules{i}=regexprep(rules{i},' or ',' | ');
+rules = strcat({' '},model.grRules,{' '});
+for i=1:length(model.genes)
+    rules=regexprep(rules,[' ' model.genes{i} ' '],[' ' replacingGenes{i} ' ']);
+    rules=regexprep(rules,['(' model.genes{i} ' '],['(' replacingGenes{i} ' ']);
+    rules=regexprep(rules,[' ' model.genes{i} ')'],[' ' replacingGenes{i} ')']);
 end
+rules=regexprep(rules,' and ',' & ');
+rules=regexprep(rules,' or ',' | ');
+rules=strtrim(rules);
 end
 
 function grRules=rulesTogrrules(model)


### PR DESCRIPTION
### Main improvements in this PR:
Misc fixes in `ravenCobraWrapper.m`, including:
* Proper creation of `model.metNames` from RAVEN to COBRA: Should be `met_name [comp_name]`.
* Added RAVEN fields `model.id` & `model.description` = COBRA fields `model.modelID` & `model.modelName`, respectively (after COBRA introduced the fields in https://github.com/opencobra/cobratoolbox/pull/1218).
* Added missing MIRIAM annotation fields:
  * [`metanetx.reaction`](https://www.ebi.ac.uk/miriam/main/datatypes/MIR:00000568) for reactions = `model.rxnMetaNetXID` in COBRA (After COBRA introduced the field in https://github.com/opencobra/cobratoolbox/pull/1295).
  * [`sbo`](https://www.ebi.ac.uk/miriam/main/datatypes/MIR:00000024) for both metabolites or reactions = `model.rxnSBOTerms` or `model.metSBOTerms` in COBRA.
* Fixed bug in subfunction `grrulesToRules` that was matching incorrectly some genes.

After all these changes, a cycle COBRA -> RAVEN -> COBRA of [yeast-GEM](https://github.com/SysBioChalmers/yeast-GEM) keeps everything unmodified and only loses `model.description`, `model.metNotes` & `model.proteins` (unexisting fields in RAVEN).

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR