### PR TITLE
fix: import of old SBML with formula in metsID

### DIFF
--- a/io/importModel.m
+++ b/io/importModel.m
@@ -354,7 +354,7 @@ for i=1:numel(modelSBML.species)
         
         %The old COBRA version sometimes has composition information in the
         %notes instead
-        if isfield(modelSBML.species(i),'notes')
+        if isfield(modelSBML.species(i),'notes') && ~isempty(parseNote(modelSBML.species(i).notes,'FORMULA'))
             metaboliteFormula{numel(metaboliteFormula)+1,1}=parseNote(modelSBML.species(i).notes,'FORMULA');
         end
     end


### PR DESCRIPTION
### Main improvements in this PR:
- Fix:
  - `importModel` parsing of metabolite formula when importing old SBML file (level 2) where formula are in metabolite IDs and not in 'notes' field.

Example of such a model: iAT601 [link](https://biotechnologyforbiofuels.biomedcentral.com/articles/10.1186/s13068-016-0607-x)

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR