### PR TITLE
chore: update parseHPA and parseHPArna

### DIFF
--- a/hpa/parseHPA.m
+++ b/hpa/parseHPA.m
@@ -6,14 +6,14 @@ function hpaData=parseHPA(fileName, version)
 %   fileName            comma- or tab-separated database dump of HPA. For details
 %                       regarding the format, see
 %                       http://www.proteinatlas.org/about/download.
-%   version             version of HPA [optional, default=18]
+%   version             version of HPA [optional, default=19]
 %
 %
 %   Output:
 %   hpaData
 %       genes               cell array with the unique gene names. In
-%                           version 18 this is the ensemble name, see
-%                           geneNames below for the names in ver 18
+%                           version >=18 this is the ensemble name, see
+%                           geneNames below for the names in ver >=18
 %       geneNames           cell array with the gene names, indexed the
 %                           same way as genes.
 %       tissues             cell array with the tissue names. The list may not be
@@ -29,7 +29,7 @@ function hpaData=parseHPA(fileName, version)
 %       gene2Type           gene-to-evidence type mapping in sparse matrix form.
 %                           The value for element i,j is the index in
 %                           hpaData.types of gene i in cell type j. Doesn't
-%                           exist in version 18.
+%                           exist in version >=18.
 %       gene2Reliability    gene-to-reliability level mapping in sparse matrix form.
 %                           The value for element i,j is the index in
 %                           hpaData.reliabilities of gene i in cell type j
@@ -37,7 +37,7 @@ function hpaData=parseHPA(fileName, version)
 %   Usage: hpaData=parseHPA(fileName,version)
 
 if nargin<2
-    version=18; %Change this and add code for more versions when the current HPA version is increased and the format is changed
+    version=19; %Change this and add code for more versions when the current HPA version is increased and the format is changed
 end
 
 if ~(exist(fileName,'file')==2)

--- a/hpa/parseHPArna.m
+++ b/hpa/parseHPArna.m
@@ -6,7 +6,7 @@ function arrayData=parseHPArna(fileName, version)
 %   fileName            tab-separated database dump of HPA RNA data. For
 %                       details regarding the format, see
 %                       http://www.proteinatlas.org/about/download.
-%   version             version of HPA [optional, default=18]
+%   version             version of HPA [optional, default=19]
 %
 %
 %   Output:
@@ -23,39 +23,47 @@ function arrayData=parseHPArna(fileName, version)
 if nargin<2
     %Change this and add code for more versions when the current HPA
     %version is increased and the format is changed
-    version=18;
+    version=19;
 end
 
 if ~(exist(fileName,'file')==2)
-    error('HPA file %s cannot be found',string(fileName));
+    error('HPA file %s cannot be found', string(fileName));
 end
 
-if (version == 18)
-    fid=fopen(fileName,'r');
-    hpa=textscan(fid,'%q %q %q %q %q','Delimiter','\t');
-    fclose(fid);
-    
-    %Go through and see if the headers match what was expected
+%NOTE! This function assumes that the first 4 columns contain (in order):
+% (1) gene ensembl ID, (2) gene abbrev, (3) tissue name,  (4) TPM value
+if (version == 19)
+    headers={'Gene' 'Gene name' 'Tissue' 'TPM' 'pTPM' 'NX'};
+elseif (version == 18)
     headers={'Gene' 'Gene name' 'Sample' 'Value' 'Unit'};
-    for i=1:numel(headers)
-        if ~strcmpi(headers(i),hpa{i}(1))
-            EM=['Could not find the header "' headers{i} '". Make sure that the input file matches the format specified at http://www.proteinatlas.org/about/download'];
-            dispEM(EM);
-        end
-        %Remove the header line here
-        hpa{i}(1)=[];
-    end
-    
-    %Get unique gene IDs and tissue names
-    [arrayData.genes, P, I] = unique(hpa{1});
-    arrayData.geneNames = hpa{2}(P);  % retrieve corresponding gene names
-    [arrayData.tissues, ~, J] = unique(hpa{3});
-    
-    %Now extract the gene levels and organize into matrix
-    arrayData.levels = NaN(max(I),max(J));
-    linearInd = sub2ind(size(arrayData.levels),I,J);
-    arrayData.levels(linearInd) = str2double(hpa{4});
-    
 else
-    error('Previous HPA versions (before 18) not currently supported.');
+    error('Only HPA versions 18 and 19 are currently supported.');
 end
+
+%extract data from file
+formatSpec = strip(repmat('%q ', 1, numel(headers)));
+fid=fopen(fileName, 'r');
+hpa=textscan(fid, formatSpec, 'Delimiter', '\t');
+fclose(fid);
+
+%Go through and see if the headers match what was expected
+for i=1:numel(headers)
+    if ~strcmpi(headers(i),hpa{i}(1))
+        EM=['Could not find the header "' headers{i} '". Make sure that the input file matches the format specified at http://www.proteinatlas.org/about/download'];
+        dispEM(EM);
+    end
+    %Remove the header line here
+    hpa{i}(1)=[];
+end
+
+%Get unique gene IDs and tissue names
+[arrayData.genes, P, I] = unique(hpa{1});
+arrayData.geneNames = hpa{2}(P);  % retrieve corresponding gene names
+[arrayData.tissues, ~, J] = unique(hpa{3});
+
+%Now extract the gene levels and organize into matrix
+arrayData.levels = NaN(max(I),max(J));
+linearInd = sub2ind(size(arrayData.levels),I,J);
+arrayData.levels(linearInd) = str2double(hpa{4});
+    
+


### PR DESCRIPTION
### Main improvements in this PR:
Updated `parseHPA` and `parseHPArna` functions for latest version of Human Protein Atlas (HPA), version 19.

The formatting of the protein data did not change, and therefore `parseHPA` only required very minor changes, mostly to comments.

The column names and number of columns for the RNA data is different in version 19. Therefore, the `parseHPArna` function required more changes. The function was also refactored to reduce the amount of repeated code and separate the pieces that actually differ between versions.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
