### PR TITLE
fix: exportToTabDelimited bug for subSystems

### DIFF
--- a/io/exportToTabDelimited.m
+++ b/io/exportToTabDelimited.m
@@ -16,7 +16,7 @@ function exportToTabDelimited(model,path)
 %
 %   Usage: exportToTabDelimited(model,path)
 %
-%   Simonas Marcisauskas, 2018-03-18
+%   Cheewin Kittikunapong, 2019-04-02
 
 if nargin<2
     path='./';
@@ -99,9 +99,11 @@ for i=1:numel(model.rxns)
     end
     
     if isfield(model,'subSystems')
-        fprintf(rxnFile,[strjoin(model.subSystems{i,1},';') '\t']);
-    else
-        fprintf(rxnFile,'\t');
+        if ~isempty(model.subSystems{i})
+            fprintf(rxnFile,[strjoin(model.subSystems{i,1},';') '\t']);
+        else
+            fprintf(rxnFile,'\t');
+        end
     end
     
     %Print replacement IDs


### PR DESCRIPTION
Fixed bug in `exportToTabDelimited` that would cause error if not all reactions have subsystem information

### Main improvements in this PR:
- fixed minor bug where `exportToTabDelimited` would encounter an error if parsing a model structure with field subSystem containing empty character arrays (e.g. no subSystem assigned/known)
- first encountered when attempting to produce .xlsx file for model via `exportToExcelFormat`.
- updated all documentation

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR