### PR TITLE
feat: exportForGit writes RAVEN commit id if version unavailable

### DIFF
--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -54,7 +54,8 @@ catch
     try
         currentPath=pwd;
         cd(RAVENpath);
-        RAVENver = git('log -n 1 --format=%H');
+        RAVENcommit = git('log -n 1 --format=%H');
+        RAVENver    = ['commit ' RAVENcommit(1:7)];
         cd(currentPath);
     catch
         RAVENver = 'unknown';

--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -51,7 +51,14 @@ try
     RAVENver = fscanf(fid,'%s');
     fclose(fid);
 catch
-    RAVENver = 'unknown';
+    try
+        currentPath=pwd;
+        cd(RAVENpath);
+        RAVENver = git('log -n 1 --format=%H');
+        cd(currentPath);
+    catch
+        RAVENver = 'unknown';
+    end
 end
 
 %Retrieve latest COBRA commit:


### PR DESCRIPTION
### Main improvements in this PR:
If RAVEN is not in `master` (where version.txt resides), then it writes the commit id as RAVEN version in the dependencies.txt file

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch