### PR TITLE
fix: remove the boundary compartment when removing boundary mets in `simplifyModel`

### DIFF
--- a/core/simplifyModel.m
+++ b/core/simplifyModel.m
@@ -72,15 +72,8 @@ if deleteUnconstrained==true
     if isfield(reducedModel,'unconstrained')
         %Remove unbalanced metabolites
         deletedMetabolites=reducedModel.mets(reducedModel.unconstrained~=0);
-        reducedModel=removeMets(reducedModel,reducedModel.unconstrained~=0);
+        reducedModel=removeMets(reducedModel,reducedModel.unconstrained~=0,false,false,false,true);
         reducedModel=rmfield(reducedModel,'unconstrained');
-        % remove the boundary compartment if exist
-        if ismember('boundary',lower(reducedModel.compNames))
-            reducedModel.compNames(ismember(reducedModel.compNames,'Boundary')) = [];
-        end
-        if ismember('x',reducedModel.comps)
-            reducedModel.comps(ismember(reducedModel.comps,'x')) = [];
-        end
     end
 end
 

--- a/core/simplifyModel.m
+++ b/core/simplifyModel.m
@@ -74,6 +74,13 @@ if deleteUnconstrained==true
         deletedMetabolites=reducedModel.mets(reducedModel.unconstrained~=0);
         reducedModel=removeMets(reducedModel,reducedModel.unconstrained~=0);
         reducedModel=rmfield(reducedModel,'unconstrained');
+        % remove the boundary compartment if exist
+        if ismember('boundary',lower(reducedModel.compNames))
+            reducedModel.compNames(ismember(reducedModel.compNames,'Boundary')) = [];
+        end
+        if ismember('x',reducedModel.comps)
+            reducedModel.comps(ismember(reducedModel.comps,'x')) = [];
+        end
     end
 end
 


### PR DESCRIPTION
### Main improvements in this PR:
* This fix allows also removing boundary compartment from `comps` and `compNames` fields when removing boundary metabolites by `simplifyModel`.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
