### PR TITLE
fix: find toolbox version

### DIFF
--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -123,17 +123,19 @@ end
 function version = getVersion(toolbox,IDfile,masterFlag)
 currentPath = pwd;
 try
-    toolboxPath = which(IDfile);
+    toolboxPath = which(IDfile);                %full file path
+    slashPos    = getSlashPos(toolboxPath);
+    toolboxPath = toolboxPath(1:slashPos(end)); %folder path
     %Go up until the root is found:
     while ~ismember({'.git'},ls(toolboxPath))
         slashPos    = getSlashPos(toolboxPath);
-        toolboxPath = toolboxPath(1:slashPos(end)-1);
+        toolboxPath = toolboxPath(1:slashPos(end-1));
     end
     cd(toolboxPath);
     checkIfMaster(toolbox,masterFlag)
     %Try to find version file of the toolbox:
     try
-        fid     = fopen('version.txt','r');
+        fid     = fopen([toolboxPath 'version.txt'],'r');
         version = fscanf(fid,'%s');
         fclose(fid);
     catch


### PR DESCRIPTION
### Main improvements in this PR:
A recent change in `exportForGit.m` (PR #160) created a bug that duplicated the version number for RAVEN and COBRA (as `fopen` will look up a file in all available paths if full path is not specified):

![image](https://user-images.githubusercontent.com/9384349/46281239-66688380-c56e-11e8-8448-1dd33c8e6fb0.png)

To correct this, `version.txt` is now opened with its full path. This was tested on yeast-GEM with the changes included locally in the master branch of RAVEN and works as expected:

![image](https://user-images.githubusercontent.com/9384349/46281126-12f63580-c56e-11e8-8629-690f0f53838a.png)

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR