### PR TITLE
fix: tutorial KEGG

### DIFF
--- a/external/kegg/getKEGGModelForOrganism.m
+++ b/external/kegg/getKEGGModelForOrganism.m
@@ -389,10 +389,10 @@ if ~isempty(dataDir)
 end
 
 %Check if the fasta-file contains '/' or'\'. If not then it's probably just
-%a file name. It is then merged with the current folder
+%a file name. Expand to full path.
 if any(fastaFile)
     if ~any(strfind(fastaFile,'\')) && ~any(strfind(fastaFile,'/'))
-        fastaFile=fullfile(pwd,fastaFile);
+        fastaFile=which(fastaFile);
     end
     %Create the required sub-folders in dataDir if they dont exist
     if ~exist(fullfile(dataDir,'keggdb'),'dir')

--- a/tutorial/tutorial4.m
+++ b/tutorial/tutorial4.m
@@ -5,7 +5,7 @@
 %is to serve as a scaffold if you would like to reconstruct a GEM for your
 %own organism.
 %
-% Rasmus Agren, 2013-08-06 Simonas Marcisauskas, 2017-06-06 - revision
+%Eduard Kerkhoven, 2019-02-01
 %
 
 %Start by downloading trained Hidden Markov Models for eukaryotes. This can
@@ -19,10 +19,10 @@
 %Type "help getKEGGModelForOrganism" to see what the different parameters
 %are for. This process takes up to 10-15 minutes, depending on your
 %hardware and the size of target organism proteome;
-model=getKEGGModelForOrganism('sce','sce.fa','euk100_kegg87','output',false,false,false,10^-30,0.8,0.3,-1);
+model=getKEGGModelForOrganism('sce','sce.fa','euk100_kegg87','output',false,false,false,false,10^-30,0.8,0.3,-1);
 
-%As you can see the resulting model contains (around) 2606 reactions, 2535
-%metabolites and 1276 genes. Small variations are possible since it is an
+%As you can see the resulting model contains (around) 1501 reactions, 1513
+%metabolites and 813 genes. Small variations are possible since it is an
 %heuristic algorithm.
 model
 
@@ -41,17 +41,15 @@ model
 %analysis we can ignore protons and try to fix it later.
 [newModel, removedRxns]=removeBadRxns(model,1,{'H+'},true);
 
-%Only a few reactions were removed because they enabled the model to
-%produce something from nothing. Since there were so few, it might be
-%worthwhile to look into this in more
-%detail.
+%Only one reaction was removed because it enabled the model to produce
+%something from nothing. Since its only one reaction, it might be
+%worthwhile to look into this in more detail.
 removedRxns
 
-%If you look it up in KEGG you will find that the reactions involve general
-%instead of specific metabolites or are general polymer reactions. You
-%might want to look at the flux distributions more in detail to try to find
-%out if there is any better alternative to delete. Use makeSomething to do
-%this
+%If you look up this reaction it up in KEGG you will find that  it is a
+%general polymer reaction. You might want to look at the flux distributions
+%in more detail to try to find out if there is any better alternative to
+%delete. Use makeSomething to do this
 [fluxes, metabolite]=makeSomething(model,{'H+'},true);
 model.metNames(metabolite)
 
@@ -81,11 +79,6 @@ printFluxes(model, fluxes, false, [], [],'%rxnID (%rxnName):\n\t%eqn: %flux\n',{
 %manually. We therefore choose to trust removeBadRxns and delete R02110.
 model=removeReactions(model,'R02110');
 
-%In a similar way you can curate the other problematic reactions that we
-%identified earlier. For simplicity we will also trust removeBadRxns for
-%the other reactions and remove these from our model.
-model=removeReactions(model,removedRxns(2:end));
-
 %The model can no longer make something from nothing. Can it consume
 %something without any output?
 [solution, metabolite]=consumeSomething(model,{'H+'},true);
@@ -104,13 +97,13 @@ model.metNames(metabolite)
 I=canProduce(model);
 
 sum(I)/numel(model.mets)
-%You can see that 28% of the metabolites could be synthesized. It is not
+%You can see that 27% of the metabolites could be synthesized. It is not
 %directly clear whether this is a high or low number, many metabolites
 %should not be possible to synthesize from those simple precursors.
 
 %We can try to fill gaps using the full KEGG model to see if that gives a
 %significantly higher number
-keggModel=getModelFromKEGG([],false,false,false);
+keggModel=getModelFromKEGG([],false,false,false,false);
 
 %The KEGG model is associated to more than 3,000,000 genes. They won't be
 %used for the gapfilling, so we remove them to make this a little faster
@@ -130,7 +123,7 @@ params.relGap=0.6; %Lower number for a more exhaustive search
 params.printReport=true;
 [newConnected, cannotConnect, addedRxns, newModel, exitFlag]=fillGaps(model,keggModel,true,false,false,[],params);
 
-%We see that we could connect 161 reactions (newConnected) by including 91
+%We see that we could connect 80 reactions (newConnected) by including 69
 %reactions from the KEGG model (addedRxns). Those should of course be
 %checked manually to see that they exist in yeast, but let's say that we
 %have done so now.
@@ -143,44 +136,40 @@ params.printReport=true;
 [noFluxRxns, noFluxRxnsRelaxed, subGraphs, notProducedMets, minToConnect,...
     neededForProductionMat]=gapReport(newModel);
 
-%You will see that 799/2697 reactions cannot carry flux. Remember that we
-%allow for output of all metabolites, that's why it calculates 799 in both
-%cases. 1114/2548 metabolites cannot be synthesized from the precursors we
-%have supplied. There are 7 subnetworks in the model, of which 2524/2548
+%You will see that 486/1574 reactions cannot carry flux. Remember that we
+%allow for output of all metabolites, that's why it calculates 486 in both
+%cases. 687/1527 metabolites cannot be synthesized from the precursors we
+%have supplied. There are 8 subnetworks in the model, of which 1511/1527
 %metabolites belong to the first one.
 %
 %It will also print something similar to:
 %
-%To enable net production of all metabolites, a total of 266 metabolites
-%must be connected Top 10 metabolites to connect:
-% 	1. Acyl-[acyl-carrier protein][s] (connects 65 metabolites)
-%   2. 1-Radyl-2-acyl-sn-glycero-3-phosphocholine[s] (connects 16 metabolites)
-% 	3. G00146[s] (connects 13 metabolites)
-%   4. NAD+[s] (connects 12	metabolites)
-%   5. Tetrahydrofolate[s] (connects 11 metabolites)
-%   6. Methylselenic acid[s] (connects 10 metabolites)
-%   7. G00003[s] (connects 10 metabolites)
-%   8. G00009[s] (connects 8 metabolites)
-%   9. FAD[s] (connects 6 metabolites)
-%   10. Thiamin monophosphate[s] (connects 6 metabolites)
+%To enable net production of all metabolites, a total of 304 metabolites
+%must be connected
+%Top 10 metabolites to connect:
+% 	1. 2,3-Dehydroacyl-CoA[s] (connects 144 metabolites)
+% 	2. 7,8-Dihydroneopterin[s] (connects 15 metabolites)
+% 	3. Thiamin diphosphate[s] (connects 13 metabolites)
+% 	4. Ergosterol[s] (connects 13 metabolites)
+% 	5. Methylselenic acid[s] (connects 12 metabolites)
+% 	6. G00003[s] (connects 12 metabolites)
+% 	7. Androstenediol[s] (connects 11 metabolites)
+% 	8. G00146[s] (connects 11 metabolites)
+% 	9. 1-Alkyl-2-acylglycerol[s] (connects 10 metabolites)
+% 	10. Progesterone[s] (connects 9 metabolites)
 
 %This is a very useful way of directing the gap-filling tasks to where they
 %are of the greatest use. In this case it says that in order to have net
 %production of all metabolites in the model from the simple inputs that we
-%have defined (1114 metabolites can currently not have net production) we
-%need to connect xxx unconnected metabolites in. However, by connecting
-%only the top 10 in the list xxx/1114 (xx%) of them will now be connected.
+%have defined (687 metabolites can currently not have net production) we
+%need to connect 304 unconnected metabolites in. However, by connecting
+%only the top 10 in the list 209/687 (30%) of them will now be connected.
 %If we look at the list we see that the top ranking one is
-%Acyl-[acyl-carrier protein]. This is because acyl-carrier protein acts as
-%a carrier for many fatty acids, but it is not synthesized in the model
-%from its amino acid constituents. Therefore there cannot be net production
-%of any of the metabolites involving it. One solution would be to add a
-%reaction representing the synthesis of it (based on its amino acid
-%composition). Another solution would be to add an uptake reaction for it.
-%Metabolites 4,5,8, and 9 are all co-factors or involved in co-factor
-%metabolism. It turns out that yeast cannot grow on only the substrates we
-%have defined, but that it requires some other precursors for co-factor
-%synthesis as well.
+%2,3-Dehydroacyl-CoA, which is involved in the elongation of many different
+%fatty acid chains. Metabolites 2 and 3 are co-factors or involved in co-
+%factor metabolism. It turns out that yeast cannot grow on only the
+%substrates we have defined, but that it requires some other precursors for
+%co-factor synthesis as well.
 
 %Add uptake reactions for the minimal media constituents needed for yeast
 %to grow.

--- a/tutorial/tutorial4.m
+++ b/tutorial/tutorial4.m
@@ -19,7 +19,7 @@
 %Type "help getKEGGModelForOrganism" to see what the different parameters
 %are for. This process takes up to 10-15 minutes, depending on your
 %hardware and the size of target organism proteome;
-model=getKEGGModelForOrganism('sce','sce.fa','euk100_kegg82','output',false,false,false,10^-30,0.8,0.3,-1);
+model=getKEGGModelForOrganism('sce','sce.fa','euk100_kegg87','output',false,false,false,10^-30,0.8,0.3,-1);
 
 %As you can see the resulting model contains (around) 1219 reactions, 1267
 %metabolites and 906 genes. Small variations are possible since it is an


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - update KEGG reference in tutorial4
  - `getKEGGModelForOrganism` correct path to fastaFile
  - `getKEGGModelForOrganism` was called in tutorial with incorrect input after fairly recent updates of the function (set the `keepGeneral` parameter)

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
