### PR TITLE
Fix/met id conversion wrapper

### DIFF
--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -90,7 +90,20 @@ if isRaven
     if all(~cellfun(@isempty,regexp(model.mets,'\[[^\]]+\]$')))
         newModel.mets=model.mets;
     else
-        newModel.mets=strcat(model.mets,'[',model.comps(model.metComps),']');
+        %Check if model has compartment info as "met_c" suffix in all metabolites:
+        BiGGformat = false(size(model.mets));
+        for i=1:numel(model.comps)
+            compPos=model.metComps==i;
+            BiGGformat(compPos)=~cellfun(@isempty,regexp(model.mets(compPos),['_' model.comps{i} '$']));
+        end
+        if all(BiGGformat)
+            newModel.mets=model.mets;
+            for i=1:numel(model.comps)
+                newModel.mets=regexprep(newModel.mets,['_' model.comps{i} '$'],['[' model.comps{i} ']']);
+            end
+        else
+            newModel.mets=strcat(model.mets,'[',model.comps(model.metComps),']');
+        end
     end
 
     %b, csense, osenseStr, genes, rules are also mandatory, but defined

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -201,8 +201,7 @@ else
     if numel(unique(newModel.mets))~=numel(model.mets)
         newModel.mets=model.mets;
         for i=1:numel(model.comps)
-            newModel.mets=regexprep(newModel.mets,'\]$','');
-            newModel.mets=regexprep(newModel.mets,['\[', model.comps{i}, '$'],['_', model.comps{i}]);
+            newModel.mets=regexprep(newModel.mets,['\[' model.comps{i} '\]$'],['_' model.comps{i}]);
         end
     end
     %Since COBRA no longer contains rev field it is assumed that rxn is

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -195,8 +195,9 @@ else
         newModel.mets=regexprep(newModel.mets,['\[', model.compNames{i}, '\]$'],'');
     end
     
-    %In some rare cases, there may be overlapping mets due to removal e.g.
-    %[c]. To avoid this, we change e.g. [c] into _c
+    %In some cases (e.g. any model that uses BiGG ids as main ids), there
+    %may be overlapping mets due to removal of compartment info. To avoid
+    %this, we change compartments from e.g. [c] into _c
     if numel(unique(newModel.mets))~=numel(model.mets)
         newModel.mets=model.mets;
         for i=1:numel(model.comps)
@@ -205,7 +206,7 @@ else
         end
     end
     %Since COBRA no longer contains rev field it is assumed that rxn is
-    %reversible if its lower bound is set to zero
+    %reversible if its lower bound is set below zero
     if ~isfield(model,'rev')
         for i=1:numel(model.rxns)
             if model.lb(i)<0


### PR DESCRIPTION
### Main improvements in this PR:

`ravenCobraWrapper` properly identifies when a COBRA model comes with non-unique metabolite ids after removing the compartment info, as it is common with BiGG models. For instance, `pydx5p[c]` will be non-unique after removing the `[c]` suffix, so then it will be converted to `pydx5p_c`. However, it fails to detect this when going from RAVEN to COBRA, and simply adds an additional suffix: in this case  `pydx5p_c` will be converted to `pydx5p_c[c]`, which is undesired. This PR fixes that by detecting if **every** metabolite from the RAVEN model comes in the `met_comp` format, and if so replacing them by `met[comp]`.

#### Behavior Before

```matlab
>> tic;model_r = ravenCobraWrapper(model);toc
   Converting COBRA structure to RAVEN..
   Elapsed time is 1.364645 seconds.
>> tic;model_c = ravenCobraWrapper(model_r);toc
   Converting RAVEN structure to COBRA..
   Elapsed time is 4.205101 seconds.
>> disp(model_c.mets{1})
   pydx5p_c[c]
```

#### Behavior After

```matlab
>> tic;model_r = ravenCobraWrapper(model);toc
   Converting COBRA structure to RAVEN..
   Elapsed time is 1.282803 seconds.
>> tic;model_c = ravenCobraWrapper(model_r);toc
   Converting RAVEN structure to COBRA..
   Elapsed time is 4.039938 seconds.
>> disp(model_c.mets{1})
   pydx5p[c]
```

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch