### PR TITLE
feat: checkFunctionUniqueness now detects multiple RAVEN versions

### DIFF
--- a/installation/checkFunctionUniqueness.m
+++ b/installation/checkFunctionUniqueness.m
@@ -5,7 +5,7 @@ function checkFunctionUniqueness()
 %
 %   Usage: checkFunctionUniqueness()
 %
-%   Simonas Marcisauskas, 2018-04-05
+%   Simonas Marcisauskas, 2019-08-28
 %
 
 %Get the RAVEN path
@@ -40,10 +40,15 @@ for i=1:numel(matlabPaths)
         end
         if ~isempty(pathFunctions)
             if any(ismember(ravenFunctions,pathFunctions))
-                disp(['WARNING: Duplicate functions in ',matlabPaths{i},': ']);
-                ovrlpFunctions=ravenFunctions(ismember(ravenFunctions,pathFunctions));
-                disp(ovrlpFunctions);
-                hasConflicts=true;
+                if sum(ismember(ravenFunctions,pathFunctions))>(numel(ravenFunctions)/4)
+                    EM='Multiple RAVEN versions detected in MATLAB path. Leave only one RAVEN version in MATLAB path and re-run checkInstallation\n';
+                    dispEM(EM);
+                else
+                    disp(['WARNING: Duplicate functions in ',matlabPaths{i},': ']);
+                    ovrlpFunctions=ravenFunctions(ismember(ravenFunctions,pathFunctions));
+                    disp(ovrlpFunctions);
+                    hasConflicts=true;
+                end
             end
         end
     end


### PR DESCRIPTION
### Main improvements in this PR:
Added the new feature to `checkFunctionUniqueness`: it now checks for multiple RAVEN versions in MATLAB path and gives a fatal error if it is the case. That is, if at least one quarter of the existing RAVEN functions are found somewhere else in MATLAB path, it is assumed that another RAVEN version exists in MATLAB path.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR