### PR TITLE
Adding potenitally missing comps field

### DIFF
--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -272,6 +272,10 @@ else
     %Mandatory RAVEN fields
     newModel.rxns=model.rxns;
     newModel.mets=model.mets;
+    if ~isfield(model,'comps')
+        model.comps = setdiff({''},unique(regexprep(model.mets,'.*\[[^\]]+\]$','')));
+    end
+
     for i=1:numel(model.comps)
         newModel.mets=regexprep(newModel.mets,['\[', model.comps{i}, '\]$'],'');
         newModel.mets=regexprep(newModel.mets,['\[', model.compNames{i}, '\]$'],'');


### PR DESCRIPTION
### Main improvements in this PR:
Currently, the `ravenCobraWrapper` requires the comps field to be present in a COBRA model to work. 
This field is an optional field in the current data structure and thus not necessarily present in all models.
As a workaround, I modified the function to create the comps field (based on compartmentIDs present in the metabolite names, as is currently standard practice in COBRA models).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [ ] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
