### PR TITLE
feat: setParam variability bounds

### DIFF
--- a/core/setParam.m
+++ b/core/setParam.m
@@ -1,4 +1,4 @@
-function model=setParam(model, paramType, rxnList, params)
+function model=setParam(model, paramType, rxnList, params, var)
 % setParam
 %   Sets parameters for reactions
 %
@@ -10,18 +10,21 @@ function model=setParam(model, paramType, rxnList, params)
 %                       constraint)
 %               'obj'   Objective coefficient
 %               'rev'   Reversibility
+%               'var'   Variance around measured bound
 %   rxnList     a cell array of reaction IDs or a vector with their
 %               corresponding indexes
 %   params      a vector of the corresponding values
+%   var         percentage of variance around measured value, if 'var' is
+%               set as paramType
 %
 %   model       an updated model structure
 %
 %   Usage: model=setParam(model, paramType, rxnList, params)
 %
-%   Rasmus Agren, 2014-09-01
+%   Eduard Kerkhoven, 2019-05-03
 %
 
-if ~isempty(setdiff(paramType,{'lb';'ub';'eq';'obj';'rev'}))
+if ~isempty(setdiff(paramType,{'lb';'ub';'eq';'obj';'rev';'var'}))
     EM=['Incorrect parameter type: "' paramType '"'];
     dispEM(EM);
 end
@@ -79,6 +82,17 @@ if ~isempty(indexes)
     if strcmpi(paramType,'rev')
         %Non-zero values are interpreted as reversible
         model.rev(indexes)=params~=0;
+    end
+    if strcmpi(paramType,'var')
+        for i=1:numel(params)
+            if params(i) < 0
+                model.lb(indexes(i)) = params(i) * (1+var/200);
+                model.ub(indexes(i)) = params(i) * (1-var/200);
+            else
+                model.lb(indexes(i)) = params(i) * (1-var/200);
+                model.ub(indexes(i)) = params(i) * (1+var/200);
+            end
+        end
     end
 end
 end

--- a/core/setParam.m
+++ b/core/setParam.m
@@ -3,7 +3,7 @@ function model=setParam(model, paramType, rxnList, params, var)
 %   Sets parameters for reactions
 %
 %   model       a model structure
-%   paramType	the type of parameter to set:
+%   paramType   the type of parameter to set:
 %               'lb'    Lower bound
 %               'ub'    Upper bound
 %               'eq'    Both upper and lower bound (equality
@@ -15,7 +15,9 @@ function model=setParam(model, paramType, rxnList, params, var)
 %               corresponding indexes
 %   params      a vector of the corresponding values
 %   var         percentage of variance around measured value, if 'var' is
-%               set as paramType
+%               set as paramType. Defining 'var' as 5 results in lb and ub
+%               at 97.5% and 102.5% of the provide params value (if params
+%               value is negative, then lb and ub are 102.5% and 97.5%).
 %
 %   model       an updated model structure
 %


### PR DESCRIPTION
### Main improvements in this PR:
- feat:
  - 'setParam' can set upper and lower bounds with a defined variability: setting this to `5` results in the lower bound being set at 97.5% of the provided value, and the upper bound at 102.5%. This is inverted for negative bounds.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
