### PR TITLE
Fix: checkTasks and fitTasks

### DIFF
--- a/core/checkTasks.m
+++ b/core/checkTasks.m
@@ -181,7 +181,16 @@ for i=1:numel(taskStructure)
         end
         %Then add the normal constraints
         if any(J)
-            tModel.b(J,1)=taskStructure(i).LBout(I);
+            %Verify that IN and OUT bounds are consistent. Cannot require
+            %that a metabolite is simultaneously input AND output at some
+            %nonzero flux.
+            nonzero_LBin = tModel.b(J,2) > 0;
+            nonzero_LBout = taskStructure(i).LBout(I) > 0;
+            if any(nonzero_LBin & nonzero_LBout)
+                EM=['The IN LB and OUT LB in "[' taskStructure(i).id '] ' taskStructure(i).description '" cannot be nonzero for the same metabolite'];
+                dispEM(EM);
+            end
+            tModel.b(J(nonzero_LBout),1)=taskStructure(i).LBout(I(nonzero_LBout));
             tModel.b(J,2)=taskStructure(i).UBout(I);
         end
     end

--- a/core/checkTasks.m
+++ b/core/checkTasks.m
@@ -184,7 +184,8 @@ for i=1:numel(taskStructure)
             %Verify that IN and OUT bounds are consistent. Cannot require
             %that a metabolite is simultaneously input AND output at some
             %nonzero flux.
-            nonzero_LBin = tModel.b(J,2) > 0;
+            I = find(I);  % otherwise indexing becomes confusing
+            nonzero_LBin = tModel.b(J,2) < 0;
             nonzero_LBout = taskStructure(i).LBout(I) > 0;
             if any(nonzero_LBin & nonzero_LBout)
                 EM=['The IN LB and OUT LB in "[' taskStructure(i).id '] ' taskStructure(i).description '" cannot be nonzero for the same metabolite'];

--- a/core/fitTasks.m
+++ b/core/fitTasks.m
@@ -234,8 +234,19 @@ for i=1:numel(taskStructure)
             end
             %Then add the normal constraints
             if any(J(I))
-                tModel.b(J(I),1)=taskStructure(i).LBout(I);
-                tModel.b(J(I),2)=taskStructure(i).UBout(I);
+                %Verify that IN and OUT bounds are consistent. Cannot require
+                %that a metabolite is simultaneously input AND output at some
+                %nonzero flux.
+                J = J(I);
+                I = find(I);  % otherwise indexing becomes confusing
+                nonzero_LBin = tModel.b(J,2) < 0;
+                nonzero_LBout = taskStructure(i).LBout(I) > 0;
+                if any(nonzero_LBin & nonzero_LBout)
+                    EM=['The IN LB and OUT LB in "[' taskStructure(i).id '] ' taskStructure(i).description '" cannot be nonzero for the same metabolite'];
+                    dispEM(EM);
+                end
+                tModel.b(J(nonzero_LBout),1)=taskStructure(i).LBout(I(nonzero_LBout));
+                tModel.b(J,2)=taskStructure(i).UBout(I);
             end
         end
         


### PR DESCRIPTION
### Main improvements in this PR:
Fixes a bug in the `checkTasks` and `fitTasks` functions.

When parsing metabolite input and output bounds defined in a metabolic task, the `checkTasks` and `fitTasks` functions will overwrite the bounds if a metabolite is listed as both a potential input and output.

For example, say we define a metabolic task for which we know oxygen is involved, but aren't sure whether it will be net produced or consumed (let us assume that, in reality, it needs to be consumed):

IN | IN LB | IN UB | OUT | OUT LB | OUT UB
-- | -- | -- | -- | -- | --
O2[s];glucose[s] |   |   | H2O[s];CO2[s];O2[s] |   |

Since the bounds are not specified, they will default to 0 and 1000 for lower and upper, respectively. Therefore, we would expect the `model.b` field for these metabolites to be:

metabolite | b (lb) | b (ub)
-- | -- | --
O2[s] | -1000 | 1000
glucose[s] | -1000 | 0
H2O[s] | 0 | 1000
CO2[s] | 0 | 1000

where oxygen can be consumed **or** produced, whereas glucose can only be consumed, and H2O and CO2 can only be produced. However, the `checkTasks` and `fitTasks` functions first process the "IN" metabolites, followed by the "OUT" metabolites. Therefore, if a metabolite appears in both (like O2 in this example), its `model.b` field will be overwritten when processing the "OUT" metabolites, yielding:

metabolite | b (lb) | b (ub)
-- | -- | --
O2[s] | 0 | 1000
glucose[s] | -1000 | 0
H2O[s] | 0 | 1000
CO2[s] | 0 | 1000

Here, O2 is only allowed to be produced. Since in reality the task requires that O2 is *consumed*, it will fail.

The `checkTasks` and `fitTasks` functions have now been revised such that the "IN" settings for a metabolite will not be overwritten by the "OUT" settings if it appears in both fields.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
