### PR TITLE
fix: getElementalBalance

### DIFF
--- a/core/getElementalBalance.m
+++ b/core/getElementalBalance.m
@@ -132,4 +132,12 @@ for i=1:numel(toPrint)
         end
     end
 end
+
+% if reaction index numbers were provided, re-order the structure entries
+% so they're consistent with the ordering of the input reaction indexes
+if ~isempty(rxns) && isnumeric(rxns)
+    [~,i] = sort(rxns);
+    balanceStructure.balanceStatus(i) = balanceStructure.balanceStatus;
+    balanceStructure.leftComp(i,:) = balanceStructure.leftComp;
+    balanceStructure.rightComp(i,:) = balanceStructure.rightComp;
 end


### PR DESCRIPTION
### Main improvements in this PR:
Fixed a bug in `getElementalBalance` where if the user supplied reaction indexes, the function would effectively "sort" those indexes in the output without the user knowing.

For example, if I called the function using an input `rxns = [5, 19, 24]`, the results structure would be properly aligned with that index ordering. However, if I called the function using an input `rxns = [24, 5, 19]`, I would get the exact same output, which is not consistent with my input ordering.

This bug was fixed by re-ordering the results based on the ordering of the input indexes prior to returning the output.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
