### PR TITLE
fix: add exceptions for met KEGG and PubChem IDs

### DIFF
--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -41,7 +41,7 @@ end
 fid             = fopen('COBRA_structure_fields.csv'); % Taken from https://github.com/opencobra/cobratoolbox/blob/develop/src/base/io/definitions/COBRA_structure_fields.csv
 fieldFile       = textscan(fid,repmat('%s',1,15),'Delimiter','\t','HeaderLines',1);
 dbFields        = ~cellfun(@isempty,fieldFile{5}); % Only keep fields with database annotations that should be translated to xxxMiriams
-dbFields        = dbFields & ~contains(fieldFile{1},{'metInChIString','rxnECNumbers','rxnReferences'});
+dbFields        = dbFields & ~contains(fieldFile{1},{'metInChIString','metKEGGID','metPubChemID','rxnECNumbers','rxnReferences'});
 COBRAnamespace  = fieldFile{5}(dbFields);
 COBRAnamespace  = regexprep(COBRAnamespace,';.*',''); % Only keep first suggested namespace
 COBRAfields     = fieldFile{1}(dbFields);


### PR DESCRIPTION
### Main improvements in this PR:

As mentioned in #286, metabolite KEGG and PubChem IDs are treated differently in the COBRA wrapper, so they should be excluded from the annotation list that adds them as miriams with no changes.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch