### PR TITLE
fix: rule conversion in raven-cobra wrapper

### DIFF
--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -181,16 +181,6 @@ if isRaven
         fprintf('WARNING: no genes detected. The model therefore may not be exportable to SBML file with writeCbModel\n');
     end
     newModel.osenseStr='max';
-    
-    %It seems that grRules, rxnGeneMat and rev are disposable fields in
-    %COBRA version, but we export them to make things faster, when
-    %converting COBRA structure back to RAVEN
-    if isfield(model,'grRules')
-        [grRules, rxnGeneMat] = standardizeGrRules(model,true);
-        newModel.grRules      = grRules;
-        %Incorporate a rxnGeneMat consistent with standardized grRules
-        newModel.rxnGeneMat   = rxnGeneMat;
-    end
 else
     fprintf('Converting COBRA structure to RAVEN..\n');
     %Convert from COBRA to RAVEN structure
@@ -249,11 +239,7 @@ else
     if isfield(model,'modelName')
         newModel.description=model.modelName;
     end
-    if isfield(model,'grRules')
-        [grRules,rxnGeneMat] = standardizeGrRules(model,true);
-        newModel.grRules     = grRules;
-        newModel.rxnGeneMat  = rxnGeneMat;
-    else
+    if isfield(model,'rules')
         model.grRules        = rulesTogrrules(model);
         [grRules,rxnGeneMat] = standardizeGrRules(model,true);
         newModel.grRules     = grRules;


### PR DESCRIPTION
### Issue this PR adresses:

When converting a model from RAVEN to COBRA, the `grRules` field is kept to _"make things faster, when converting COBRA structure back to RAVEN"_. However, doing this creates conflicts if we edit gene IDs at the COBRA stage, as COBRA doesn't include gene IDs in the rule. For instance, consider the following RAVEN model:

```matlab
>> disp(model_r.grRules{27})
YALI0_A02541g
```

When converted to COBRA, the rule reads:

```matlab
>> model_c = ravenCobraWrapper(model_r);
Converting RAVEN structure to COBRA..
>> disp(model_c.rules{27})
x(5)
```

Hence, we can easily change the id of the gene (without having to touch the rule) by doing:

```matlab
model_c.genes{5} = 'test';
```

As the rule will still point to the 5th position in `genes`. However, if we do that and convert back to RAVEN, the rule is now incorrect, as it preserved what was written in `grRules` instead of interpreting `rules` again:

```matlab
>> model_r2 = ravenCobraWrapper(model_c);
Converting COBRA structure to RAVEN..
>> disp(model_r2.genes{5})
test
>> disp(model_r2.grRules{27})
YALI0_A02541g
```

### Improvement in this PR:

I propose to skip saving `grRules` when going from RAVEN to COBRA and to not look for `grRules` when going from COBRA to RAVEN, this way avoiding redundancy in rules that can lead to conflicts like the one presented above. I tested the performance impact of this change in my machine, and the conversion time COBRA->RAVEN for this model goes up from ~1.6 seconds to ~2.1 seconds, which is significant but probably ok to live with.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch