### PR TITLE
doc/feat/fix: enhance checkInstallation

### DIFF
--- a/installation/checkFunctionUniqueness.m
+++ b/installation/checkFunctionUniqueness.m
@@ -5,7 +5,7 @@ function checkFunctionUniqueness()
 %
 %   Usage: checkFunctionUniqueness()
 %
-%   Simonas Marcisauskas, 2019-08-28
+%   Simonas Marcisauskas, 2019-10-05
 %
 
 %Get the RAVEN path
@@ -40,6 +40,7 @@ for i=1:numel(matlabPaths)
         end
         if ~isempty(pathFunctions)
             if any(ismember(ravenFunctions,pathFunctions))
+                fprintf('Not OK\n');
                 if sum(ismember(ravenFunctions,pathFunctions))>(numel(ravenFunctions)/4)
                     EM='Multiple RAVEN versions detected in MATLAB path. Leave only one RAVEN version in MATLAB path and re-run checkInstallation\n';
                     dispEM(EM);
@@ -57,7 +58,7 @@ end
 if hasConflicts
     fprintf('It is strongly recommended to resolve conflicting functions as this may compromise RAVEN functionality\n');
 else
-    fprintf('No conflicting functions were found\n');
+    fprintf('OK\n');
 end
 
 end

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -3,14 +3,14 @@ function checkInstallation()
 %   The purpose of this function is to check if all necessary functions are
 %   installed and working. It also checks whether there are any functions
 %   with overlapping names between RAVEN and other toolboxes or
-%   user-defined functions, which are accessible from Matlab pathlist
+%   user-defined functions, which are accessible from MATLAB pathlist
 %
 %   Usage: checkInstallation()
 %
-%	Simonas Marcisauskas, 2019-10-04
+%	Simonas Marcisauskas, 2019-10-05
 %
 
-%Check if RAVEN is in the Matlab path list
+%Check if RAVEN is in the MATLAB path list
 paths=textscan(path,'%s','delimiter', pathsep);
 paths=paths{1};
 
@@ -25,10 +25,11 @@ else
     fprintf('\n*** THE RAVEN TOOLBOX - DEVELOPMENT VERSION ***\n\n');
 end
 
+fprintf('Checking if RAVEN is on the MATLAB path... ');
 if ismember(ravenDir,paths)
-    fprintf('Checking if RAVEN is on the Matlab path... PASSED\n');
+    fprintf('OK\n');
 else
-    fprintf('Checking if RAVEN is on the Matlab path... FAILED\n');
+    fprintf('Not OK\n');
     addMe=input('Would you like to add the RAVEN directory to the path list? Y/N\n','s');
     if strcmpi(addMe,'y')
         subpath=regexp(genpath(ravenDir),pathsep,'split'); %List all subdirectories
@@ -46,26 +47,29 @@ xmlFile=fullfile(ravenDir,'tutorial','empty.xml');
 matFile=fullfile(ravenDir,'tutorial','empty.mat');
 
 %Check if it is possible to parse an Excel file
+fprintf('Checking if it is possible to parse a model in Microsoft Excel format... ');
 try
     importExcelModel(excelFile,false,false,true);
-    fprintf('Checking if it is possible to parse a model in Microsoft Excel format... PASSED\n');
+    fprintf('OK\n');
 catch
-    fprintf('Checking if it is possible to parse a model in Microsoft Excel format... FAILED\n');
+    fprintf('Not OK\n');
 end
 
 %Check if it is possible to import an SBML model using libSBML
+fprintf('Checking if it is possible to import an SBML model using libSBML... ');
 try
     importModel(xmlFile);
     try
         libSBMLver=OutputSBML; % Only works in libSBML 5.17.0+
-        fprintf('Checking if it is possible to import an SBML model using libSBML... PASSED\n');
+        fprintf('OK\n');
     catch
-        fprintf(['Checking if it is possible to import an SBML model using libSBML... PASSED\n\n'...
+        fprintf(['Not OK\n\n'...
             'An older libSBML version was found, update to version 5.17.0 or higher\n'...
-            'for a significant improvement of model import.\n\n']);
+            'for a significant improvement of model import\n\n']);
     end
 catch
-    fprintf('Checking if it is possible to import an SBML model using libSBML... FAILED\nTo import SBML models, download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n');
+    fprintf(['Not OK\nTo import SBML models, download libSBML from\n'...
+        'http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n']);
 end
 
 %Define values for keepSolver and workingSolvers, needed for solver
@@ -86,17 +90,18 @@ end
 solver={'gurobi','mosek','cobra'};
 
 for i=1:numel(solver)
+    fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'... ']);
     try
         setRavenSolver(solver{i});
         load(matFile);
         solveLP(empty);
         workingSolvers=strcat(workingSolvers,';',solver{i});
-        fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'... PASSED\n']);
+        fprintf('OK\n');
         if strcmp(curSolv,solver{i})
             keepSolver=true;
         end
     catch
-        fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'... FAILED\n']);
+        fprintf('Not OK\n');
     end
 end
 
@@ -117,7 +122,9 @@ else
     %No functional solvers were found, so the setting is restored back to
     %original
     setRavenSolver(curSolv);
-    fprintf('WARNING: No working solver was found!\nInstall the solver, set it using setRavenSolver(''solverName'') and run checkInstallation again.\nAvailable solverName options are ''mosek'', ''gurobi'' and ''cobra''\n\n');
+    fprintf(['WARNING: No working solver was found!\n'...
+        'Install the solver, set it using setRavenSolver(''solverName'') and run checkInstallation again\n'...
+        'Available solverName options are ''mosek'', ''gurobi'' and ''cobra''\n\n']);
 end
 
 if ~ispc
@@ -126,50 +133,60 @@ if ~ispc
     elseif isunix
         binEnd='';
     end
-    fprintf('Checking binary executables..\n');
-    [res,~]=system(['"' fullfile(ravenDir,'software','blast+',['blastp' binEnd]) '"']);
-    if res==1
-        fprintf(['Checking blastp' binEnd '.. OK\n']);
-    else
-        fprintf(['Checking blastp' binEnd '.. Not OK! The binary must be recompiled from source before running RAVEN\n']);
-    end
+    fprintf('Checking essential binary executables:\n');
+    fprintf('NOTE: Broken binary executables <strong>must be fixed</strong> before running RAVEN\n');    
+    fprintf(['\tmakeblastdb' binEnd '... ']);
     [res,~]=system(['"' fullfile(ravenDir,'software','blast+',['makeblastdb' binEnd]) '"']);
     if res==1
-        fprintf(['Checking makeblastdb' binEnd '.. OK\n']);
+        fprintf('OK\n');
     else
-        fprintf(['Checking makeblastdb' binEnd '.. Not OK! The binary must be recompiled from source before running RAVEN\n']);
+        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
     end
-    [res,~]=system(['"' fullfile(ravenDir,'software','cd-hit',['cd-hit' binEnd]) '"']);
+    fprintf(['\tblastp' binEnd '... ']);
+    [res,~]=system(['"' fullfile(ravenDir,'software','blast+',['blastp' binEnd]) '"']);
     if res==1
-        fprintf(['Checking cd-hit' binEnd '.. OK\n']);
+        fprintf('OK\n');
     else
-        fprintf(['Checking cd-hit' binEnd '.. Not OK! The binary must be recompiled from source before running RAVEN\n']);
+        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
     end
-    [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmbuild' binEnd]) '"']);
-    if res==1
-        fprintf(['Checking hmmbuild' binEnd '.. OK\n']);
-    else
-        fprintf(['Checking hmmbuild' binEnd '.. Not OK! The binary must be recompiled from source before running RAVEN\n']);
-    end
+    fprintf(['\thmmsearch' binEnd '... ']);
     [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmsearch' binEnd]) '"']);
     if res==1
-        fprintf(['Checking hmmsearch' binEnd '.. OK\n']);
+        fprintf('OK\n');
     else
-        fprintf(['Checking hmmsearch' binEnd '.. Not OK! The binary must be recompiled from source before running RAVEN\n']);
+        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
     end
+    fprintf('Checking non-essential/development binary executables:\n');
+    fprintf('NOTE: Only fix these binaries if planning to use KEGG FTP dump files in getKEGGModelForOrganism\n');
+    fprintf(['\tcd-hit' binEnd '... ']);
+    [res,~]=system(['"' fullfile(ravenDir,'software','cd-hit',['cd-hit' binEnd]) '"']);
+    if res==1
+        fprintf('OK\n');
+    else
+        fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
+    end
+    fprintf('\tmafft.bat... ');
     if ismac
         [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-mac','mafft.bat') '" --help ']);
     elseif unix
         [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-linux64','mafft.bat') '" --help ']);
     end
     if res==1
-        fprintf('Checking mafft.bat.. OK\n\n');
+        fprintf('OK\n');
     else
-        fprintf('Checking mafft.bat.. Not OK! The binary must be recompiled from source before running RAVEN\n\n');
+        fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
+    end
+    fprintf(['\thmmbuild' binEnd '... ']);
+    [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmbuild' binEnd]) '"']);
+    if res==1
+        fprintf('OK\n\n');
+    else
+        fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
     end
 end
 
-fprintf('Checking the uniqueness of RAVEN functions across Matlab path...\n');
+fprintf('Checking whether RAVEN functions are non-redundant across MATLAB path... ');
 checkFunctionUniqueness();
 
+fprintf('\n*** checkInstallation complete ***\n\n');
 end

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -7,7 +7,7 @@ function checkInstallation()
 %
 %   Usage: checkInstallation()
 %
-%	Simonas Marcisauskas, 2019-10-05
+%	Simonas Marcisauskas, 2019-10-09
 %
 
 %Check if RAVEN is in the MATLAB path list
@@ -25,7 +25,7 @@ else
     fprintf('\n*** THE RAVEN TOOLBOX - DEVELOPMENT VERSION ***\n\n');
 end
 
-fprintf('Checking if RAVEN is on the MATLAB path... ');
+fprintf('Checking if RAVEN is on the MATLAB path...\t\t\t\t\t');
 if ismember(ravenDir,paths)
     fprintf('OK\n');
 else
@@ -47,7 +47,7 @@ xmlFile=fullfile(ravenDir,'tutorial','empty.xml');
 matFile=fullfile(ravenDir,'tutorial','empty.mat');
 
 %Check if it is possible to parse an Excel file
-fprintf('Checking if it is possible to parse a model in Microsoft Excel format... ');
+fprintf('Checking if it is possible to parse a model in Microsoft Excel format...\t');
 try
     importExcelModel(excelFile,false,false,true);
     fprintf('OK\n');
@@ -56,7 +56,7 @@ catch
 end
 
 %Check if it is possible to import an SBML model using libSBML
-fprintf('Checking if it is possible to import an SBML model using libSBML... ');
+fprintf('Checking if it is possible to import an SBML model using libSBML...\t\t');
 try
     importModel(xmlFile);
     try
@@ -90,7 +90,7 @@ end
 solver={'gurobi','mosek','cobra'};
 
 for i=1:numel(solver)
-    fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'... ']);
+    fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'...\t\t']);
     try
         setRavenSolver(solver{i});
         load(matFile);
@@ -136,28 +136,28 @@ elseif ispc
 end
 fprintf('Checking essential binary executables:\n');
 fprintf('NOTE: Broken binary executables <strong>must be fixed</strong> before running RAVEN\n');
-fprintf(['\tmakeblastdb' binEnd '... ']);
+fprintf(['\tmakeblastdb' binEnd '...\t\t\t\t\t\t\t']);
 [res,~]=system(['"' fullfile(ravenDir,'software','blast+',['makeblastdb' binEnd]) '"']);
 if res==1
     fprintf('OK\n');
 else
     fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
 end
-fprintf(['\tblastp' binEnd '... ']);
+fprintf(['\tblastp' binEnd '...\t\t\t\t\t\t\t\t']);
 [res,~]=system(['"' fullfile(ravenDir,'software','blast+',['blastp' binEnd]) '"']);
 if res==1
     fprintf('OK\n');
 else
     fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
 end
-fprintf(['\tdiamond' binEnd '... ']);
+fprintf(['\tdiamond' binEnd '...\t\t\t\t\t\t\t\t']);
 [res,~]=system(['"' fullfile(ravenDir,'software','diamond',['diamond' binEnd]) '"']);
 if res==1
     fprintf('OK\n');
 else
     fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
 end
-fprintf(['\thmmsearch' binEnd '... ']);
+fprintf(['\thmmsearch' binEnd '...\t\t\t\t\t\t\t']);
 [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmsearch' binEnd]) '"']);
 if res==1
     fprintf('OK\n');
@@ -166,14 +166,14 @@ else
 end
 fprintf('Checking non-essential/development binary executables:\n');
 fprintf('NOTE: Only fix these binaries if planning to use KEGG FTP dump files in getKEGGModelForOrganism\n');
-fprintf(['\tcd-hit' binEnd '... ']);
+fprintf(['\tcd-hit' binEnd '...\t\t\t\t\t\t\t\t']);
 [res,~]=system(['"' fullfile(ravenDir,'software','cd-hit',['cd-hit' binEnd]) '"']);
 if res==1
     fprintf('OK\n');
 else
     fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
 end
-fprintf('\tmafft.bat... ');
+fprintf('\tmafft.bat...\t\t\t\t\t\t\t\t');
 if ismac
     [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-mac','mafft.bat') '" --help ']);
 elseif isunix
@@ -186,7 +186,7 @@ if res==1
 else
     fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
 end
-fprintf(['\thmmbuild' binEnd '... ']);
+fprintf(['\thmmbuild' binEnd '...\t\t\t\t\t\t\t\t']);
 [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmbuild' binEnd]) '"']);
 if res==1
     fprintf('OK\n\n');
@@ -194,7 +194,7 @@ else
     fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
 end
 
-fprintf('Checking whether RAVEN functions are non-redundant across MATLAB path... ');
+fprintf('Checking whether RAVEN functions are non-redundant across MATLAB path...\t');
 checkFunctionUniqueness();
 
 fprintf('\n*** checkInstallation complete ***\n\n');

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -25,7 +25,7 @@ else
     fprintf('\n*** THE RAVEN TOOLBOX - DEVELOPMENT VERSION ***\n\n');
 end
 
-fprintf('Checking if RAVEN is on the MATLAB path...\t\t\t\t\t');
+fprintf('Checking if RAVEN is on the MATLAB path...\t\t\t\t\t\t\t\t\t');
 if ismember(ravenDir,paths)
     fprintf('OK\n');
 else
@@ -56,7 +56,7 @@ catch
 end
 
 %Check if it is possible to import an SBML model using libSBML
-fprintf('Checking if it is possible to import an SBML model using libSBML...\t\t');
+fprintf('Checking if it is possible to import an SBML model using libSBML...\t\t\t');
 try
     importModel(xmlFile);
     try
@@ -90,7 +90,7 @@ end
 solver={'gurobi','mosek','cobra'};
 
 for i=1:numel(solver)
-    fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'...\t\t']);
+    fprintf(['Checking if it is possible to solve an LP problem using ',solver{i},'...\t\t\t']);
     try
         setRavenSolver(solver{i});
         load(matFile);

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -7,21 +7,23 @@ function checkInstallation()
 %
 %   Usage: checkInstallation()
 %
-%	Simonas Marcisauskas, 2019-08-22
+%	Simonas Marcisauskas, 2019-10-04
 %
 
-fprintf('\n*** THE RAVEN TOOLBOX v. 2.0 ***\n\n');
-
-keepSolver=false;
-workingSolvers='';
-
-%Check if RAVEN is in the path list
+%Check if RAVEN is in the Matlab path list
 paths=textscan(path,'%s','delimiter', pathsep);
 paths=paths{1};
 
 %Get the RAVEN path
 [ST, I]=dbstack('-completenames');
 [ravenDir,~,~]=fileparts(fileparts(ST(I).file));
+
+%Print the RAVEN version if it is not the development version
+if exist(fullfile(ravenDir,'version.txt'), 'file') == 2
+    fprintf(['\n*** THE RAVEN TOOLBOX v.' fgetl(fopen(fullfile(ravenDir,'version.txt'))) ' ***\n\n']);
+else
+    fprintf('\n*** THE RAVEN TOOLBOX - DEVELOPMENT VERSION ***\n\n');
+end
 
 if ismember(ravenDir,paths)
     fprintf('Checking if RAVEN is on the Matlab path... PASSED\n');
@@ -66,6 +68,10 @@ catch
     fprintf('Checking if it is possible to import an SBML model using libSBML... FAILED\nTo import SBML models, download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n');
 end
 
+%Define values for keepSolver and workingSolvers, needed for solver
+%functionality check
+keepSolver=false;
+workingSolvers='';
 % Get current solver. Set it to 'none', if it is not set;
 if ~ispref('RAVEN','solver')
     fprintf('Solver found in preferences... NONE\n');

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -38,7 +38,7 @@ else
     end
 end
 
-%Adds the required classes to the static Java path if not already added
+%Add the required classes to the static Java path if not already added
 addJavaPaths();
 
 excelFile=fullfile(ravenDir,'tutorial','empty.xlsx');
@@ -72,7 +72,7 @@ end
 %functionality check
 keepSolver=false;
 workingSolvers='';
-% Get current solver. Set it to 'none', if it is not set;
+%Get current solver. Set it to 'none', if it is not set
 if ~ispref('RAVEN','solver')
     fprintf('Solver found in preferences... NONE\n');
     setRavenSolver('none');
@@ -101,22 +101,21 @@ for i=1:numel(solver)
 end
 
 if keepSolver
-    % The solver set in curSolv is functional, so the settings are restored
-    % to the ones which were set before running checkInstallation;
+    %The solver set in curSolv is functional, so the settings are restored
+    %to the ones which were set before running checkInstallation
     setRavenSolver(curSolv);
     fprintf(['Preferred solver... KEPT\nSolver saved as preference... ',curSolv,'\n\n']);
 elseif ~isempty(workingSolvers)
-    % There are working solvers, but the none of them is the solver defined
-    % by curSolv. The first working solver is therefore set as RAVEN
-    % solver;
+    %There are working solvers, but the none of them is the solver defined
+    %by curSolv. The first working solver is therefore set as RAVEN solver
     workingSolvers=regexprep(workingSolvers,'^;','');
     workingSolvers=regexprep(workingSolvers,';.+$','');
-    % Only one working solver should be left by now in workingSolvers;
+    %Only one working solver should be left by now in workingSolvers
     setRavenSolver(workingSolvers);
     fprintf(['Preferred solver... NEW\nSolver saved as preference... ',workingSolvers,'\n\n']);
 else
-    % No functional solvers were found, so the setting is restored back to
-    % original;
+    %No functional solvers were found, so the setting is restored back to
+    %original
     setRavenSolver(curSolv);
     fprintf('WARNING: No working solver was found!\nInstall the solver, set it using setRavenSolver(''solverName'') and run checkInstallation again.\nAvailable solverName options are ''mosek'', ''gurobi'' and ''cobra''\n\n');
 end

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -149,6 +149,13 @@ if ~ispc
     else
         fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
     end
+    fprintf(['\tdiamond' binEnd '... ']);
+    [res,~]=system(['"' fullfile(ravenDir,'software','diamond',['diamond' binEnd]) '"']);
+    if res==1
+        fprintf('OK\n');
+    else
+        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
+    end
     fprintf(['\thmmsearch' binEnd '... ']);
     [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmsearch' binEnd]) '"']);
     if res==1

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -127,69 +127,71 @@ else
         'Available solverName options are ''mosek'', ''gurobi'' and ''cobra''\n\n']);
 end
 
-if ~ispc
-    if ismac
-        binEnd='.mac';
-    elseif isunix
-        binEnd='';
-    end
-    fprintf('Checking essential binary executables:\n');
-    fprintf('NOTE: Broken binary executables <strong>must be fixed</strong> before running RAVEN\n');    
-    fprintf(['\tmakeblastdb' binEnd '... ']);
-    [res,~]=system(['"' fullfile(ravenDir,'software','blast+',['makeblastdb' binEnd]) '"']);
-    if res==1
-        fprintf('OK\n');
-    else
-        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
-    end
-    fprintf(['\tblastp' binEnd '... ']);
-    [res,~]=system(['"' fullfile(ravenDir,'software','blast+',['blastp' binEnd]) '"']);
-    if res==1
-        fprintf('OK\n');
-    else
-        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
-    end
-    fprintf(['\tdiamond' binEnd '... ']);
-    [res,~]=system(['"' fullfile(ravenDir,'software','diamond',['diamond' binEnd]) '"']);
-    if res==1
-        fprintf('OK\n');
-    else
-        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
-    end
-    fprintf(['\thmmsearch' binEnd '... ']);
-    [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmsearch' binEnd]) '"']);
-    if res==1
-        fprintf('OK\n');
-    else
-        fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
-    end
-    fprintf('Checking non-essential/development binary executables:\n');
-    fprintf('NOTE: Only fix these binaries if planning to use KEGG FTP dump files in getKEGGModelForOrganism\n');
-    fprintf(['\tcd-hit' binEnd '... ']);
-    [res,~]=system(['"' fullfile(ravenDir,'software','cd-hit',['cd-hit' binEnd]) '"']);
-    if res==1
-        fprintf('OK\n');
-    else
-        fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
-    end
-    fprintf('\tmafft.bat... ');
-    if ismac
-        [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-mac','mafft.bat') '" --help ']);
-    elseif unix
-        [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-linux64','mafft.bat') '" --help ']);
-    end
-    if res==1
-        fprintf('OK\n');
-    else
-        fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
-    end
-    fprintf(['\thmmbuild' binEnd '... ']);
-    [res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmbuild' binEnd]) '"']);
-    if res==1
-        fprintf('OK\n\n');
-    else
-        fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
-    end
+if ismac
+    binEnd='.mac';
+elseif isunix
+    binEnd='';
+elseif ispc
+    binEnd='.exe';
+end
+fprintf('Checking essential binary executables:\n');
+fprintf('NOTE: Broken binary executables <strong>must be fixed</strong> before running RAVEN\n');
+fprintf(['\tmakeblastdb' binEnd '... ']);
+[res,~]=system(['"' fullfile(ravenDir,'software','blast+',['makeblastdb' binEnd]) '"']);
+if res==1
+    fprintf('OK\n');
+else
+    fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
+end
+fprintf(['\tblastp' binEnd '... ']);
+[res,~]=system(['"' fullfile(ravenDir,'software','blast+',['blastp' binEnd]) '"']);
+if res==1
+    fprintf('OK\n');
+else
+    fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
+end
+fprintf(['\tdiamond' binEnd '... ']);
+[res,~]=system(['"' fullfile(ravenDir,'software','diamond',['diamond' binEnd]) '"']);
+if res==1
+    fprintf('OK\n');
+else
+    fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
+end
+fprintf(['\thmmsearch' binEnd '... ']);
+[res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmsearch' binEnd]) '"']);
+if res==1
+    fprintf('OK\n');
+else
+    fprintf('Not OK! Download/compile the binary and run checkInstallation again\n');
+end
+fprintf('Checking non-essential/development binary executables:\n');
+fprintf('NOTE: Only fix these binaries if planning to use KEGG FTP dump files in getKEGGModelForOrganism\n');
+fprintf(['\tcd-hit' binEnd '... ']);
+[res,~]=system(['"' fullfile(ravenDir,'software','cd-hit',['cd-hit' binEnd]) '"']);
+if res==1
+    fprintf('OK\n');
+else
+    fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
+end
+fprintf('\tmafft.bat... ');
+if ismac
+    [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-mac','mafft.bat') '" --help ']);
+elseif isunix
+    [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-linux64','mafft.bat') '" --help ']);
+elseif ispc
+    [res,~]=system(['"' fullfile(ravenDir,'software','mafft','mafft-win','mafft.bat') '" --help ']);
+end
+if res==1
+    fprintf('OK\n');
+else
+    fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
+end
+fprintf(['\thmmbuild' binEnd '... ']);
+[res,~]=system(['"' fullfile(ravenDir,'software','hmmer',['hmmbuild' binEnd]) '"']);
+if res==1
+    fprintf('OK\n\n');
+else
+    fprintf('Not OK! If necessary, download/compile the binary and run checkInstallation again\n');
 end
 
 fprintf('Checking whether RAVEN functions are non-redundant across MATLAB path... ');

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -31,7 +31,7 @@ else
     fprintf('Checking if RAVEN is on the Matlab path... FAILED\n');
     addMe=input('Would you like to add the RAVEN directory to the path list? Y/N\n','s');
     if strcmpi(addMe,'y')
-        subpath=regexp(genpath(ravenDir),pathsep,'split'); % Lists all subdirectories
+        subpath=regexp(genpath(ravenDir),pathsep,'split'); %List all subdirectories
         pathsToKeep=cellfun(@(x) isempty(strfind(x,'.git')),subpath) & cellfun(@(x) isempty(strfind(x,'doc')),subpath);
         addpath(strjoin(subpath(pathsToKeep),pathsep));
         savepath


### PR DESCRIPTION
### Main improvements in this PR:
doc/fix:
- `checkInstallation`: divide external binaries into two categories and which are therefore reported separately. The essential binaries (`makeblastdb`, `blastp`, `hmmsearch`) are the ones which are used by most of the users, while the remaining ones (`cd-hit`, `mafft`, `hmmbuild`) are only used if KEGG FTP dump files are parsed in `getKEGGModelForOrganism`. The latter category is therefore not essential.
- `checkInstallation`, `checkFunctionUniqueness`: fix the printed messages to increase the clarity of the printed output

feat:
- `checkInstallation` prints correct RAVEN version (#234)
- `checkInstallation`: enable the external binaries functionality check in Windows (#252)
- `checkInstallation`: add check for `diamond`, which belongs to essential external binaries category, see above

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR