### PR TITLE
fix: constructEquations

### DIFF
--- a/core/constructEquations.m
+++ b/core/constructEquations.m
@@ -72,7 +72,7 @@ for i=1:numel(Rindexes)
     end
     %Define stoich coeffs and reversibility:
     stoichCoeffs = model.S(Mindexes,Rindexes(i));
-    isrev        = model.rev(Rindexes(i))==1;
+    isrev        = model.lb(Rindexes(i))<0;
     
     %Construct equation:
     equationStrings{i} = buildEquation(mets,stoichCoeffs,isrev);

--- a/core/constructEquations.m
+++ b/core/constructEquations.m
@@ -74,7 +74,7 @@ for i=1:numel(Rindexes)
     end
     %Define stoich coeffs and reversibility:
     stoichCoeffs = model.S(Mindexes,Rindexes(i));
-    isrev        = model.lb(Rindexes(i))<0;
+    isrev        = model.lb(Rindexes(i))<0 & model.ub(Rindexes(i))>0;
     
     %Construct equation:
     equationStrings{i} = buildEquation(mets,stoichCoeffs,isrev);

--- a/core/constructEquations.m
+++ b/core/constructEquations.m
@@ -1,4 +1,4 @@
-function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sortMetNames,useMetID)
+function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sortMetNames,useMetID,useFormula)
 % constructEquations
 %   Construct equation strings for reactions
 %
@@ -14,8 +14,10 @@ function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sort
 %   sortMetNames      sort the metabolite names in the equation. Uses
 %                     compartment even if useComps is false (opt, default
 %                     false)
-%   useMetID          use metabolite ID in generated equations, otherwise metNames are
-%                     used (opt, default false)
+%   useMetID          use metabolite ID in generated equations (opt,
+%                     default false)
+%   useFormula        use metabolite formula in generated equations (opt,
+%                     default false)
 %
 %   Outut:
 %   equationStrings   a cell array with equations
@@ -25,7 +27,7 @@ function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sort
 %   constructed by this function.
 %
 %   Usage: equationStrings=constructEquations(model,rxns,useComps,...
-%           sortRevRxns,sortMetNames,useMetID)
+%           sortRevRxns,sortMetNames,useMetID,useFormula)
 %
 %   Hao Wang, 2017-05-15
 %   Benjamin Sanchez, 2018-08-22
@@ -45,6 +47,9 @@ if nargin<5
 end
 if nargin<6
     useMetID=false;
+end
+if nargin<7
+    useFormula=false;
 end
 if isempty(rxns) && nargin>2
     rxns=model.rxns;
@@ -67,8 +72,12 @@ equationStrings=cell(numel(Rindexes),1);
 for i=1:numel(Rindexes)
     Mindexes=find(model.S(:,Rindexes(i)));
     %Define metabolites by id or name, and with or without compartment:
-    if useMetID==true
+    if useMetID==true && useFormula==false
         mets = model.mets(Mindexes);
+    elseif useMetID==false && useFormula==true
+        mets = strcat('[',model.metFormulas(Mindexes),']');
+    elseif useMetID==true && useFormula==true
+        error('Arguments useMetID and useFormula cannot be both TRUE!');
     else
         mets = model.metNames(Mindexes);
     end

--- a/core/constructEquations.m
+++ b/core/constructEquations.m
@@ -20,6 +20,10 @@ function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sort
 %   Outut:
 %   equationStrings   a cell array with equations
 %
+%   NOTE: Reactions in a model should be organized in their forward direction
+%   (e.g. ub = 1000 and lb = -1000/0) so that their equations can be correctly
+%   constructed by this function.
+%
 %   Usage: equationStrings=constructEquations(model,rxns,useComps,...
 %           sortRevRxns,sortMetNames,useMetID)
 %

--- a/core/constructEquations.m
+++ b/core/constructEquations.m
@@ -29,7 +29,7 @@ function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sort
 %   Usage: equationStrings=constructEquations(model,rxns,useComps,...
 %           sortRevRxns,sortMetNames,useMetID,useFormula)
 %
-%   Hao Wang, 2017-05-15
+%   Hao Wang, 2019-03-05
 %   Benjamin Sanchez, 2018-08-22
 %
 
@@ -71,7 +71,7 @@ equationStrings=cell(numel(Rindexes),1);
 
 for i=1:numel(Rindexes)
     Mindexes=find(model.S(:,Rindexes(i)));
-    %Define metabolites by id or name, and with or without compartment:
+    %Define metabolites by id, formula or name, and with or without compartment: 
     if useMetID==true && useFormula==false
         mets = model.mets(Mindexes);
     elseif useMetID==false && useFormula==true

--- a/core/constructEquations.m
+++ b/core/constructEquations.m
@@ -2,6 +2,7 @@ function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sort
 % constructEquations
 %   Construct equation strings for reactions
 %
+%   Input:
 %   model             a model structure
 %   rxns              either a cell array of reaction IDs, a logical vector with the
 %                     same number of elements as reactions in the model, or a vector
@@ -16,9 +17,10 @@ function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sort
 %   useMetID          use metabolite ID in generated equations, otherwise metNames are
 %                     used (opt, default false)
 %
+%   Outut:
 %   equationStrings   a cell array with equations
 %
-%    Usage: equationStrings=constructEquations(model,rxns,useComps,...
+%   Usage: equationStrings=constructEquations(model,rxns,useComps,...
 %           sortRevRxns,sortMetNames,useMetID)
 %
 %   Hao Wang, 2017-05-15


### PR DESCRIPTION
### Main improvements in this PR:
- fix: get the reversibility information by querying both `lb` and `ub` fields, instead of the obsolete `rev` field that could be inaccurate or unavailable
- doc: refine function description with `Input` and `Output` sub-headings
- feat: additional option is added for allowing the generation of equations with met formulas

**NOTE:** None of these changes affect backward-compatibility of any of the modified functions. All reactions in a model should be organized in their forward direction, typically by setting `ub = 1000` and `lb = -1000 (or 0)`, so that their equations can be correctly constructed by the `constructEquations` function.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch