### PR TITLE
feat: enable I/O of SBO terms from SBML file

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -225,6 +225,10 @@ for i=1:numel(model.comps)
         [~,sbo_ind] = ismember('sbo',model.compMiriams{i}.name);
         if sbo_ind > 0
             modelSBML.compartment(i).sboTerm=str2double(regexprep(model.compMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+            % remove the SBO term from compMiriams so the information is
+            % not duplicated in the "annotation" field later on
+            model.compMiriams{i}.name(sbo_ind) = [];
+            model.compMiriams{i}.value(sbo_ind) = [];
         end
     end
     if ~isempty(model.compMiriams{i}) && isfield(modelSBML.compartment(i),'annotation')
@@ -296,6 +300,10 @@ for i=1:numel(model.mets)
         [~,sbo_ind] = ismember('sbo',model.metMiriams{i}.name);
         if sbo_ind > 0
             modelSBML.species(i).sboTerm=str2double(regexprep(model.metMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+            % remove the SBO term from metMiriams so the information is
+            % not duplicated in the "annotation" field later on
+            model.metMiriams{i}.name(sbo_ind) = [];
+            model.metMiriams{i}.value(sbo_ind) = [];
         end
     end
     if isfield(modelSBML.species,'annotation')
@@ -347,6 +355,10 @@ if isfield(model,'genes')
             [~,sbo_ind] = ismember('sbo',model.geneMiriams{i}.name);
             if sbo_ind > 0
                 modelSBML.fbc_geneProduct(i).sboTerm=str2double(regexprep(model.geneMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+                % remove the SBO term from compMiriams so the information is
+                % not duplicated in the "annotation" field later on
+                model.geneMiriams{i}.name(sbo_ind) = [];
+                model.geneMiriams{i}.value(sbo_ind) = [];
             end
         end
         if ~isempty(model.geneMiriams{i}) && isfield(modelSBML.fbc_geneProduct(i),'annotation')
@@ -476,6 +488,10 @@ for i=1:numel(model.rxns)
         [~,sbo_ind] = ismember('sbo',model.rxnMiriams{i}.name);
         if sbo_ind > 0
             modelSBML.reaction(i).sboTerm=str2double(regexprep(model.rxnMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+            % remove the SBO term from rxnMiriams so the information is not
+            % duplicated in the "annotation" field later on
+            model.rxnMiriams{i}.name(sbo_ind) = [];
+            model.rxnMiriams{i}.value(sbo_ind) = [];
         end
     end
     

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -221,6 +221,12 @@ for i=1:numel(model.comps)
         modelSBML.compartment(i).metaid=model.comps{i};
     end
     %Prepare Miriam strings
+    if ~isempty(model.compMiriams{i})
+        [~,sbo_ind] = ismember('sbo',model.compMiriams{i}.name);
+        if sbo_ind > 0
+            modelSBML.compartment(i).sboTerm=str2double(regexprep(model.compMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+        end
+    end
     if ~isempty(model.compMiriams{i}) && isfield(modelSBML.compartment(i),'annotation')
         modelSBML.compartment(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.comps{i} '">'];
         modelSBML.compartment(i).annotation=[modelSBML.compartment(i).annotation '<bqbiol:is><rdf:Bag>'];
@@ -286,6 +292,12 @@ for i=1:numel(model.mets)
             modelSBML.species(i).isSetfbc_charge=0;
         end
     end
+    if ~isempty(model.metMiriams{i})
+        [~,sbo_ind] = ismember('sbo',model.metMiriams{i}.name);
+        if sbo_ind > 0
+            modelSBML.species(i).sboTerm=str2double(regexprep(model.metMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+        end
+    end
     if isfield(modelSBML.species,'annotation')
         if ~isempty(model.metMiriams{i}) || ~isempty(model.metFormulas{i})
             hasInchi=false;
@@ -330,6 +342,12 @@ if isfield(model,'genes')
         
         if isfield(modelSBML.fbc_geneProduct,'metaid')
             modelSBML.fbc_geneProduct(i).metaid=model.genes{i};
+        end
+        if ~isempty(model.geneMiriams{i})
+            [~,sbo_ind] = ismember('sbo',model.geneMiriams{i}.name);
+            if sbo_ind > 0
+                modelSBML.fbc_geneProduct(i).sboTerm=str2double(regexprep(model.geneMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+            end
         end
         if ~isempty(model.geneMiriams{i}) && isfield(modelSBML.fbc_geneProduct(i),'annotation')
             modelSBML.fbc_geneProduct(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.genes{i} '">'];
@@ -451,6 +469,14 @@ for i=1:numel(model.rxns)
             modelSBML.reaction(i).notes=[modelSBML.reaction(i).notes '<p>NOTES: ' model.rxnNotes{i} '</p>'];
         end
         modelSBML.reaction(i).notes=[modelSBML.reaction(i).notes '</body></notes>'];
+    end
+    
+    % Export SBO terms from rxnMiriams
+    if ~isempty(model.rxnMiriams{i})
+        [~,sbo_ind] = ismember('sbo',model.rxnMiriams{i}.name);
+        if sbo_ind > 0
+            modelSBML.reaction(i).sboTerm=str2double(regexprep(model.rxnMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
+        end
     end
     
     %Export annotation information from rxnMiriams

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -331,7 +331,7 @@ if isfield(model,'genes')
         %Add the default values, as these will be the same in all entries
         if i==1
             if isfield(modelSBML.fbc_geneProduct, 'sboTerm')
-                modelSBML.fbc_geneProduct(i).sboTerm=252;
+                modelSBML.fbc_geneProduct(i).sboTerm=243;
             end
         end
         %Copy the default values to the next index as long as it is not the

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -2,6 +2,7 @@ function exportModel(model,fileName,exportGeneComplexes,supressWarnings)
 % exportModel
 %   Exports a constraint-based model to an SBML file (L3V1 FBCv2)
 %
+%   Input:
 %   model               a model structure
 %   fileName            filename to export the model to (without file extension)
 %   exportGeneComplexes true if gene complexes (all gene sets linked with

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -846,6 +846,15 @@ else
         %that matching geneShortNames in function below will work
         if isfield(modelSBML,'fbc_geneProduct')
             genes={modelSBML.fbc_geneProduct.fbc_id};
+            
+            %Get gene Miriams if they were not retrieved above (this occurs
+            %when genes are stored as fbc_geneProduct instead of species)
+            if isempty(geneMiriams)
+                geneMiriams = cell(numel(genes),1);
+                for i = 1:numel(genes)
+                    geneMiriams{i}=parseMiriam(modelSBML.fbc_geneProduct(i).annotation);
+                end
+            end
         else
             genes=getGeneList(grRules);
         end

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -2,6 +2,7 @@ function model=importModel(fileName,removeExcMets,isSBML2COBRA,supressWarnings)
 % importModel
 %   Import a constraint-based model from a SBML file
 %
+%   Input:
 %   fileName        a SBML file to import
 %   removeExcMets   true if exchange metabolites should be removed. This is
 %                   needed to be able to run simulations, but it could also
@@ -12,6 +13,7 @@ function model=importModel(fileName,removeExcMets,isSBML2COBRA,supressWarnings)
 %   supressWarnings true if warnings regarding the model structure should
 %                   be supressed (opt, default false)
 %
+%   Output:
 %   model
 %       id               model ID
 %       description      description of model contents

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -162,6 +162,11 @@ compartmentIDs=cell(numel(modelSBML.compartment),1);
 compartmentOutside=cell(numel(modelSBML.compartment),1);
 compartmentMiriams=cell(numel(modelSBML.compartment),1);
 
+if isfield(modelSBML.compartment,'sboTerm') && numel(unique([modelSBML.compartment.sboTerm])) == 1
+    %If all the SBO terms are identical, don't add them to compMiriams
+    modelSBML.compartment = rmfield(modelSBML.compartment,'sboTerm');
+end
+    
 for i=1:numel(modelSBML.compartment)
     compartmentNames{i}=modelSBML.compartment(i).name;
     compartmentIDs{i}=regexprep(modelSBML.compartment(i).id,'^C_','');
@@ -179,6 +184,10 @@ for i=1:numel(modelSBML.compartment)
         compartmentMiriams{i}=parseMiriam(modelSBML.compartment(i).annotation);
     else
         compartmentMiriams{i}=[];
+    end
+    
+    if isfield(modelSBML.compartment(i),'sboTerm')
+        compartmentMiriams{i} = addSBOtoMiriam(compartmentMiriams{i},modelSBML.compartment(i).sboTerm);
     end
 end
 
@@ -209,7 +218,8 @@ complexNames={};
 %specified in the yeast consensus model both metabolites and genes are a
 %type of 'species'. The metabolites have names starting with 'M_' and genes
 %with 'E_'
-
+geneSBOs = [];
+metSBOs = [];
 for i=1:numel(modelSBML.species)
     if ~isSBML2COBRA
         if length(modelSBML.species(i).id)>=2 && strcmpi(modelSBML.species(i).id(1:2),'E_')
@@ -240,8 +250,13 @@ for i=1:numel(modelSBML.species)
             else
                 geneShortNames{numel(geneShortNames)+1,1}='';
             end
-            %If it's a complex keep the ID and name
+            
+            %Get SBO term
+            if isfield(modelSBML.species(i),'sboTerm')
+                geneSBOs(end+1,1) = modelSBML.species(i).sboTerm;
+            end
         elseif length(modelSBML.species(i).id)>=2 && strcmpi(modelSBML.species(i).id(1:3),'Cx_')
+            %If it's a complex keep the ID and name
             complexIDs=[complexIDs;modelSBML.species(i).id];
             complexNames=[complexNames;modelSBML.species(i).name];
         else
@@ -322,6 +337,10 @@ for i=1:numel(modelSBML.species)
             elseif ~isfield(modelSBML.species(i),'annotation')
                 metaboliteFormula{numel(metaboliteFormula)+1,1}='';
             end
+            %Get SBO term
+            if isfield(modelSBML.species(i),'sboTerm')
+                metSBOs(end+1,1) = modelSBML.species(i).sboTerm;
+            end
         end
         
     elseif isSBML2COBRA
@@ -356,6 +375,19 @@ for i=1:numel(modelSBML.species)
         %notes instead
         if isfield(modelSBML.species(i),'notes')
             metaboliteFormula{numel(metaboliteFormula)+1,1}=parseNote(modelSBML.species(i).notes,'FORMULA');
+        end
+        
+        %Get Miriam info
+        if ~isempty(modelSBML.species(i).annotation)
+            metMiriam=parseMiriam(modelSBML.species(i).annotation);    
+        else
+            metMiriam=[];
+        end
+        metaboliteMiriams{numel(metaboliteMiriams)+1,1}=metMiriam;
+        
+        %Get SBO term
+        if isfield(modelSBML.species(i),'sboTerm')
+            metSBOs(end+1,1) = modelSBML.species(i).sboTerm;
         end
     end
     %The following lines are executed regardless isSBML2COBRA setting
@@ -412,6 +444,18 @@ for i=1:numel(modelSBML.species)
     end
 end
 
+%Add SBO terms to gene and metabolite miriam fields
+if numel(unique(geneSBOs)) > 1  % don't add if they're all identical
+    for i = 1:numel(geneNames)
+        geneMiriams{i} = addSBOtoMiriam(geneMiriams{i},geneSBOs(i));
+    end
+end
+if numel(unique(metSBOs)) > 1
+    for i = 1:numel(metaboliteNames)
+        metaboliteMiriams{i} = addSBOtoMiriam(metaboliteMiriams{i},metSBOs(i));
+    end
+end
+
 %Retrieve info on reactions
 reactionNames=cell(numel(modelSBML.reaction),1);
 reactionIDs=cell(numel(modelSBML.reaction),1);
@@ -442,6 +486,11 @@ if isfield(modelSBML,'parameter')
     parameter.name=cell(numel(modelSBML.parameter),1);
     parameter.name={modelSBML.parameter(:).id}';
     parameter.value={modelSBML.parameter(:).value}';
+end
+
+if isfield(modelSBML.reaction,'sboTerm') && numel(unique([modelSBML.reaction.sboTerm])) == 1
+    %If all the SBO terms are identical, don't add them to rxnMiriams
+    modelSBML.reaction = rmfield(modelSBML.reaction,'sboTerm');
 end
 
 for i=1:numel(modelSBML.reaction)
@@ -601,6 +650,11 @@ for i=1:numel(modelSBML.reaction)
             rxnreferences{counter,1}=parseNote(modelSBML.reaction(i).notes,'AUTHORS');
             rxnnotes{counter,1}=parseNote(modelSBML.reaction(i).notes,'NOTES');
         end
+    end
+    
+    %Get SBO terms
+    if isfield(modelSBML.reaction(i),'sboTerm')
+        rxnMiriams{counter} = addSBOtoMiriam(rxnMiriams{counter}, modelSBML.reaction(i).sboTerm);
     end
     
     %Get ec-codes
@@ -851,8 +905,15 @@ else
             %when genes are stored as fbc_geneProduct instead of species)
             if isempty(geneMiriams)
                 geneMiriams = cell(numel(genes),1);
+                if isfield(modelSBML.fbc_geneProduct,'sboTerm') && numel(unique([modelSBML.fbc_geneProduct.sboTerm])) == 1
+                    %If all the SBO terms are identical, don't add them to geneMiriams
+                    modelSBML.fbc_geneProduct = rmfield(modelSBML.fbc_geneProduct,'sboTerm');
+                end
                 for i = 1:numel(genes)
                     geneMiriams{i}=parseMiriam(modelSBML.fbc_geneProduct(i).annotation);
+                    if isfield(modelSBML.fbc_geneProduct(i),'sboTerm')
+                        geneMiriams{i} = addSBOtoMiriam(geneMiriams{i},modelSBML.fbc_geneProduct(i).sboTerm);
+                    end
                 end
             end
         else
@@ -1130,4 +1191,18 @@ for i=1:numel(targetString)
         miriamStruct.name{counter,1} = regexprep(miriamStruct.name{counter,1},'^obo\.','');
     end
 end
+end
+
+function miriam = addSBOtoMiriam(miriam,sboTerm)
+%Appends SBO term to miriam structure
+
+sboTerm = {['SBO:' sprintf('%07u',sboTerm)]};  % convert to proper format
+if isempty(miriam)
+    miriam.name = {'sbo'};
+    miriam.value = sboTerm;
+else
+    miriam.name(end+1) = {'sbo'};
+    miriam.value(end+1) = sboTerm;
+end
+
 end

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -2,8 +2,10 @@ function newModel=ravenCobraWrapper(model)
 % ravenCobraWrapper
 %   Converts between RAVEN and COBRA structures
 %
+%   Input:
 %   model          a RAVEN/COBRA-compatible model structure
 %
+%   Ouput:
 %   newModel       a COBRA/RAVEN-compatible model structure
 %   
 %   This function is a bidirectional tool to convert between RAVEN and COBRA

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -243,7 +243,11 @@ if isRaven
         i=ismember(extractedMiriamNames,'uniprot');
         if any(i)
             newModel.proteinisuniprotID=miriams(:,i);
-        end      
+        end
+        i=ismember(extractedMiriamNames,'sbo');
+        if any(i)
+            newModel.geneSBOTerms=miriams(:,i);
+        end
     end
     if isfield(model,'geneShortNames')
         newModel.geneNames=model.geneShortNames;
@@ -456,7 +460,7 @@ else
     if isfield(model,'genes')
         newModel.genes=model.genes;
     end
-    if isfield(model,'geneiskegg__46__genesID') || isfield(model,'geneissgdID') || isfield(model,'proteinisuniprotID')
+    if any(isfield(model,{'geneiskegg__46__genesID','geneissgdID','proteinisuniprotID','geneSBOTerm'}))
         for i=1:numel(model.genes)
             counter=1;
             newModel.geneMiriams{i,1}=[];
@@ -478,6 +482,13 @@ else
                 if ~isempty(model.proteinisuniprotID{i})
                     newModel.geneMiriams{i,1}.name{counter,1} = 'uniprot';
                     newModel.geneMiriams{i,1}.value{counter,1} = model.proteinisuniprotID{i};
+                    counter=counter+1;
+                end
+            end
+            if isfield(model,'geneSBOTerm')
+                if ~isempty(model.geneSBOTerm{i})
+                    newModel.geneMiriams{i,1}.name{counter,1} = 'sbo';
+                    newModel.geneMiriams{i,1}.value{counter,1} = model.geneSBOTerm{i};
                     counter=counter+1;
                 end
             end


### PR DESCRIPTION
### Main improvements in this PR:

The `exportModel`, `importModel`, and `ravenCobraWrapper` functions were updated to enable writing and reading of gene, reaction, and metabolite SBO terms to and from an SBML file. This PR addresses Issue #196.

1.  `exportModel` writes SBO terms from `.xyzMiriams` model fields to SBML `.sboTerm` fields.

2.  The default gene SBO term assigned in `exportModel` was changed from `SBO:0000252` ("polypeptide chain") to `SBO:0000243` ("gene"), the latter of which is consistent with [memote](https://memote.readthedocs.io/en/latest/).

3. `importModel` reads SBO terms from the SBML `.sboTerm` fields, and adds them to the corresponding `.xyzMiriams` model fields. 

4. A check was implemented in `importModel` to prevent importing SBO terms if they are all identical for a given entity (e.g., if all metabolites have the same SBO term, it will not be imported into the model structure).

5. `ravenCobraWrapper` was updated to enable conversion of gene SBO terms between the `.geneMiriams` and `.geneSBOTerms` fields of RAVEN and COBRA model structures, respectively.


**I hereby confirm that I have:**
- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch