### PR TITLE
fix: getIndexes enable returnLogical when "type" is "metscomps"

### DIFF
--- a/core/getIndexes.m
+++ b/core/getIndexes.m
@@ -60,6 +60,11 @@ elseif strcmpi(type,'metscomps')
         end
     end
     indexes=indexes(:);
+    if returnLogical==true
+        tempIndexes=false(numel(model.mets),1);
+        tempIndexes(indexes)=true;
+        indexes=tempIndexes;
+    end
     return; % If metscomps is queried, remaining codes doesn't need executing
 else
     EM='Incorrect value of the "type" parameter. Allowed values are "rxns", "mets" or "genes"';

--- a/core/getIndexes.m
+++ b/core/getIndexes.m
@@ -2,6 +2,7 @@ function indexes=getIndexes(model, objects, type, returnLogical)
 % getIndexes
 %   Retrieves the indexes for a list of reactions or metabolites
 %
+%   Input:
 %   model           a model structure
 %   objects         either a cell array of IDs, a logical vector with the
 %                   same number of elements as metabolites in the model,
@@ -13,6 +14,7 @@ function indexes=getIndexes(model, objects, type, returnLogical)
 %   returnLogical   Sets whether to return a logical array or an array with
 %                   the indexes (opt, default false)
 %
+%   Output:
 %   indexes         can be a logical array or a double array depending on
 %                   the value of returnLogical
 %


### PR DESCRIPTION
### Main improvements in this PR:
- Fixed a bug in `getIndexes` where the function would ignore the `returnLogical` input if the `type` input was set to `metscomps`.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
