### PR TITLE
fix: exportModel

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -13,7 +13,7 @@ function exportModel(model,fileName,exportGeneComplexes,supressWarnings)
 %
 %   Usage: exportModel(model,fileName,exportGeneComplexes,supressWarnings)
 %
-%   Eduard Kerkhoven, 2018-07-19
+%   Simonas Marcisauskas, 2018-09-06
 
 if nargin<3
     exportGeneComplexes=false;
@@ -207,6 +207,11 @@ for i=1:numel(model.comps)
     end
     
     if isfield(modelSBML.compartment,'metaid')
+        if ~isnan(str2double(model.comps(i)))
+            EM='The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with "c_" string';
+            dispEM(EM,false);
+            model.comps(i)=strcat('c_',model.comps(i));
+        end
         modelSBML.compartment(i).metaid=model.comps{i};
     end
     %Prepare Miriam strings
@@ -564,6 +569,8 @@ ind=find(model.c);
 
 if isempty(ind)
     modelSBML.fbc_objective.fbc_fluxObjective.fbc_coefficient=0;
+    EM='The objective function is not defined. The model will be exported as it is. Notice that having undefined objective function may produce warnings related to "fbc:coefficient" and "fbc:reaction" in SBML Validator';
+    dispEM(EM,false);
 else
     for i=1:length(ind)
         %Copy the default values to the next index as long as it is not the


### PR DESCRIPTION
### Main improvements in this PR:
- fixed an issue for entirely numeric compartment IDs. If that is the case, each compartment ID is preceded with "c_" string. This fix was necessary since OutputSBML did not consider exporting entirely numeric compartment IDs
- added the warning message stating that SBML specification requires the objective function to be set

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR