### PR TITLE
fix: getElementalBalance ignored order of rxns when using strings (IDs)

### DIFF
--- a/core/getElementalBalance.m
+++ b/core/getElementalBalance.m
@@ -133,9 +133,10 @@ for i=1:numel(toPrint)
     end
 end
 
-% if reaction index numbers were provided, re-order the structure entries
-% so they're consistent with the ordering of the input reaction indexes
-if ~isempty(rxns) && isnumeric(rxns)
+% Re-order the structure entries so they're consistent with the ordering of
+% the input reaction indexes
+if ~isempty(rxns)
+    rxns = getIndexes(model,rxns,'rxns');
     [~,i] = sort(rxns);
     balanceStructure.balanceStatus(i) = balanceStructure.balanceStatus;
     balanceStructure.leftComp(i,:) = balanceStructure.leftComp;


### PR DESCRIPTION
### Main improvements in this PR:
The `getElementalBalance` function ignores the order of reactions if they are supplied as a list of reaction IDs, resulting in an output that is not aligned with the inputs.

This same bug was fixed in #240 for inputs of reaction indexes - here I implemented a more general solution that fixes the problem regardless of input type (index numbers, reaction IDs, or logical vector).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch

