### PR TITLE
fix: setExchangeBounds fixed bug where closeOthers var was not updated

### DIFF
--- a/core/setExchangeBounds.m
+++ b/core/setExchangeBounds.m
@@ -130,6 +130,7 @@ else
     if closeOthers
         fprintf('         Therefore, the "closeOthers" option will be set to FALSE.\n');
     end
+    closeOthers = false;
 end
 
 % prepare exchanged metabolites and bounds


### PR DESCRIPTION
### Main improvements in this PR:
Bug fix in `setExchangeBounds` function.

When using `setExchangeBounds`, if a model contains exchange reactions differing in their direction (i.e., positive flux indicates export for some reactions, but import for others), then the `closeOthers` input should be forced to `false`. The function was not properly making this change, so this has now been corrected.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
