### PR TITLE
fix: add chemical formula to metabolites with associated inchi string

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -336,6 +336,7 @@ for i=1:numel(model.mets)
                 end
                 if hasInchi==true
                     modelSBML.species(i).annotation=[modelSBML.species(i).annotation '<rdf:li rdf:resource="https://identifiers.org/inchi/InChI=' regexprep(model.inchis{i},'^InChI=','') '"/>'];
+                    modelSBML.species(i).fbc_chemicalFormula=char(regexp(model.inchis{i}, '/(\w+)/', 'tokens', 'once'));
                 end
                 modelSBML.species(i).annotation=[modelSBML.species(i).annotation '</rdf:Bag></bqbiol:is></rdf:Description></rdf:RDF></annotation>'];
             end


### PR DESCRIPTION
### Main improvements in this PR:
When exporting the chemical formula of a metabolite, the `exportModel` function will only use the `metFormulas` field if the corresponding `inchis` field for that metabolite is missing. According to a comment in the function, the formula is instead retrieved from the `inchis` field if it exists ([lines 322-323 of `exportModel`](https://github.com/SysBioChalmers/RAVEN/blob/0a6efab6a3a7a05d6978c3ad6c4737f530f06f8e/io/exportModel.m#L322-L323)):

```
%Only export formula if there is no InChI. This is because
%the metFormulas field is populated by InChIs if available
```

However, I noticed that when a metabolite does have an `inchis` entry, the formula is never actually extracted from the InChI string. This results in a missing `fbc:chemicalFormula` field for that metabolite in the exported SBML file.

This PR adds a line to the `exportModel` function that extracts the chemical formula from the InChI string (if available), as promised by the original comment.


**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch

