### PR TITLE
fix: switch from ls to dir in exportForGit

### DIFF
--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -129,9 +129,11 @@ try
     slashPos    = getSlashPos(toolboxPath);
     toolboxPath = toolboxPath(1:slashPos(end)); %folder path
     %Go up until the root is found:
-    while ~ismember({'.git'},ls(toolboxPath))
+    D = dir(toolboxPath);
+    while ~ismember({'.git'},{D.name})
         slashPos    = getSlashPos(toolboxPath);
         toolboxPath = toolboxPath(1:slashPos(end-1));
+        D           = dir(toolboxPath);
     end
     cd(toolboxPath);
 catch


### PR DESCRIPTION
### Main improvements in this PR:
Solves #169 by changing the use of `ls` to `dir`, for MAC compatibility (as in MAC `ls` won't show hidden folders like `.git`).

Tested both in windows by @BenjaSanchez and in MAC by @feiranl

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR