### PR TITLE
fix: exportModel prevent duplicated InChI prefix

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -335,7 +335,7 @@ for i=1:numel(model.mets)
                     modelSBML.species(i).annotation=[modelSBML.species(i).annotation getMiriam(model.metMiriams{i})];
                 end
                 if hasInchi==true
-                    modelSBML.species(i).annotation=[modelSBML.species(i).annotation '<rdf:li rdf:resource="https://identifiers.org/inchi/InChI=' model.inchis{i} '"/>'];
+                    modelSBML.species(i).annotation=[modelSBML.species(i).annotation '<rdf:li rdf:resource="https://identifiers.org/inchi/InChI=' regexprep(model.inchis{i},'^InChI=','') '"/>'];
                 end
                 modelSBML.species(i).annotation=[modelSBML.species(i).annotation '</rdf:Bag></bqbiol:is></rdf:Description></rdf:RDF></annotation>'];
             end


### PR DESCRIPTION
### Main improvements in this PR:
The `exportModel` function will by default add the `InChI=` prefix to entries in the model `inchis` field prior to exporting. If the model's InChI strings already contain this prefix, it will be duplicated in the exported file and cause SBML loading errors.

This PR makes a small modification to the `exportModel` function, which will strip the `InChI=` prefix from InChI strings if it exists, prior to re-adding the prefix. In other words, it will work whether or not a model contains the `InChI=` prefix in the InChI strings.

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
