### PR TITLE
fix: optimizeProb

### DIFF
--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -26,13 +26,13 @@ if(isfield(prob,'ints')), disp('MILP detected.'); milp=true; end
 solver=getpref('RAVEN','solver');
 if strcmp(solver,'gurobi')
     gparams=struct('Presolve',2,'TimeLimit',1000,'OutputFlag',1,'MIPGap',1e-12,'Seed',0,'FeasibilityTol',1e-9,'OptimalityTol',1e-9);
-    if (~milp) gparams.OutputFlag=0; end
-    %gparams=structUpdate(gparams,params);
+    if (~milp)
+        gparams.OutputFlag=0;
+    end
     gparams=structUpdate(gparams,params);
     % remove some MOSEK-specific fields that generate warnings with Gurobi
     gparams=rmfield(gparams, intersect(fieldnames(gparams),{'MSK_IPAR_OPTIMIZER';'relGap'}));
     res = gurobi(mosekToGurobiProb(prob), gparams);
-    
     res=gurobiToMosekRes(res,length(prob.c),milp);
 elseif strcmp(solver,'cobra')
     if (milp)
@@ -60,12 +60,14 @@ else
     dispEM(['Raven solver not defined or unknown. Try using setRavenSolver(',char(39),'solver',char(39),')']);
 end
 
-    function s_merged=structUpdate(s_old,s_new)
-        %// Remove overlapping fields from first struct%// Obtain all
-        %unique names of remaining fields,%// Merge both structs
-        s_merged = rmfield(s_old, intersect(fieldnames(s_old), fieldnames(s_new)));
-        names = [fieldnames(s_merged); fieldnames(s_new)];
-        s_merged = cell2struct([struct2cell(s_merged); struct2cell(s_new)], names, 1);
-    end
+end
 
+
+function s_merged=structUpdate(s_old,s_new)
+%Remove overlapping fields from first struct;
+%Obtain all unique names of remaining fields;
+%Merge both structs
+s_merged = rmfield(s_old, intersect(fieldnames(s_old), fieldnames(s_new)));
+names = [fieldnames(s_merged); fieldnames(s_new)];
+s_merged = cell2struct([struct2cell(s_merged); struct2cell(s_new)], names, 1);
 end

--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -29,6 +29,8 @@ if strcmp(solver,'gurobi')
     if (~milp) gparams.OutputFlag=0; end
     %gparams=structUpdate(gparams,params);
     gparams=structUpdate(gparams,params);
+    % remove some MOSEK-specific fields that generate warnings with Gurobi
+    gparams=rmfield(gparams, intersect(fieldnames(gparams),{'MSK_IPAR_OPTIMIZER';'relGap'}));
     res = gurobi(mosekToGurobiProb(prob), gparams);
     
     res=gurobiToMosekRes(res,length(prob.c),milp);

--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -28,6 +28,7 @@ if strcmp(solver,'gurobi')
     gparams=struct('Presolve',2,'TimeLimit',1000,'OutputFlag',1,'MIPGap',1e-12,'Seed',0,'FeasibilityTol',1e-9,'OptimalityTol',1e-9);
     if (~milp) gparams.OutputFlag=0; end
     %gparams=structUpdate(gparams,params);
+    gparams=structUpdate(gparams,params);
     res = gurobi(mosekToGurobiProb(prob), gparams);
     
     res=gurobiToMosekRes(res,length(prob.c),milp);

--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -11,7 +11,7 @@ function res = optimizeProb(prob,params)
 %	Eduard Kerkhoven, 2016-10-22 - Use Matlab preferences for solver selection
 %
 
-if nargin<2
+if nargin<2 || isempty(params)
     params=struct();
 end
 


### PR DESCRIPTION
### Main improvements in this PR:
Fixed usage of the `params` input in the `optimizeProb` function to avoid errors and ignoring of optional parameter specification.

The `optimizeProb` function ignores the `params` input when using the Gurobi solver, preventing users (or other calling functions) to modify optimization parameters using this input. Attempting to fix this by un-commenting line 30 (`gparams=structUpdate(gparams,params);`) results in warnings from Gurobi due to the presence of Mosek-specific parameters, as well as errors due to some functions calling `optimizeProb` with `params` set to an empty double `[]`.

The problem with the Gurobi warnings was fixed by removing non-Gurobi fields (specifically `relGap` and `MSK_OPTIMIZER_FREE_SIMPLEX`) from `params` prior to passing to the `gurobi` function. This is probably not the most efficient way to do this since it is not a very generalized solution, but it works for now.

The error caused by an empty `params` input was solved by adding a second condition to the input argument check on line 14 (i.e., `|| isempty(params)`), which converts it to an empty structure that is compatible with the rest of the function (specifically the `structUpdate` sub-function).

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
