### PR TITLE
fix: importModel if FBCv2, but groups not used for subsystems

### DIFF
--- a/io/importModel.m
+++ b/io/importModel.m
@@ -664,13 +664,14 @@ if isfield(modelSBML,'groups_group')
         groupreactions={modelSBML.groups_group(i).groups_member(:).groups_idRef};
         groupreactions=regexprep(groupreactions,'^R_','');
         [~, idx] = ismember(groupreactions, reactionIDs);
+        if idx==0;else
         for j=1:numel(idx)
             if isempty(subsystems{idx(j)}) % First subsystem
                 subsystems{idx(j)} = {modelSBML.groups_group(i).groups_name};
             else % Consecutive subsystems: concatenate
                 subsystems{idx(j)} = horzcat(subsystems{idx(j)}, modelSBML.groups_group(i).groups_name);
             end
-        end
+        end;end
     end
 end
 

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -664,14 +664,15 @@ if isfield(modelSBML,'groups_group')
         groupreactions={modelSBML.groups_group(i).groups_member(:).groups_idRef};
         groupreactions=regexprep(groupreactions,'^R_','');
         [~, idx] = ismember(groupreactions, reactionIDs);
-        if idx==0;else
-        for j=1:numel(idx)
-            if isempty(subsystems{idx(j)}) % First subsystem
-                subsystems{idx(j)} = {modelSBML.groups_group(i).groups_name};
-            else % Consecutive subsystems: concatenate
-                subsystems{idx(j)} = horzcat(subsystems{idx(j)}, modelSBML.groups_group(i).groups_name);
+        if any(idx)
+            for j=1:numel(idx)
+                if isempty(subsystems{idx(j)}) % First subsystem
+                    subsystems{idx(j)} = {modelSBML.groups_group(i).groups_name};
+                else % Consecutive subsystems: concatenate
+                    subsystems{idx(j)} = horzcat(subsystems{idx(j)}, modelSBML.groups_group(i).groups_name);
+                end
             end
-        end;end
+        end
     end
 end
 


### PR DESCRIPTION
### Main improvements in this PR:
- if a model is FBCv2 and groups seem to be used, it can still be that they don't specify subsystems. So if none of the assigned group reactions are reactionIDs, then skip trying to assign subsystems from groups.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch