### PR TITLE
fix: add check for query file existence in MetaCyc reconstruction

### DIFF
--- a/external/metacyc/getEnzymesFromMetaCyc.m
+++ b/external/metacyc/getEnzymesFromMetaCyc.m
@@ -67,8 +67,9 @@ metaCycProteinFile='proteins.dat';
 metaCycEnzrxnsFile='enzrxns.dat';
 
 if exist(enzymesFile, 'file')
-    fprintf(['NOTE: Importing MetaCyc enzymes and reaction-enzyme association from ' strrep(enzymesFile,'\','/') '.\n']);
+    fprintf(['Importing MetaCyc enzymes and reaction-enzyme association from ' strrep(enzymesFile,'\','/') '... ']);
     load(enzymesFile);
+    fprintf('done\n');
 else
     fprintf(['Cannot locate ' strrep(enzymesFile,'\','/') '\nNow try to generate it from local MetaCyc data files...\n']);
     if ~exist(fullfile(metacycPath,metaCycProteinFile),'file') || ~exist(fullfile(metacycPath,metaCycEnzrxnsFile),'file')

--- a/external/metacyc/getMetaCycModelForOrganism.m
+++ b/external/metacyc/getMetaCycModelForOrganism.m
@@ -56,9 +56,10 @@ end
 if isempty(fastaFile)
     error('*** The query FASTA filename cannot be empty! ***');
 else
-    fprintf('\n\n*** Check existence of query FASTA file ***\n\n');
+    fprintf('\nChecking existence of query FASTA file... ');
     %Check if query fasta exists
     fastaFile=checkFileExistence(fastaFile,true,false);
+    fprintf('done\n');
 end
 
 %First generate the full MetaCyc model

--- a/external/metacyc/getMetaCycModelForOrganism.m
+++ b/external/metacyc/getMetaCycModelForOrganism.m
@@ -53,6 +53,14 @@ if nargin<8
     useDiamond=true;
 end
 
+if isempty(fastaFile)
+    error('*** The query FASTA filename cannot be empty! ***');
+else
+    fprintf('\n\n*** Check existence of query FASTA file ***\n\n');
+    %Check if query fasta exists
+    fastaFile=checkFileExistence(fastaFile,true,false);
+end
+
 %First generate the full MetaCyc model
 metaCycModel=getModelFromMetaCyc([],keepTransportRxns,keepUnbalanced,keepUndetermined);
 fprintf('The full MetaCyc model loaded\n');

--- a/external/metacyc/getMetsFromMetaCyc.m
+++ b/external/metacyc/getMetsFromMetaCyc.m
@@ -63,8 +63,9 @@ metsFile=fullfile(ravenPath,'external','metacyc','metaCycMets.mat');
 metaCycMetFile='compounds.dat';
 
 if exist(metsFile, 'file')
-    fprintf(['NOTE: Importing MetaCyc metabolites from ' strrep(metsFile,'\','/') '.\n']);
+    fprintf(['Importing MetaCyc metabolites from ' strrep(metsFile,'\','/') '... ']);
     load(metsFile);
+    fprintf('done\n');
 else
     fprintf(['Cannot locate ' strrep(metsFile,'\','/') '\nNow try to generate it from local MetaCyc data files...\n']);
     if ~exist(fullfile(metacycPath,metaCycMetFile),'file')

--- a/external/metacyc/getModelFromMetaCyc.m
+++ b/external/metacyc/getModelFromMetaCyc.m
@@ -48,11 +48,9 @@ end
 
 %First get all reactions
 metaCycModel=getRxnsFromMetaCyc(metacycPath,keepTransportRxns,keepUnbalanced,keepUndetermined);
-fprintf('MetaCyc reactions loaded\n');
 
 %Get reaction and enzyme association
 metaCycEnzymes=getEnzymesFromMetaCyc(metacycPath);
-fprintf('MetaCyc enzymes loaded\n');
 
 %Replace rxnNames with those from metaCycEnzymes
 [a, b]=ismember(metaCycModel.rxns,metaCycEnzymes.rxns);
@@ -60,6 +58,7 @@ a=find(a);
 b=b(a);
 metaCycModel.rxnNames(a)=metaCycEnzymes.rxnNames(b);
 
+fprintf('Reorganizing reaction-enzyme associations... ')
 %Create the rxnGeneMat for the reactions, by geting all enzymes and
 %corresponding subunits
 rxnNum=numel(metaCycModel.rxns);
@@ -121,10 +120,9 @@ for i=1:rxnNum
         
     end
 end
-
+fprintf('done\n')
 %Then get all metabolites
 metaCycMets=getMetsFromMetaCyc(metacycPath);
-fprintf('MetaCyc compounds loaded\n');
 
 %Add information about all metabolites to the model
 [a, b]=ismember(metaCycModel.mets,metaCycMets.mets);

--- a/external/metacyc/getRxnsFromMetaCyc.m
+++ b/external/metacyc/getRxnsFromMetaCyc.m
@@ -88,8 +88,9 @@ metaCycRxnFile='reactions.dat';
 metaCycPwyFile='pathway-links.dat';
 
 if exist(rxnsFile, 'file')
-    fprintf(['NOTE: Importing MetaCyc reactions from ' strrep(rxnsFile,'\','/') '.\n']);
+    fprintf(['Importing MetaCyc reactions from ' strrep(rxnsFile,'\','/') '... ']);
     load(rxnsFile);
+    fprintf('done\n');
 else
     fprintf(['Cannot locate ' strrep(rxnsFile,'\','/') '\nNow try to generate it from local MetaCyc data files...\n']);
     if ~exist(fullfile(metacycPath,metaCycRxnFile),'file') || ~exist(fullfile(metacycPath,metaCycPwyFile),'file')


### PR DESCRIPTION
### Main improvements in this PR:
* Add check for the existence of query FASTA file under current path in `getMetaCycModelForOrganism` function

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [X] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
