### PR TITLE
Fix/getKeggModelForOrganism

### DIFF
--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -278,7 +278,7 @@ if isempty(outDir)
     outDir=tempdir;
     %Delete all *.out files if any exist
     delete(fullfile(outDir,'*.out'));
-elseif ~isstring(outDir)
+elseif ~isstr(outDir)
     error('outDir should be provided as string');
 end
 if nargin<5
@@ -370,8 +370,8 @@ if ~isempty(dataDir)
             fprintf('Extracting HMMs archive file...\n');
             unzip([dataDir,'.zip']);
         else
-            [~,hmmIndex]=ismember(dataDir,hmmOptions);
-            
+            hmmIndex=regexp(dataDir,hmmOptions);
+            hmmIndex=~cellfun(@isempty,hmmIndex);
             fprintf('Downloading HMMs archive file...\n');
             websave([dataDir,'.zip'],['https://chalmersuniversity.box.com/shared/static/',hmmLinks{hmmIndex},'.zip']);
             fprintf('Extracting HMMs archive file...\n');
@@ -534,7 +534,7 @@ missingFASTA=setdiff(KOModel.rxns,[fastaFiles;alignedFiles;hmmFiles;outFiles]);
 
 if ~isempty(missingFASTA)
     if ~exist(fullfile(dataDir,'keggdb','genes.pep'),'file')
-        EM=fprintf(['The file ''genes.pep'' cannot be located at ' strrep(dataDir,'\','/') '/ and should be downloaded from the KEGG FTP.\n']);
+        EM=['The file ''genes.pep'' cannot be located at ' strrep(dataDir,'\','/') '/ and should be downloaded from the KEGG FTP.\n'];
         dispEM(EM);
     end
     %Only construct models for KOs which don't have files already

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -368,16 +368,18 @@ if ~isempty(dataDir)
     else
         if exist(dataDir,'dir')
             fprintf('Provided dataDir is in correct format for this RAVEN version in order to use pre-trained HMMs...\n')
-        elseif ~exist(dataDir,'dir') && exist([dataDir,'.zip'],'file')
-            fprintf('Extracting HMMs archive file...\n');
-            unzip([dataDir,'.zip']);
         else
-            hmmIndex=regexp(dataDir,hmmOptions);
-            hmmIndex=~cellfun(@isempty,hmmIndex);
-            fprintf('Downloading HMMs archive file...\n');
-            websave([dataDir,'.zip'],['https://chalmersuniversity.box.com/shared/static/',hmmLinks{hmmIndex},'.zip']);
+            if ~exist(dataDir,'dir') && ~exist([dataDir,'.zip'],'file')
+                hmmIndex=regexp(dataDir,hmmOptions);
+                hmmIndex=~cellfun(@isempty,hmmIndex);
+                fprintf('Downloading HMMs archive file...\n');
+                websave([dataDir,'.zip'],['https://chalmersuniversity.box.com/shared/static/',hmmLinks{hmmIndex},'.zip']);
+            end
             fprintf('Extracting HMMs archive file...\n');
             unzip([dataDir,'.zip']);
+            if ~exist(fullfile(dataDir,'hmms','K00001.hmm'),'file')
+                error('Extracting HMMs archive file failed. Unzip the file manually in the dedicated folder and then rerun this function.');
+            end           
         end
     end
 end

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -299,10 +299,10 @@ if nargin<9
     cutOff=10^-50;
 end
 if nargin<10
-    minScoreRatioG=0.8;
+    minScoreRatioKO=0.3;
 end
 if nargin<11
-    minScoreRatioKO=0.3;
+    minScoreRatioG=0.8;
 end
 if nargin<12
     maxPhylDist=inf;

--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -9,6 +9,7 @@ function model=getKEGGModelForOrganism(organismID,fastaFile,dataDir,...
 %   possible to circumvent protein homology search (see fastaFile parameter
 %   for more details)
 %
+%   Input:
 %   organismID          three or four letter abbreviation of the organism
 %                       (as used in KEGG). If not available, use a closely
 %                       related species. This is used for determing the
@@ -103,6 +104,7 @@ function model=getKEGGModelForOrganism(organismID,fastaFile,dataDir,...
 %                       CD-HIT is skipped (opt, default -1, i.e. CD-HIT is
 %                       skipped)
 %
+%   Output:
 %   model               the reconstructed model
 %
 %   PLEASE READ THIS: The input to this function can be confusing, because
@@ -156,7 +158,7 @@ function model=getKEGGModelForOrganism(organismID,fastaFile,dataDir,...
 %       | Sequence identity (-c)    | 1.0    | 0.9    | 0.5    | x       |
 %       | word_length (-n)          | 5      | 5      | 4      | 2-5*    |
 %       | Max available memory (-M) |               2000                 |
-%       ------------------------------------------------------------------        
+%       ------------------------------------------------------------------
 %       * - word length depends from sequence identity value (see CD-HIT
 %       manual for more details)
 %
@@ -701,7 +703,7 @@ if ~isempty(missingAligned)
                         else
                             EM='The provided seqIdentity must be between 0 and 1\n';
                             dispEM(EM);
-                        end 
+                        end
                         if status~=0
                             EM=['Error when performing clustering of ' missingAligned{i} ':\n' output];
                             dispEM(EM);


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  -  order of arguments getKEGGModelForOrganism: `minScoreRatioKO` is defined before `minScoreRatioG`
- feat:
  - getKEGGModelForOrganism warning if unzipping fails

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR