### PR TITLE
Fix/remove genes

### DIFF
--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -20,57 +20,59 @@ function reducedModel = removeGenes(model,genesToRemove,removeUnusedMets,removeB
 if nargin<3
     removeUnusedMets = false;
 end
-
 if nargin<4
     removeBlockedRxns = false;
 end
-
 if nargin<5
     standardizeRules = true;
 end
-
 %Format grRules and rxnGeneMatrix:
 if standardizeRules
-    [grRules,rxnGeneMat] = standardizeGrRules(model,true);
-    model.grRules = grRules;
+    [grRules,rxnGeneMat,toCheck] = standardizeGrRules(model,true);
+    model.grRules    = grRules;
     model.rxnGeneMat = rxnGeneMat;
 end
-
 reducedModel = model;
-
 %Only remove genes that are actually in the model
 try
     ischar(genesToRemove{1});
     genesToRemove=genesToRemove(ismember(genesToRemove,model.genes));
 end
-
 if ~isempty(genesToRemove)
     indexesToRemove = getIndexes(model,genesToRemove,'genes');
     if ~isempty(indexesToRemove)
         %Make 0 corresponding columns from rxnGeneMat:
-        reducedModel.rxnGeneMat(:,indexesToRemove) = 0;
-        
-        genes        = model.genes(indexesToRemove);
-        canCarryFlux = true(size(model.rxns));
-        
+        reducedModel.rxnGeneMat(:,indexesToRemove) = 0;        
+        genes = model.genes(indexesToRemove);
+        %Check if conflicting grRules contain any of the genes to remove
+        if ~isempty(toCheck)
+            for i=1:numel(toCheck)
+                index   = toCheck(i);
+                gIdxs   = find(rxnGeneMat(index,:));
+                g2check = model.genes(gIdxs);
+                if any(ismember(g2check,genes))
+                    warning(['Conflicting grRule #' num2str(index) ' (' model.rxns{index} ') contains at least one of the genes to be removed, this grRule will be bypassed in order to avoid logical errors'])
+                end
+            end
+        end
+        canCarryFlux = true(size(model.rxns));       
         %Loop through genes and adapt rxns:
         for i = 1:length(genes)
             %Find all reactions for this gene and loop through them:
             isGeneInRxn = ~cellfun(@isempty,strfind(reducedModel.grRules,genes{i}));
             for j = 1:length(reducedModel.grRules)
-                if isGeneInRxn(j) && canCarryFlux(j)
-                    grRule = reducedModel.grRules{j};
-                    
-                    %Check if rxn can carry flux without this gene:
-                    canCarryFlux(j) = canRxnCarryFlux(reducedModel,grRule,genes{i});
-                    
-                    %Adapt gene rule & gene matrix:
-                    grRule = removeGeneFromRule(grRule,genes{i});
-                    reducedModel.grRules{j} = grRule;
+                if ~ismember(j,toCheck)
+                    if isGeneInRxn(j) && canCarryFlux(j)
+                        grRule = reducedModel.grRules{j};
+                        %Check if rxn can carry flux without this gene:
+                        canCarryFlux(j) = canRxnCarryFlux(reducedModel,grRule,genes{i});
+                        %Adapt gene rule & gene matrix:
+                        grRule = removeGeneFromRule(grRule,genes{i});
+                        reducedModel.grRules{j} = grRule;
+                    end
                 end
             end
-        end
-        
+        end        
         %Delete or block the reactions that cannot carry flux:
         if removeBlockedRxns
             rxnsToRemove = reducedModel.rxns(~canCarryFlux);
@@ -82,7 +84,12 @@ if ~isempty(genesToRemove)
         end
     end
 end
-
+%Format grRules and rxnGeneMatrix:
+if standardizeRules
+    [grRules,rxnGeneMat] = standardizeGrRules(reducedModel,true);
+    reducedModel.grRules = grRules;
+    reducedModel.rxnGeneMat = rxnGeneMat;
+end
 end
 
 function canIt = canRxnCarryFlux(model,geneRule,geneToRemove)

--- a/core/removeGenes.m
+++ b/core/removeGenes.m
@@ -31,6 +31,9 @@ if standardizeRules
     [grRules,rxnGeneMat,toCheck] = standardizeGrRules(model,true);
     model.grRules    = grRules;
     model.rxnGeneMat = rxnGeneMat;
+else
+    toCheck    = [];
+    rxnGeneMat = model.rxnGeneMat;
 end
 reducedModel = model;
 %Only remove genes that are actually in the model
@@ -62,20 +65,18 @@ if ~isempty(genesToRemove)
             geneRxns = find(rxnGeneMat(:,indexesToRemove(i)));
             if ~isempty(geneRxns)
                 for j = 1:numel(geneRxns)
-                    index = geneRxns(j);
-                    if ~ismember(index,toCheck)
-                        if canCarryFlux(index)
-                            grRule = reducedModel.grRules{index};
-                            %Check if rxn can carry flux without this gene:
-                            canCarryFlux(index) = canRxnCarryFlux(reducedModel,grRule,genes{i});
-                            %Adapt gene rule & gene matrix:
-                            grRule = removeGeneFromRule(grRule,genes{i});
-                            reducedModel.grRules{index} = grRule;
-                        end
+                    index  = geneRxns(j);
+                    grRule = reducedModel.grRules{index};
+                    if ~ismember(index,toCheck) && canCarryFlux(index) && ~isempty(grRule)
+                        %Check if rxn can carry flux without this gene:
+                        canCarryFlux(index) = canRxnCarryFlux(reducedModel,grRule,genes{i});
+                        %Adapt gene rule & gene matrix:
+                        grRule = removeGeneFromRule(grRule,genes{i});
+                        reducedModel.grRules{index} = grRule;
                     end
                 end
             end
-        end        
+        end
         %Delete or block the reactions that cannot carry flux:
         if removeBlockedRxns
             rxnsToRemove = reducedModel.rxns(~canCarryFlux);


### PR DESCRIPTION
### Main improvements in this PR:
- fix bug where `canRxnCarryFlux` (embeded in `removeGenes`) failed to evaluate if rxns with non-standardized grRules can carry any flux. These reactions are identified  first by `standardizeGrRules`, for each of them the genes to be removed are searched in the grRule and if a match is found then the rxn is bypassed and a warning message indicating the reaction ID and number is returned.

- Speed-up `removeGenes` function by restricting loops to `grRules` related to each of the genes to be removed, instead  of looping through all `grRules` for each gene case.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
