### PR TITLE
fix: getKEGGModelForOrganism error report bug

### DIFF
--- a/external/kegg/getGenesFromKEGG.m
+++ b/external/kegg/getGenesFromKEGG.m
@@ -2,16 +2,17 @@ function model=getGenesFromKEGG(keggPath,koList)
 % getGenesFromKEGG
 %   Retrieves information on all genes stored in KEGG database
 %
+%   Input:
 %   keggPath	if keggGenes.mat is not in the RAVEN\external\kegg
 %               directory, this function will attempt to read data from a
 %               local FTP dump of the KEGG database. keggPath is the path
 %               to the root of this database
-%
 %   koList      the number of genes in KEGG is very large. koList can be a
 %               cell array with KO identifiers, in which case only genes
 %               belonging to one of those KEGG orthologies are retrieved
 %               (opt, default all KOs with associated reactions)
 %
+%   Output:
 %   model       a model structure generated from the database. The
 %               following fields are filled
 %       id              'KEGG'
@@ -24,15 +25,15 @@ function model=getGenesFromKEGG(keggPath,koList)
 %       rxnGeneMat      A binary matrix that indicates whether a specific
 %                       gene is present in a KO id
 %
-%   If the file keggGenes.mat is in the RAVEN\external\kegg directory it
-%   will be loaded instead of parsing of the KEGG files. If it does not
+%   NOTE: If the file keggGenes.mat is in the RAVEN\external\kegg directory
+%   it will be loaded instead of parsing of the KEGG files. If it does not
 %   exist it will be saved after parsing of the KEGG files. In general, you
 %   should remove the keggGenes.mat file if you want to rebuild the model
 %   structure from a newer version of KEGG.
 %
 %   Usage: model=getGenesFromKEGG(keggPath,koList)
 %
-%   Simonas Marcisauskas, 2018-08-15
+%   Simonas Marcisauskas, 2019-01-08
 %
 %
 % NOTE: This is how one entry looks in the file

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -263,7 +263,7 @@ function model=getKEGGModelForOrganism(organismID,fastaFile,dataDir,...
 %    keepGeneral,cutOff,minScoreRatioKO,minScoreRatioG,maxPhylDist,...
 %    nSequences,seqIdentity)
 %
-%   Simonas Marcisauskas, 2018-09-06
+%   Simonas Marcisauskas, 2019-01-08
 
 if nargin<2
     fastaFile=[];
@@ -354,9 +354,9 @@ if ~isempty(dataDir)
         'u3z7s31q5be4zqpmmsxgvfb0ye1x2lez', ...
         'rsug46hptvoy7hurooi6fsc1hz2f5b6v'};
     if all(cellfun(@isempty,regexp(dataDir,strcat(hmmOptions,'$')))) %Check if dataDir ends with any of the hmmOptions
-        if ~exist(fullfile(dataDir,'keggdb','genes.pep'),'file') &&...
-                ~exist(fullfile(dataDir,'fasta'),'dir') &&...
-                ~exist(fullfile(dataDir,'aligned'),'dir') &&...
+        if ~exist(fullfile(dataDir,'keggdb','genes.pep'),'file') && ...
+                ~exist(fullfile(dataDir,'fasta'),'dir') && ...
+                ~exist(fullfile(dataDir,'aligned'),'dir') && ...
                 ~exist(fullfile(dataDir,'hmms'),'dir')
             EM='Pre-trained HMMs set is not recognised. It should match any of the following sets (which are available to download):';
             disp(EM);
@@ -371,11 +371,16 @@ if ~isempty(dataDir)
             unzip([dataDir,'.zip']);
         else
             [~,hmmIndex]=ismember(dataDir,hmmOptions);
-            
             fprintf('Downloading HMMs archive file...\n');
             websave([dataDir,'.zip'],['https://chalmersuniversity.box.com/shared/static/',hmmLinks{hmmIndex},'.zip']);
             fprintf('Extracting HMMs archive file...\n');
             unzip([dataDir,'.zip']);
+        end
+        %Check if HMMs are extracted
+        if ~exist(fullfile(dataDir,'hmms','K00844.hmm'),'file')
+            EM='No HMMs are available in dataDir/hmms. Try to manually remove dataDir parent directory and start over\n';
+            disp(EM);
+            error('Fatal error occured. See the details above');
         end
     end
 end

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -265,7 +265,7 @@ function model=getKEGGModelForOrganism(organismID,fastaFile,dataDir,...
 %    keepGeneral,cutOff,minScoreRatioKO,minScoreRatioG,maxPhylDist,...
 %    nSequences,seqIdentity)
 %
-%   Simonas Marcisauskas, 2019-01-08
+%   Simonas Marcisauskas, 2019-01-14
 
 if nargin<2
     fastaFile=[];
@@ -380,7 +380,7 @@ if ~isempty(dataDir)
         end
         %Check if HMMs are extracted
         if ~exist(fullfile(dataDir,'hmms','K00844.hmm'),'file')
-            EM='No HMMs are available in dataDir/hmms. Try to manually remove dataDir parent directory and start over\n';
+            EM=['The HMM files seem improperly extracted and not found in ',dataDir,'/hmms. Please remove ',dataDir,' folder and rerun getKEGGModelForOrganism'];
             disp(EM);
             error('Fatal error occured. See the details above');
         end

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -9,6 +9,7 @@ function model=getKEGGModelForOrganism(organismID,fastaFile,dataDir,...
 %   possible to circumvent protein homology search (see fastaFile parameter
 %   for more details)
 %
+%   Input:
 %   organismID          three or four letter abbreviation of the organism
 %                       (as used in KEGG). If not available, use a closely
 %                       related species. This is used for determing the
@@ -103,6 +104,7 @@ function model=getKEGGModelForOrganism(organismID,fastaFile,dataDir,...
 %                       CD-HIT is skipped (opt, default -1, i.e. CD-HIT is
 %                       skipped)
 %
+%   Output:
 %   model               the reconstructed model
 %
 %   PLEASE READ THIS: The input to this function can be confusing, because

--- a/external/kegg/getMetsFromKEGG.m
+++ b/external/kegg/getMetsFromKEGG.m
@@ -2,11 +2,13 @@ function model=getMetsFromKEGG(keggPath)
 % getMetsFromKEGG
 %   Retrieves information on all metabolites stored in KEGG database
 %
+%   Input:
 %   keggPath	if keggMets.mat is not in the RAVEN\external\kegg
 %               directory, this function will attempt to read data from a
 %               local FTP dump of the KEGG database. keggPath is the path
 %               to the root of this database
 %
+%   Output:
 %   model       a model structure generated from the database. The
 %               following fields are filled
 %   	id              'KEGG'
@@ -20,15 +22,15 @@ function model=getMetsFromKEGG(keggPath)
 %   	metFormulas     The chemical composition of the metabolite. This
 %                       will only be loaded if there is no InChI string
 %
-%   If the file keggMets.mat is in the RAVEN\external\kegg directory it
-%   will be loaded instead of parsing of the KEGG files. If it does not
+%   NOTE: If the file keggMets.mat is in the RAVEN\external\kegg directory
+%   it will be loaded instead of parsing of the KEGG files. If it does not
 %   exist it will be saved after parsing of the KEGG files. In general, you
 %   should remove the keggMets.mat file if you want to rebuild the model
 %   structure from a newer version of KEGG.
 %               
 %   Usage: model=getMetsFromKEGG(keggPath)
 %
-%   Simonas Marcisauskas, 2018-07-25
+%   Simonas Marcisauskas, 2019-01-08
 %
 %
 % NOTE: This is how one entry looks in the file

--- a/external/kegg/getModelFromKEGG.m
+++ b/external/kegg/getModelFromKEGG.m
@@ -3,6 +3,7 @@ function [model,KOModel]=getModelFromKEGG(keggPath,keepSpontaneous,...
 % getModelFromKEGG
 %   Retrieves information stored in KEGG database and generates a model
 %
+%   Input:
 %   keggPath            if keggGenes.mat, keggMets.mat, keggPhylDist.mat or
 %                       keggRxns.mat are not in the RAVEN/external/kegg
 %                       directory, this function will attempt to read data
@@ -28,6 +29,7 @@ function [model,KOModel]=getModelFromKEGG(keggPath,keepSpontaneous,...
 %                       script will therefore not be able to remove all
 %                       such reactions (opt, default false)
 %
+%   Output:
 %   model               a model structure generated from the database. All
 %                       reactions and the metabolites used in them will be
 %                       added
@@ -35,15 +37,14 @@ function [model,KOModel]=getModelFromKEGG(keggPath,keepSpontaneous,...
 %                       ids and their associated genes. The KO ids are
 %                       saved as reactions
 %
+%   NOTE: The model output from getModelFromKEGG can be used as template
+%   for fillGaps. In that case, ensure that the genes and rxnGeneMat fields
+%   are removed before parsing: model=rmfield(model,'genes'), etc.
+%
 %   Usage: [model,KOModel]=getModelFromKEGG(keggPath,keepSpontaneous,...
 %    keepUndefinedStoich,keepIncomplete,keepGeneral)
 %
-%   Note:               The model output from getModelFromKEGG can be used
-%                       as template for fillGaps. In that case, ensure that
-%                       the genes and rxnGeneMat fields are removed before
-%                       parsing: model=rmfield(model,'genes'), etc.
-%
-%   Simonas Marcisauskas, 2018-09-06
+%   Simonas Marcisauskas, 2019-01-08
 %
 
 if nargin<1

--- a/external/kegg/getPhylDist.m
+++ b/external/kegg/getPhylDist.m
@@ -2,6 +2,7 @@ function phylDistStruct=getPhylDist(keggPath,onlyInKingdom)
 % getPhylDist
 %   Calculates distance between species in KEGG based on systematic name
 %
+%   Input:
 %   keggPath        if keggPhylDist.mat is not in the RAVEN\external\kegg
 %                   directory, this function will attempt to read data from
 %                   a local FTP dump of the KEGG database. keggPath is the
@@ -10,15 +11,16 @@ function phylDistStruct=getPhylDist(keggPath,onlyInKingdom)
 %                   Inf for organisms from another domains (Prokaryota,
 %                   Eukaryota) (opt, default false)
 %
+%   Output:
 %   phylDistStruct  a structure with a list of organism ids and a matrix
 %                   that specifies their pairwise distances
 %
-%   This simple metric is based on the number of nodes two organisms are
-%   away from each other in KEGG
+%   NOTE: This simple metric is based on the number of nodes two organisms
+%   are away from each other in KEGG
 %
 %   Usage: phylDistStruct=getPhylDist(keggPath,onlyInKingdom)
 %
-%   Simonas Marcisauskas, 2018-07-25
+%   Simonas Marcisauskas, 2019-01-08
 %
 
 if nargin<1

--- a/external/kegg/getRxnsFromKEGG.m
+++ b/external/kegg/getRxnsFromKEGG.m
@@ -3,11 +3,13 @@ function [model,isSpontaneous,isUndefinedStoich,isIncomplete,...
 % getRxnsFromKEGG
 %   Retrieves information on all reactions stored in KEGG database
 %
+%   Input:
 %   keggPath            if keggRxns.mat is not in the RAVEN\external\kegg
 %                       directory, this function will attempt to read data
 %                       from a local FTP dump of the KEGG database.
 %                       keggPath is the path to the root of this database
 %
+%   Output:
 %   model               a model structure generated from the database. The
 %                       following fields are filled
 %       id                  'KEGG'
@@ -37,7 +39,7 @@ function [model,isSpontaneous,isUndefinedStoich,isIncomplete,...
 %   isGeneral           a cell array with the reactions labelled as
 %                       "general reaction"
 %
-%   Reactions on the form A <=> A + B will not be loaded. If the file
+%   NOTE: Reactions on the form A <=> A + B will not be loaded. If the file
 %   keggRxns.mat is in the RAVEN/external/kegg directory it will be loaded
 %   instead of parsing of the KEGG files. If it does not exist it will be
 %   saved after parsing of the KEGG files. In general, you should remove
@@ -47,7 +49,7 @@ function [model,isSpontaneous,isUndefinedStoich,isIncomplete,...
 %   Usage: [model,isSpontaneous,isUndefinedStoich,isIncomplete,...
 %    isGeneral]=getRxnsFromKEGG(keggPath)
 %
-%   Simonas Marcisauskas, 2018-07-25
+%   Simonas Marcisauskas, 2019-01-08
 %
 %
 % NOTE: This is how one entry looks in the file


### PR DESCRIPTION
### Main improvements in this PR:
- During model reconstruction from KEGG, the users may download pre-trained HMMs ZIP file, but sometimes MATLAB may fail to extract it. Upon the fix, such error is now correctly reported to the user. This is done by checking existence for _K00844.hmm_ (hexokinase), which is present in all HMM sets
- Misc formatting fixes

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
