### PR TITLE
Feat/addRxns alternative

### DIFF
--- a/core/addRxns.m
+++ b/core/addRxns.m
@@ -9,11 +9,24 @@ function newModel=addRxns(model,rxnsToAdd,eqnType,compartment,allowNewMets)
 %            equations          cell array with equation strings. Decimal
 %                               coefficients are expressed as "1.2".
 %                               Reversibility is indicated by "<=>" or "=>"
+%            mets               (alternative to equations) cell array with
+%                               the metabolites involved in each reaction
+%                               as nested arrays. E.g.:
+%                               {{'met1','met2'},{'met1','met3','met4'}}
+%                               In the case of one single reaction added,
+%                               it can be a string array: {'met1','met2'}
+%            stoichCoeffs       (alternative to equations) cell array with
+%                               the corresponding stoichiometries as nested
+%                               vectors. E.g.: {[-1,+2],[-1,-1,+1]}
+%                               In the case of one single reaction added,
+%                               it can be a vector: [-1,+2]
 %            rxnNames           cell array with the names of each reaction
 %                               (opt, default '')
 %            lb                 vector with the lower bounds (opt, default
 %                               -inf for reversible reactions and 0 for
-%                               irreversible)
+%                               irreversible when "equations" is used, or
+%                               -inf for all reactions when "mets" + 
+%                               "stoichCoeffs" are used
 %            ub                 vector with the upper bounds (opt, default
 %                               inf)
 %            c                  vector with the objective function
@@ -82,6 +95,7 @@ function newModel=addRxns(model,rxnsToAdd,eqnType,compartment,allowNewMets)
 %   Usage: newModel=addRxns(model,rxnsToAdd,eqnType,compartment,allowNewMets)
 %
 %   Simonas Marcisauskas, 2018-04-03
+%   Benjamin J. Sanchez,  2018-08-22
 %
 
 if nargin<4
@@ -127,8 +141,8 @@ elseif iscell(rxnsToAdd.rxns)
     %To fit with some later printing
     rxnsToAdd.rxns=rxnsToAdd.rxns(:);
 end
-if ~isfield(rxnsToAdd,'equations')
-    EM='equations is a required field in rxnsToAdd';
+if ~(isfield(rxnsToAdd,'equations') || (isfield(rxnsToAdd,'mets') && isfield(rxnsToAdd,'stoichCoeffs')))
+    EM='Either "equations" or "mets"+"stoichCoeffs" are required fields in rxnsToAdd';
     dispEM(EM);
 end
 
@@ -144,12 +158,55 @@ if ~iscellstr(rxnsToAdd.rxns) && ~ischar(rxnsToAdd.rxns)
 else
     rxnsToAdd.rxns=cellstr(rxnsToAdd.rxns);
 end
-if ~iscellstr(rxnsToAdd.equations) && ~ischar(rxnsToAdd.equations)
-    %It could also be a string, but it's not encouraged
-    EM='rxnsToAdd.equations must be a cell array of strings';
-    dispEM(EM);
+
+%Normal case: equations provided
+if isfield(rxnsToAdd,'equations')
+    if ~iscellstr(rxnsToAdd.equations) && ~ischar(rxnsToAdd.equations)
+        %It could also be a string, but it's not encouraged
+        EM='rxnsToAdd.equations must be a cell array of strings';
+        dispEM(EM);
+    else
+        rxnsToAdd.equations=cellstr(rxnsToAdd.equations);
+    end
+    
+%Alternative case: mets+stoichiometry provided
 else
-    rxnsToAdd.equations=cellstr(rxnsToAdd.equations);
+    %In the case of 1 rxn added (array of strings + vector), transform to
+    %cells of length=1:
+    if iscellstr(rxnsToAdd.mets)
+        rxnsToAdd.mets = {rxnsToAdd.mets};        
+    end
+    if isnumeric(rxnsToAdd.stoichCoeffs)
+        rxnsToAdd.stoichCoeffs = {rxnsToAdd.stoichCoeffs};        
+    end
+    %Now both rxnsToAdd.mets and rxnsToAdd.stoichCoeffs should be cell
+    %arrays & of the same size:
+    if ~iscell(rxnsToAdd.mets) || ~iscell(rxnsToAdd.stoichCoeffs)
+        EM='rxnsToAdd.mets & rxnsToAdd.stoichCoeffs must be cell arrays';
+        dispEM(EM);
+    elseif length(rxnsToAdd.stoichCoeffs) ~= length(rxnsToAdd.mets)
+        EM = 'rxnsToAdd.stoichCoeffs must have the same number of elements as rxnsToAdd.mets';
+        dispEM(EM);
+    end
+    %In this case we need lb to decide if the reaction is reversible or not:
+    if ~isfield(rxnsToAdd,'lb')
+        %Fill with standard if it doesn't exist
+        rxnsToAdd.lb=-inf(size(rxnsToAdd.mets));
+    elseif ~isnumeric(rxnsToAdd.lb)
+        EM = 'rxnsToAdd.lb must be a vector';
+        dispEM(EM);
+    elseif length(rxnsToAdd.lb) ~= length(rxnsToAdd.mets)
+        EM = 'rxnsToAdd.lb must have the same number of elements as rxnsToAdd.mets';
+        dispEM(EM);
+    end
+    %Now we construct equations, to comply with the rest of the script:
+    rxnsToAdd.equations = cell(size(rxnsToAdd.mets));
+    for i = 1:length(rxnsToAdd.mets)
+        mets         = rxnsToAdd.mets{i};
+        stoichCoeffs = rxnsToAdd.stoichCoeffs{i};
+        isrev        = rxnsToAdd.lb(i) < 0;
+        rxnsToAdd.equations{i} = buildEquation(mets,stoichCoeffs,isrev);
+    end
 end
 
 nRxns=numel(rxnsToAdd.rxns);

--- a/core/buildEquation.m
+++ b/core/buildEquation.m
@@ -1,5 +1,5 @@
-function equationString=constructEquation(mets,stoichCoeffs,isrev)
-% constructEquation
+function equationString=buildEquation(mets,stoichCoeffs,isrev)
+% buildEquation
 %   Construct single equation string for a given reaction
 %
 %   mets            string array with metabolites involved in the reaction.
@@ -9,7 +9,7 @@ function equationString=constructEquation(mets,stoichCoeffs,isrev)
 %
 %   equationString  equation as a string
 %
-%    Usage: equationString=constructEquation(mets,stoichCoeffs,isrev)
+%    Usage: equationString=buildEquation(mets,stoichCoeffs,isrev)
 %
 %   Benjamin Sanchez, 2018-08-22
 %

--- a/core/changeRxns.m
+++ b/core/changeRxns.m
@@ -4,7 +4,11 @@ function model=changeRxns(model,rxns,equations,eqnType,compartment,allowNewMets)
 %
 %   model            a model structure
 %   rxns             cell array with reaction ids
-%   equations        cell array with equations
+%   equations        cell array with equations. Alternatively, it can be a
+%                    structure with the fields "mets" and "stoichCoeffs",
+%                    in the same fashion as addRxns. E.g.:
+%                    equations.mets = {{'met1','met2'},{'met1','met3'}}
+%                    equations.stoichCoeffs = {[-1,+2],[-1,+1]}
 %   eqnType          double describing how the equation string should be
 %                    interpreted
 %                    1 - The metabolites are matched to model.mets. New
@@ -50,6 +54,7 @@ function model=changeRxns(model,rxns,equations,eqnType,compartment,allowNewMets)
 %   Usage: model=changeRxns(model,rxns,equations,eqnType,compartment,allowNewMets)
 %
 %   Simonas Marcisauskas, 2018-03-17
+%   Benjamin J. Sanchez,  2018-08-22
 %
 
 if nargin<5
@@ -80,7 +85,12 @@ end
 %reordered to match the original order. This is done like this to make use
 %of the advanced parsing of equations that addRxns use.
 rxnsToChange.rxns=rxns;
-rxnsToChange.equations=equations;
+if isfield(equations,'mets') && isfield(equations,'stoichCoeffs')
+    rxnsToChange.mets=equations.mets;
+    rxnsToChange.stoichCoeffs=equations.stoichCoeffs;
+else
+    rxnsToChange.equations=equations;
+end
 if isfield(model,'rxnNames')
     rxnsToChange.rxnNames=model.rxnNames(J);
 end

--- a/core/constructEquation.m
+++ b/core/constructEquation.m
@@ -1,0 +1,71 @@
+function equationString=constructEquation(mets,stoichCoeffs,isrev)
+% constructEquation
+%   Construct single equation string for a given reaction
+%
+%   mets            string array with metabolites involved in the reaction.
+%   stoichCoeffs    vector with corresponding stoichiometric coeffs.
+%   isrev           logical indicating if the reaction is or not
+%                   reversible.
+%
+%   equationString  equation as a string
+%
+%    Usage: equationString=constructEquation(mets,stoichCoeffs,isrev)
+%
+%   Benjamin Sanchez, 2018-08-22
+%
+
+if ~iscellstr(mets) && ~ischar(mets)
+    EM = 'mets must be a cell array of strings';
+    dispEM(EM);
+else
+    mets = cellstr(mets);
+end
+if ~isnumeric(stoichCoeffs)
+    EM = 'stoichCoeffs must be a numeric vector';
+    dispEM(EM);
+elseif ~islogical(isrev)
+    EM = 'isrev must be a logical';
+    dispEM(EM);
+elseif length(mets) ~= length(stoichCoeffs)
+    EM = 'lengths of mets and stoichCoeffs should be the same';
+    dispEM(EM);
+end
+
+%Reactant half:
+reactants       = mets(stoichCoeffs<0);
+reactantsCoeffs = abs(stoichCoeffs(stoichCoeffs<0));
+reactantsEqn    = concatenateEquation(reactants,reactantsCoeffs);
+
+%Product half:
+products       = mets(stoichCoeffs>0);
+productsCoeffs = abs(stoichCoeffs(stoichCoeffs>0));
+productsEqn    = concatenateEquation(products,productsCoeffs);
+
+%Full equation:
+if isrev
+    equationString = [reactantsEqn ' <=> ' productsEqn];
+else
+    equationString = [reactantsEqn ' => ' productsEqn];
+end
+
+end
+
+function eqn = concatenateEquation(mets,stoichCoeffs)
+%This function concatenates metabolites and stoich. coefficients to form
+%either the left or right side of the rxn equation
+eqn = '';
+for i = 1:length(stoichCoeffs)
+    if i == 1
+        plusString='';
+    else
+        plusString=' + ';
+    end
+    stoich = stoichCoeffs(i);
+    if stoich == 1
+        stoich = '';
+    else
+        stoich = [num2str(stoich) ' '];
+    end
+    eqn = [eqn plusString stoich mets{i}];
+end
+end

--- a/core/constructEquations.m
+++ b/core/constructEquations.m
@@ -74,7 +74,7 @@ for i=1:numel(indexes)
     isrev        = model.rev(indexes(i))==1;
     
     %Construct equation:
-    equationStrings{i} = constructEquation(mets,stoichCoeffs,isrev);
+    equationStrings{i} = buildEquation(mets,stoichCoeffs,isrev);
 end
 
 end


### PR DESCRIPTION
### Main improvements in this PR:
`addRxns.m` and `changeRxns.m` have now options for inputing the reaction stoichiometry as an array of mets + an array of stoichiometric coefficients. Note that in that case, those mets+stoichCoeffs are inmediately converted to an equation using the new function `buildEquation.m`, so to comply with the rest of `addRxns.m`. This might not be the nicest way of doing it (as the rxn equation needs to be later parsed anyways); however this way we avoid extensive changes in the function. Also, it does not add significant computing time, as it can be seen using [this function](https://github.com/SysBioChalmers/gem-scripts/blob/master/Ben/testAddRxns.m) from GEM-scripts, which runs each option for yeast-GEM 100 times, giving almost the same average time:

```
Using equations: 0.80885±0.28079 secs.
Using mets+stoichCoeffs: 0.81062±0.26878 secs.
```

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
