### PR TITLE
fix: correct mismatch between `genes` and `grRules` fields in `getMetaCycModelOrganism`

### DIFF
--- a/external/metacyc/getMetaCycModelForOrganism.m
+++ b/external/metacyc/getMetaCycModelForOrganism.m
@@ -30,7 +30,7 @@ function model=getMetaCycModelForOrganism(organismID,fastaFile,...
 %   Usage: model=getMetaCycModelForOrganism(organismID,fastaFile,...
 %    keepTransportRxns,keepUnbalanced,keepUndetermined,minScore,minPositives,useDiamond)
 %
-%   Hao Wang, 2018-11-05
+%   Hao Wang, 2020-03-19
 %
 
 if nargin<2
@@ -172,6 +172,8 @@ for j=1:rxnNum
         end
     end
 end
+%update genes field
+model.genes=model.genes(any(model.rxnGeneMat));
 
 %Construct the S matrix and list of metabolites
 [S, mets, badRxns]=constructS(model.equations);


### PR DESCRIPTION
### Main improvements in this PR:
- fix bug in `getMetaCycModelOrganism` that output mismatched `genes` and `grRules` fields, by updating `genes` according to the newly generated `rxnGeneMat`

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
