### PR TITLE
doc: updated runtime info regarding getKEGGModelForOrganism

### DIFF
--- a/tutorial/tutorial4.m
+++ b/tutorial/tutorial4.m
@@ -5,7 +5,7 @@
 %is to serve as a scaffold if you would like to reconstruct a GEM for your
 %own organism.
 %
-%Eduard Kerkhoven, 2019-02-01
+%Simonas Marcisauskas, 2019-08-28
 %
 
 %Start by downloading trained Hidden Markov Models for eukaryotes. This can
@@ -17,8 +17,9 @@
 %This creates a model for S. cerevisiae. The parameters are set to exclude
 %general or unclear reactions and reactions with undefined stoichiometry.
 %Type "help getKEGGModelForOrganism" to see what the different parameters
-%are for. This process takes up to 10-15 minutes, depending on your
-%hardware and the size of target organism proteome;
+%are for. This process takes up to 20-30 minutes in macOS, Unix systems and
+%40-50 minutes in Windows, depending on your hardware and the size of
+%target organism proteome
 model=getKEGGModelForOrganism('sce','sce.fa','euk100_kegg87','output',false,false,false,false,10^-30,0.8,0.3,-1);
 
 %As you can see the resulting model contains (around) 1501 reactions, 1513


### PR DESCRIPTION
### Main improvements in this PR:
In `tutorial4`, the more accurate runtime estimates for `getKEGGModelForOrganism` were added for macOS, Unix and Windows systems

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR