### PR TITLE
fix: misc gap-filling, addTransport, exportModel, getModelFromHomology bugs

### DIFF
--- a/core/addMets.m
+++ b/core/addMets.m
@@ -144,7 +144,7 @@ if numel(compMap)~=nMets
     EM='metsToAdd.compartments must have the same number of elements as metsToAdd.mets';
     dispEM(EM);
 else
-    newModel.metComps=[newModel.metComps;compMap];
+    newModel.metComps=[newModel.metComps;compMap(:)];
 end
 
 if isfield(metsToAdd,'b')

--- a/core/addRxnsGenesMets.m
+++ b/core/addRxnsGenesMets.m
@@ -65,7 +65,7 @@ end
 [notNewRxn,oldRxn]=ismember(rxns,model.rxns);
 rxns=rxns(~notNewRxn);
 if isempty(rxns)
-    error('All reactions are already in the model.\n');
+    error('All reactions are already in the model.');
 elseif ~isempty(notNewRxn)
     fprintf('The following reactions were already present in the model and will not be added:\n')
     fprintf([strjoin(model.rxns(oldRxn(find(oldRxn))),'\n') '\n'])

--- a/core/addTransport.m
+++ b/core/addTransport.m
@@ -134,7 +134,7 @@ for i=1:numel(toComps)
     %Add annotation
     filler=cell(nRxns,1);
     filler(:)={''};
-    addedRxnsID=generateNewIds(model,'rxns',prefix,length(nRxns));
+    addedRxnsID=generateNewIds(model,'rxns',prefix,nRxns);
     addedRxnsName=strcat(metNames, {' transport, '}, model.compNames(fromID), '-', model.compNames(toIDs(i)));
     model.rxns=[model.rxns;addedRxnsID];
     model.rxnNames=[model.rxnNames;addedRxnsName];

--- a/core/addTransport.m
+++ b/core/addTransport.m
@@ -135,7 +135,7 @@ for i=1:numel(toComps)
     filler=cell(nRxns,1);
     filler(:)={''};
     addedRxnsID=generateNewIds(model,'rxns',prefix,nRxns);
-    addedRxnsName=strcat(metNames, {' transport, '}, model.compNames(fromID), '-', model.compNames(toIDs(i)));
+    addedRxnsName=transpose(strcat(metNames, {' transport, '}, model.compNames(fromID), '-', model.compNames(toIDs(i))));
     model.rxns=[model.rxns;addedRxnsID];
     model.rxnNames=[model.rxnNames;addedRxnsName];
     

--- a/core/addTransport.m
+++ b/core/addTransport.m
@@ -82,7 +82,7 @@ if ~all(J)
     dispEM(EM);
 end
 fromMets=I(K); %These are the ids of the metabolites to transport. The order corresponds to metNames
-
+addedRxns={};
 %Loop through and add for each compartment in toComps
 for i=1:numel(toComps)
     fromMetsInComp=fromMets; %If onlyToExisting==true then not all mets are transported to each compartment
@@ -176,5 +176,6 @@ for i=1:numel(toComps)
     if isfield(model,'rxnConfidenceScores')
         model.rxnConfidenceScores=[model.rxnConfidenceScores;ones(nRxns,1)];
     end
+    addedRxns = [addedRxns; addedRxnsID];
 end
 end

--- a/core/fillGaps.m
+++ b/core/fillGaps.m
@@ -220,7 +220,7 @@ templateRxns=find(~strcmp(allModels.rxnFrom,model.id));
 %Remove everything except for the added ones
 I=true(numel(allModels.rxns),1);
 I(templateRxns(J))=false;
-addedModel=removeReactions(allModels,I,true);
+addedModel=removeReactions(allModels,I,true,true,true);
 
 newModel=mergeModels({model;addedModel},true);
 addedRxns=setdiff(newModel.rxns,model.rxns);

--- a/core/getMinNrFluxes.m
+++ b/core/getMinNrFluxes.m
@@ -124,7 +124,7 @@ prob.ints.sub=numel(irrevModel.rxns)+1:numel(irrevModel.rxns)+numel(indexes);
 %Use the output from the linear solution as starting point. Only the values
 %for the integer variables will be used, but all are supplied.
 prob.sol.int.xx=zeros(numel(prob.c),1);
-prob.sol.int.xx(prob.ints.sub(sol.x(indexes)>10^-9))=1;
+prob.sol.int.xx(prob.ints.sub(sol.x(indexes)>10^-12))=1;
 
 % Optimize the problem
 res = optimizeProb(prob,params);
@@ -151,5 +151,5 @@ if numel(irrevModel.rxns)>numel(model.rxns)
     x(model.rev~=0)=x(model.rev~=0)-xx(numel(model.rxns)+1:end);
 end
 
-I=ismember(toMinimize,strrep(irrevModel.rxns(indexes(I>10^-9)),'_REV',''));
+I=ismember(toMinimize,strrep(irrevModel.rxns(indexes(I>10^-12)),'_REV',''));
 end

--- a/core/getMinNrFluxes.m
+++ b/core/getMinNrFluxes.m
@@ -124,7 +124,7 @@ prob.ints.sub=numel(irrevModel.rxns)+1:numel(irrevModel.rxns)+numel(indexes);
 %Use the output from the linear solution as starting point. Only the values
 %for the integer variables will be used, but all are supplied.
 prob.sol.int.xx=zeros(numel(prob.c),1);
-prob.sol.int.xx(prob.ints.sub(sol.x(indexes)>10^-7))=1;
+prob.sol.int.xx(prob.ints.sub(sol.x(indexes)>10^-9))=1;
 
 % Optimize the problem
 res = optimizeProb(prob,params);
@@ -151,5 +151,5 @@ if numel(irrevModel.rxns)>numel(model.rxns)
     x(model.rev~=0)=x(model.rev~=0)-xx(numel(model.rxns)+1:end);
 end
 
-I=ismember(toMinimize,strrep(irrevModel.rxns(indexes(I>10^-7)),'_REV',''));
+I=ismember(toMinimize,strrep(irrevModel.rxns(indexes(I>10^-9)),'_REV',''));
 end

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -390,7 +390,7 @@ if ~isempty(preferredOrder) && numel(models)>1
         
         %Remove all the genes that were already found and add the other
         %ones to allUsedGenes
-        models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},allGenes{i+1}(genesToDelete),true,false,false);
+        models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},allGenes{i+1}(genesToDelete),true,true,false);
         allUsedGenes(usedGenes)=true;
         
         %Remove the deleted genes from finalMappings and allGenes.

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -456,7 +456,7 @@ for i=1:numel(models)
                     repString=[repString ') or (' fullGeneList{b(l)}];
                 end
                 %Use regexprep instead of strrep to prevent partial matches
-                models{useOrderIndexes(i)}.grRules{j}=regexprep(models{useOrderIndexes(i)}.grRules{j},[geneName{1} '($|\s|\))'],[repString '$1']);
+                models{useOrderIndexes(i)}.grRules{j}=regexprep(models{useOrderIndexes(i)}.grRules{j},['(^|\s|\()' geneName{1} '($|\s|\))'],['$1' repString '$2']);
             else
                 %Then search in the non-replaceable genes. There could only
                 %be one match here

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -455,7 +455,8 @@ for i=1:numel(models)
                 for l=2:numel(b)
                     repString=[repString ') or (' fullGeneList{b(l)}];
                 end
-                models{useOrderIndexes(i)}.grRules{j}=strrep(models{useOrderIndexes(i)}.grRules{j},geneName{1},repString);
+                %Use regexprep instead of strrep to prevent partial matches
+                models{useOrderIndexes(i)}.grRules{j}=regexprep(models{useOrderIndexes(i)}.grRules{j},[geneName{1} '($|\s)'],[repString '$1']);
             else
                 %Then search in the non-replaceable genes. There could only
                 %be one match here

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -456,7 +456,7 @@ for i=1:numel(models)
                     repString=[repString ') or (' fullGeneList{b(l)}];
                 end
                 %Use regexprep instead of strrep to prevent partial matches
-                models{useOrderIndexes(i)}.grRules{j}=regexprep(models{useOrderIndexes(i)}.grRules{j},[geneName{1} '($|\s)'],[repString '$1']);
+                models{useOrderIndexes(i)}.grRules{j}=regexprep(models{useOrderIndexes(i)}.grRules{j},[geneName{1} '($|\s|\))'],[repString '$1']);
             else
                 %Then search in the non-replaceable genes. There could only
                 %be one match here

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -113,10 +113,13 @@ model.rxns=regexprep(model.rxns,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 model.mets=regexprep(model.mets,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 model.comps=regexprep(model.comps,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 if isfield(model,'genes')
-    model.genes=regexprep(model.genes,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
-end
-if isfield(model,'grRules')
-    model.grRules=regexprep(model.grRules,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
+    problemGenes=find(~cellfun('isempty',regexp(model.genes,'([^0-9_a-zA-Z])')));
+    originalGenes=model.genes(problemGenes);
+    replacedGenes=regexprep(model.genes(problemGenes),'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
+    model.genes(problemGenes)=replacedGenes;
+    for i=1:numel(problemGenes)
+        model.grRules=strrep(model.grRules,originalGenes{i},replacedGenes{i});
+    end
 end
 
 %Generate an empty SBML structure

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -115,6 +115,9 @@ model.comps=regexprep(model.comps,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 if isfield(model,'genes')
     model.genes=regexprep(model.genes,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
 end
+if isfield(model,'grRules')
+    model.grRules=regexprep(model.grRules,'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
+end
 
 %Generate an empty SBML structure
 modelSBML=getSBMLStructure(sbmlLevel,sbmlVersion,sbmlPackages,sbmlPackageVersions);

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -118,7 +118,7 @@ if isfield(model,'genes')
     replacedGenes=regexprep(model.genes(problemGenes),'([^0-9_a-zA-Z])','__${num2str($1+0)}__');
     model.genes(problemGenes)=replacedGenes;
     for i=1:numel(problemGenes)
-        model.grRules=strrep(model.grRules,originalGenes{i},replacedGenes{i});
+        model.grRules = regexprep(model.grRules, ['(^|\s|\()' originalGenes{i} '($|\s|\))'], ['$1' replacedGenes{i} '$2']);
     end
 end
 

--- a/solver/getMILPParams.m
+++ b/solver/getMILPParams.m
@@ -23,16 +23,16 @@ if nargin<1
 end
 
 mosekParams=params;
-mosekParams.MSK_DPAR_MIO_TOL_ABS_RELAX_INT=10^-9;
+mosekParams.MSK_DPAR_MIO_TOL_ABS_RELAX_INT=10^-12;
 mosekParams.MSK_DPAR_MIO_TOL_REL_GAP=0.05;
 
 %NOTE: These options were removed or renamed in Mosek 8. Should be
 %investigated. mosekParams.MSK_DPAR_MIO_TOL_REL_RELAX_INT=10^-9;
 %mosekParams.MSK_DPAR_MIO_TOL_X=10^-9;
-mosekParams.MSK_DPAR_MIO_TOL_FEAS=10^-9;
-mosekParams.MSK_DPAR_BASIS_TOL_S=10^-9;
-mosekParams.MSK_DPAR_BASIS_TOL_X=10^-9;
-mosekParams.MSK_DPAR_PRESOLVE_TOL_ABS_LINDEP=10^-9;
+mosekParams.MSK_DPAR_MIO_TOL_FEAS=10^-12;
+mosekParams.MSK_DPAR_BASIS_TOL_S=10^-12;
+mosekParams.MSK_DPAR_BASIS_TOL_X=10^-12;
+mosekParams.MSK_DPAR_PRESOLVE_TOL_ABS_LINDEP=10^-12;
 
 %Get the mosek version. This is a bit problematic since the Mosek function
 %for getting the version came in version 7.

--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -25,7 +25,7 @@ if(isfield(prob,'ints')), disp('MILP detected.'); milp=true; end
 
 solver=getpref('RAVEN','solver');
 if strcmp(solver,'gurobi')
-    gparams=struct('Presolve',2,'TimeLimit',1000,'OutputFlag',1,'MIPGap',1e-9,'Seed',0,'FeasibilityTol',1e-8,'OptimalityTol',1e-8);
+    gparams=struct('Presolve',2,'TimeLimit',1000,'OutputFlag',1,'MIPGap',1e-9,'Seed',0,'FeasibilityTol',1e-9,'OptimalityTol',1e-9);
     if (~milp) gparams.OutputFlag=0; end
     %gparams=structUpdate(gparams,params);
     res = gurobi(mosekToGurobiProb(prob), gparams);

--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -25,7 +25,7 @@ if(isfield(prob,'ints')), disp('MILP detected.'); milp=true; end
 
 solver=getpref('RAVEN','solver');
 if strcmp(solver,'gurobi')
-    gparams=struct('Presolve',2,'TimeLimit',1000,'OutputFlag',1,'MIPGap',1e-9,'Seed',0,'FeasibilityTol',1e-9,'OptimalityTol',1e-9);
+    gparams=struct('Presolve',2,'TimeLimit',1000,'OutputFlag',1,'MIPGap',1e-12,'Seed',0,'FeasibilityTol',1e-9,'OptimalityTol',1e-9);
     if (~milp) gparams.OutputFlag=0; end
     %gparams=structUpdate(gparams,params);
     res = gurobi(mosekToGurobiProb(prob), gparams);


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - slightly decrease tolerance when using gurobi solver, particularly when solving MILP. If tolerance is set not strict enough, `fillGaps` does not function well.
  - `addTransport` when defining new reaction IDs
  - error message in `addRxnsGenesMets`
  - bug in `getModelFromHomology` when using multiple template models
  - bug in `getModelFromHomology` where genes were partial matched: YAL001W is not YAL001W-A
  - bug in `fillGaps` where all genes from template models were kept, not only the ones annotated to gap-filling reactions
  - `exportModel` replace illegal characters in grRules
  - bug in `addTransport` when adding multiple transport reactions
  - `addMets`: multiple compartments can be given as either rows or columns
- feat:
  - `addTransport` has list of added reaction IDs as alternative 

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
