### PR TITLE
fix: fseof and style:standardizeGrRules

### DIFF
--- a/core/FSEOF.m
+++ b/core/FSEOF.m
@@ -110,7 +110,11 @@ for num=1:length(fseof.target)
         A1=num2str(num);                                  %row ID
         A2=char(model.rxns(num));                         %enzyme ID
         A3=char(model.rxnNames(num));                     %enzyme Name
-        A4=char(strjoin(model.subSystems{num,1},';'));                   %Subsystems
+        if isfield(model,'subSystems') && ~isempty(model.subSystems{num});
+            A4=char(strjoin(model.subSystems{num,1},';'));                   %Subsystems
+        else
+            A4='';
+        end
         A5=num2str(model.rev(num)*rxnDirection(num,1));   %reaction Dirction
         A6=char(model.grRules(num));                      %Gr Rule
         if output == 1    %Output to a file

--- a/core/standardizeGrRules.m
+++ b/core/standardizeGrRules.m
@@ -139,7 +139,7 @@ if ~isempty(indexes2check)
         STR = [STR,'ionships found in\n\n'];
         for i=1:length(indexes2check)
             index = indexes2check(i);
-            STR = [STR '  - grRule #' num2str(index) ': ' grRules{index} '\n'];
+            STR = [STR '  - grRule #' model.rxns{index} ': ' grRules{index} '\n'];
         end
         STR = [STR,'\n This kind of relationships should only be present '];
         STR = [STR,'in  reactions catalysed by complexes of isoenzymes e'];


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `FSEOF` if model has no subSystems defined or if subSystem field is empty
- style:
  - `standardizeGrRules` reports reaction IDs instead of indexex, makes it easier to curate questionable grRules

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch