### PR TITLE
Feat/readTags

### DIFF
--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -19,7 +19,7 @@ function out=exportForGit(model,prefix,path,formats,masterFlag)
 %
 %   Usage: exportForGit(model,prefix,path,formats,masterFlag)
 %
-%   Benjamin J. Sanchez, 2018-09-26
+%   Benjamin J. Sanchez, 2018-10-19
 %
 if nargin<5
     masterFlag=false;
@@ -119,58 +119,3 @@ if isfield(model,'modelVersion')
 end
 fclose(fid);
 end
-
-function version = getVersion(toolbox,IDfile,masterFlag)
-currentPath = pwd;
-version     = '';
-%Try to find root of toolbox:
-try
-    toolboxPath = which(IDfile);                %full file path
-    slashPos    = getSlashPos(toolboxPath);
-    toolboxPath = toolboxPath(1:slashPos(end)); %folder path
-    %Go up until the root is found:
-    D = dir(toolboxPath);
-    while ~ismember({'.git'},{D.name})
-        slashPos    = getSlashPos(toolboxPath);
-        toolboxPath = toolboxPath(1:slashPos(end-1));
-        D           = dir(toolboxPath);
-    end
-    cd(toolboxPath);
-catch
-    disp([toolbox ' toolbox cannot be found'])
-    version = 'unknown';
-end
-%Check if in master:
-if masterFlag
-    currentBranch = git('rev-parse --abbrev-ref HEAD');
-    if ~strcmp(currentBranch,'master')
-        cd(currentPath);
-        error(['ERROR: ' toolbox ' not in master. Check-out the master branch of ' toolbox ' before submitting model for Git.'])
-    end
-end
-%Try to find version file of the toolbox:
-if isempty(version)
-    try
-        fid     = fopen([toolboxPath 'version.txt'],'r');
-        version = fscanf(fid,'%s');
-        fclose(fid);
-    catch
-        %If not possible, try to find latest commit:
-        try
-            commit  = git('log -n 1 --format=%H');
-            version = ['commit ' commit(1:7)];
-        catch
-            version = 'unknown';
-        end
-    end
-end
-cd(currentPath);
-end
-
-function slashPos = getSlashPos(path)
-slashPos = strfind(path,'\');       %Windows
-if isempty(slashPos)
-    slashPos = strfind(path,'/');   %MAC/Linux
-end
-end
-

--- a/io/getVersion.m
+++ b/io/getVersion.m
@@ -56,10 +56,17 @@ if isempty(version)
         version = fscanf(fid,'%s');
         fclose(fid);
     catch
-        %If not possible, try to find latest commit:
+        %If no file available, look up the tag:
         try
+            version = git('describe --tags');
             commit  = git('log -n 1 --format=%H');
-            version = ['commit ' commit(1:7)];
+            commit = commit(1:7);
+            %If no tag available or commit is part of tag, get commit instead:
+            if ~isempty(strfind(version,'fatal')) || ~isempty(strfind(version,commit))
+                version = ['commit ' commit];
+            else
+                version = strrep(version,'v','');
+            end
         catch
             version = 'unknown';
         end

--- a/io/getVersion.m
+++ b/io/getVersion.m
@@ -1,0 +1,76 @@
+function version = getVersion(toolbox,fileID,masterFlag)
+% getVersion
+%   Returns the version of a given toolbox, or if not available the latest
+%   commit hash (7 characters).
+%
+%   toolbox         string with the toolbox name (e.g. "RAVEN")
+%   fileID          string with the name of a file that is only found in
+%                   the corresponding toolbox (e.g. "ravenCobraWrapper.m").
+%   masterFlag      logical, if true, function will error if the toolbox is
+%                   not on the master branch (opt, default false).
+%
+%   version         string containing either the toolbox version or latest
+%                   commit hash (7 characters).
+%
+%   Usage: version = getVersion(toolbox,fileID,masterFlag)
+%
+%   Benjamin J. Sanchez, 2018-10-19
+%
+
+if nargin<3
+    masterFlag = false;
+end
+
+currentPath = pwd;
+version     = '';
+
+%Try to find root of toolbox:
+try
+    toolboxPath = which(fileID);                %full file path
+    slashPos    = getSlashPos(toolboxPath);
+    toolboxPath = toolboxPath(1:slashPos(end)); %folder path
+    %Go up until the root is found:
+    D = dir(toolboxPath);
+    while ~ismember({'.git'},{D.name})
+        slashPos    = getSlashPos(toolboxPath);
+        toolboxPath = toolboxPath(1:slashPos(end-1));
+        D           = dir(toolboxPath);
+    end
+    cd(toolboxPath);
+catch
+    disp([toolbox ' toolbox cannot be found'])
+    version = 'unknown';
+end
+%Check if in master:
+if masterFlag
+    currentBranch = git('rev-parse --abbrev-ref HEAD');
+    if ~strcmp(currentBranch,'master')
+        cd(currentPath);
+        error(['ERROR: ' toolbox ' not in master. Check-out the master branch of ' toolbox ' before submitting model for Git.'])
+    end
+end
+%Try to find version file of the toolbox:
+if isempty(version)
+    try
+        fid     = fopen([toolboxPath 'version.txt'],'r');
+        version = fscanf(fid,'%s');
+        fclose(fid);
+    catch
+        %If not possible, try to find latest commit:
+        try
+            commit  = git('log -n 1 --format=%H');
+            version = ['commit ' commit(1:7)];
+        catch
+            version = 'unknown';
+        end
+    end
+end
+cd(currentPath);
+end
+
+function slashPos = getSlashPos(path)
+slashPos = strfind(path,'\');       %Windows
+if isempty(slashPos)
+    slashPos = strfind(path,'/');   %MAC/Linux
+end
+end


### PR DESCRIPTION
### Main improvements in this PR:
* COBRA finally started versioning their releases (https://github.com/opencobra/cobratoolbox/releases); however, they do so by only creating a tag. So `git describe --tags` is used to find this, in case the version file is not available.
* Note that if either toolbox is on any branch without a release tag, `git describe --tags` will return a lightweight tag containing the commit hash, e.g. `2.0.0-rc.2-253-gc9a2856`; if this is detected by `getVersion.m`, the commit info will be returned instead, e.g. `commit c9a2856`, keeping the standard from before.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [x] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR