### PR TITLE
fix: removeGenes / feat: addTransport and changeGrRules

### DIFF
--- a/core/addTransport.m
+++ b/core/addTransport.m
@@ -1,4 +1,4 @@
-function [model, addedRxns]=addTransport(model,fromComp,toComps,metNames,isRev,onlyToExisting)
+function [model, addedRxns]=addTransport(model,fromComp,toComps,metNames,isRev,onlyToExisting,prefix)
 % addTransport
 %   Adds transport reactions between compartments
 %
@@ -14,6 +14,8 @@ function [model, addedRxns]=addTransport(model,fromComp,toComps,metNames,isRev,o
 %   onlyToExisting  true if transport of a metabolite should only be added
 %                   if it already exists in toComp. If false, then new metabolites
 %                   are added with addMets first (opt, default true)
+%   prefix          string specifying prefix to reaction IDs (opt, default
+%                   'tr_')
 %
 %   This is a faster version than addRxns when adding transport reactions.
 %   New reaction names are formatted as "metaboliteName, fromComp-toComp", 
@@ -21,9 +23,9 @@ function [model, addedRxns]=addTransport(model,fromComp,toComps,metNames,isRev,o
 %   e.g. tr_0001, tr_0002, etc.
 %
 %   Usage: [model, addedRxns]=addTransport(model,fromComp,toComps,metNames,...
-%           isRev,onlyToExisting)
+%           isRev,onlyToExisting,prefix)
 %
-%   Simonas Marcisauskas, 2018-03-17
+%   Eduard Kerkhoven, 2019-03-19
 %
 
 if iscell(fromComp)
@@ -59,6 +61,9 @@ if nargin<5
 end
 if nargin<6
     onlyToExisting=true;
+end
+if nargin<7
+    prefix='tr_';
 end
 
 %Check that the names are unique
@@ -109,21 +114,28 @@ for i=1:numel(toComps)
     
     %Add the reactions
     model.S=[model.S sparse(newS)];
+    if isfield(model.annotation,'defaultLB')
+        lb = model.annotation.defaultLB;
+        ub = model.annotation.defaultUB;
+    else
+        lb = -inf;
+        ub = inf;
+    end
     if isRev==true
-        model.lb=[model.lb;ones(nRxns,1)*-inf];
+        model.lb=[model.lb;ones(nRxns,1)*lb];
         model.rev=[model.rev;ones(nRxns,1)];
     else
         model.lb=[model.lb;zeros(nRxns,1)];
         model.rev=[model.rev;zeros(nRxns,1)];
     end
-    model.ub=[model.ub;ones(nRxns,1)*inf];
+    model.ub=[model.ub;ones(nRxns,1)*ub];
     model.c=[model.c;zeros(nRxns,1)];
     
     %Add annotation
     filler=cell(nRxns,1);
     filler(:)={''};
-    addedRxnsID=generateNewIds(model,'rxns','tr_',length(nRxns));
-    addedRxnsName=strcat(metNames, ' transport, ', model.compNames(fromID), '-', model.compNames(toIDs(i)));
+    addedRxnsID=generateNewIds(model,'rxns',prefix,length(nRxns));
+    addedRxnsName=strcat(metNames, {' transport, '}, model.compNames(fromID), '-', model.compNames(toIDs(i)));
     model.rxns=[model.rxns;addedRxnsID];
     model.rxnNames=[model.rxnNames;addedRxnsName];
     
@@ -162,8 +174,7 @@ for i=1:numel(toComps)
         model.rxnReferences=[model.rxnReferences;filler];
     end
     if isfield(model,'rxnConfidenceScores')
-        model.rxnConfidenceScores=[model.rxnConfidenceScores;NaN(nRxns,1)];
-        fprintf('NOTE: The added transport reactions will have confidence scores as NaNs\n');
+        model.rxnConfidenceScores=[model.rxnConfidenceScores;ones(nRxns,1)];
     end
 end
 end

--- a/core/changeGeneAssoc.m
+++ b/core/changeGeneAssoc.m
@@ -32,9 +32,11 @@ if ~isstr(geneAssoc)
     error(sprintf(EM))
 end
 
+
 % Add genes to model
 geneList=transpose(cell(unique(regexp(geneAssoc,'[)(]*|( and )*|( or )*','split')))); % Extract individual, unique genes from the geneAssoc provided
-genesToAdd.genes=setdiff(geneList(2:length(geneList)),model.genes); % Only keep the genes that are not yet part of the model.genes.
+geneList=geneList(~cellfun(@isempty, geneList));
+genesToAdd.genes=setdiff(geneList,model.genes); % Only keep the genes that are not yet part of the model.genes.
 model=addGenesRaven(model,genesToAdd); % Add genes
 
 % Find reaction and gene indices

--- a/core/changeGrRules.m
+++ b/core/changeGrRules.m
@@ -1,0 +1,60 @@
+function model = changeGrRules(model,rxns,grRules,replace)
+% changeGrRules
+%   Changes multiple grRules at the same time.
+%
+%   model       a model structure to change the gene association
+%   rxns        string or cell array of reaction IDs
+%   grRules     string of additional or replacement gene association.
+%               Should be written with ' and ' to indicate subunits, ' or '
+%               to indicate isoenzymes, and brackets '()' to separate
+%               different instances
+%   replace     true if old gene association should be replaced with new
+%               association. False if new gene association should be
+%               concatenated to the old association (opt, default true)
+%
+%   model       an updated model structure
+%
+%   Usage: changeGrRules(model,rxns,grRules,replace)
+%
+%   Eduard Kerkhoven, 2019-03-26
+%
+
+if nargin==3
+    replace=true;
+end
+
+if isstr(rxns)
+    rxns={rxns};
+end
+
+if isstr(grRules)
+    grRules={grRules};
+end
+
+if ~(numel(grRules)==numel(rxns))
+    error('Number of rxns and grRules should be identical')
+end
+
+for i=1:length(rxns)
+    % Add genes to model
+    geneList=transpose(cell(unique(regexp(grRules{i},'[)(]*|( and )*|( or )*','split')))); % Extract individual, unique genes from the geneAssoc provided
+    geneList=geneList(~cellfun(@isempty, geneList));
+    genesToAdd.genes=setdiff(geneList,model.genes); % Only keep the genes that are not yet part of the model.genes.
+    model=addGenesRaven(model,genesToAdd); % Add genes
+    
+    % Find reaction and gene indices
+    idx=getIndexes(model,rxns,'rxns');
+end
+
+% Change gene associations
+if replace==true % Replace old gene associations
+    model.grRules(idx)=grRules;
+else % Add gene associations, add new gene rules after 'OR'.
+    model.grRules(idx)=strcat('(',model.grRules(idx),') or (',grRules,')');
+end
+
+%Fix grRules and reconstruct rxnGeneMat
+[grRules,rxnGeneMat] = standardizeGrRules(model,true);
+model.grRules = grRules;
+model.rxnGeneMat = rxnGeneMat;
+end

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -390,15 +390,12 @@ if ~isempty(preferredOrder) && numel(models)>1
         
         %Remove all the genes that were already found and add the other
         %ones to allUsedGenes
-        [models{useOrderIndexes(i)}, notDeleted]=removeGenes(models{useOrderIndexes(i)},allGenes{i+1}(genesToDelete),true,false,false);
+        models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},allGenes{i+1}(genesToDelete),true,false,false);
         allUsedGenes(usedGenes)=true;
         
-        %Remove the deleted genes from finalMappings and allGenes. Don't
-        %remove the genes in notDeleted, they are part of complexes with
-        %some non-mapped genes
-        deletedIndexes=~ismember(allGenes{i+1}(genesToDelete),notDeleted);
-        finalMappings{i}(:,genesToDelete(deletedIndexes))=[];
-        allGenes{i+1}(genesToDelete(deletedIndexes))=[];
+        %Remove the deleted genes from finalMappings and allGenes.
+        finalMappings{i}(:,genesToDelete)=[];
+        allGenes{i+1}(genesToDelete)=[];
     end
 end
 

--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -41,6 +41,12 @@ end
 
 reducedModel = model;
 
+%Only remove genes that are actually in the model
+try
+    ischar(genesToRemove{1});
+    genesToRemove=genesToRemove(ismember(genesToRemove,model.genes));
+end
+
 if ~isempty(genesToRemove)
     indexesToRemove = getIndexes(model,genesToRemove,'genes');
     if ~isempty(indexesToRemove)


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `removeGenes` doesn't throw an error if gene is not in model
  - `getModelFromHomology` works with newer `removeGenes` functionality 
- feat:
  - `addTransport` have reaction ID prefix as parameter
  - new `changeGrRules` function: in contrast to `changeGeneAssoc`, `changeGrRules` can modify multiple different grRules at the same time. Each function is useful in specific circumstances.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
