### PR TITLE
feat: exportForGit folder behaviour & import COBRA modelID

### DIFF
--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -18,13 +18,13 @@ function out=exportForGit(model,prefix,path,formats,masterFlag,subDirs)
 %                       (opt, default false)
 %   subDirs             logical, whether model files for each file format 
 %                       should be written in its own subdirectory, with
-%                       'models' as parent directory, in accordance to the
+%                       'model' as parent directory, in accordance to the
 %                       standard-GEM repository format. If false, all files
-%                       are stored in the same folder. (opt, default false)
+%                       are stored in the same folder. (opt, default true)
 %
 %   Usage: exportForGit(model,prefix,path,formats,masterFlag)
 if nargin<6
-    subDirs=false;
+    subDirs=true;
 end
 if nargin<5
     masterFlag=false;
@@ -64,7 +64,7 @@ end
 
 % Make models folder, no warnings if folder already exists
 if subDirs
-    path=fullfile(path,'models');
+    path=fullfile(path,'model');
     filePath=strcat(path,filesep,{'txt','yml','mat','xlsx','xml'});
     [~,~,~]=mkdir(path);
     for i = 1:length(formats)

--- a/io/exportForGit.m
+++ b/io/exportForGit.m
@@ -1,4 +1,4 @@
-function out=exportForGit(model,prefix,path,formats,masterFlag)
+function out=exportForGit(model,prefix,path,formats,masterFlag,subDirs)
 % exportForGit
 %   Generates a directory structure and populates this with model files, ready
 %   to be commited to a Git(Hub) maintained model repository. Writes the model
@@ -16,12 +16,20 @@ function out=exportForGit(model,prefix,path,formats,masterFlag)
 %   masterFlag          logical, if true, function will error if RAVEN (and
 %                       COBRA if detected) is/are not on the master branch.
 %                       (opt, default false)
+%   subDirs             logical, whether model files for each file format 
+%                       should be written in its own subdirectory, with
+%                       'models' as parent directory, in accordance to the
+%                       standard-GEM repository format. If false, all files
+%                       are stored in the same folder. (opt, default false)
 %
 %   Usage: exportForGit(model,prefix,path,formats,masterFlag)
+if nargin<6
+    subDirs=false;
+end
 if nargin<5
     masterFlag=false;
 end
-if nargin<4
+if nargin<4 || isempty(formats)
     formats={'mat', 'txt', 'xlsx', 'xml', 'yml'};
 end
 if ischar(formats)
@@ -54,15 +62,22 @@ catch % before 5.17.0
     delete('tempModelForLibSBMLversion.xml');
 end
 
-% Make ModelFiles folder, no warnings if folder already exists
-[~,~,~]=mkdir(fullfile(path,'ModelFiles'));
-for i = 1:length(formats)
-    [~,~,~]=mkdir(fullfile(path,'ModelFiles',formats{i}));
+% Make models folder, no warnings if folder already exists
+if subDirs
+    path=fullfile(path,'models');
+    filePath=strcat(path,filesep,{'txt','yml','mat','xlsx','xml'});
+    [~,~,~]=mkdir(path);
+    for i = 1:length(formats)
+        [~,~,~]=mkdir(fullfile(path,formats{i}));
+    end
+else
+    filePath=cell(1,5); filePath(:)={path};
 end
+
 
 % Write TXT format
 if ismember('txt', formats)
-    fid=fopen(fullfile(path,'ModelFiles','txt',strcat(prefix,'.txt')),'w');
+    fid=fopen(fullfile(filePath{1},strcat(prefix,'.txt')),'w');
     eqns=constructEquations(model,model.rxns,false,false,false,true);
     eqns=strrep(eqns,' => ','  -> ');
     eqns=strrep(eqns,' <=> ','  <=> ');
@@ -81,26 +96,26 @@ end
 
 % Write YML format
 if ismember('yml', formats)
-    writeYaml(model,fullfile(path,'ModelFiles','yml',strcat(prefix,'.yml')));
+    writeYaml(model,fullfile(filePath{2},strcat(prefix,'.yml')));
 end
 
 % Write MAT format
 if ismember('mat', formats)
-    save(fullfile(path,'ModelFiles','mat',strcat(prefix,'.mat')),'model');
+    save(fullfile(filePath{3},strcat(prefix,'.mat')),'model');
 end
 
 % Write XLSX format
 if ismember('xlsx', formats)
-    exportToExcelFormat(model,fullfile(path,'ModelFiles','xlsx',strcat(prefix,'.xlsx')));
+    exportToExcelFormat(model,fullfile(filePath{4},strcat(prefix,'.xlsx')));
 end
 
 % Write XML format
 if ismember('xml', formats)
-    exportModel(model,fullfile(path,'ModelFiles','xml',strcat(prefix,'.xml')));
+        exportModel(model,fullfile(filePath{5},strcat(prefix,'.xml')));
 end
 
 %Save file with versions:
-fid = fopen(fullfile(path,'ModelFiles','dependencies.txt'),'wt');
+fid = fopen(fullfile(path,'dependencies.txt'),'wt');
 fprintf(fid,['MATLAB\t' version '\n']);
 fprintf(fid,['libSBML\t' libSBMLver '\n']);
 fprintf(fid,['RAVEN_toolbox\t' RAVENver '\n']);

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -746,7 +746,7 @@ reactionObjective=reactionObjective(1:counter);
 S=S(:,1:counter);
 
 model.description=modelSBML.name;
-model.id=modelSBML.id;
+model.id=regexprep(modelSBML.id,'^M_',''); % COBRA adds M_ prefix
 model.rxns=reactionIDs;
 model.mets=metaboliteIDs;
 model.S=sparse(S);
@@ -1015,6 +1015,7 @@ model.mets=regexprep(model.mets,'__([0-9]+)__','${char(str2num($1))}');
 model.comps=regexprep(model.comps,'__([0-9]+)__','${char(str2num($1))}');
 model.grRules=regexprep(model.grRules,'__([0-9]+)__','${char(str2num($1))}');
 model.genes=regexprep(model.genes,'__([0-9]+)__','${char(str2num($1))}');
+model.id=regexprep(model.id,'__([0-9]+)__','${char(str2num($1))}');
 
 %Remove unused fields
 if isempty(model.annotation)


### PR DESCRIPTION
### Main improvements in this PR:
- feat:
  - `exportForGit`: more flexible folder selection with `subDirs` flag to write all files in one folder, or model-specific subfolders.
- fix:
  - `importModel`: COBRA `writeCbModel` adds M_ prefix to `modelID`. Unlikely that such prefix is meant to be included in `model.id`, remove this prefix when importing SBML file.

~~Will keep this PR open until https://github.com/MetabolicAtlas/standard-GEM/issues/4 is resolved, to provide the correct model folder name.~~

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR