### PR TITLE
fix: ravenCobraWrapper PubMed ID parsing

### DIFF
--- a/io/writeYaml.m
+++ b/io/writeYaml.m
@@ -247,7 +247,7 @@ if isfield(model,fieldName)
         %All other fields:
         if strcmp(type,'txt')
             value = field{pos};
-            if preserveQuotes
+            if preserveQuotes && ~isempty(value)
                 value = strcat('"',value,'"');
             end
         elseif strcmp(type,'num')

--- a/io/writeYaml.m
+++ b/io/writeYaml.m
@@ -210,19 +210,19 @@ if isfield(model,fieldName)
         elseif strcmp(fieldName,'newMetMiriams')
             index = str2double(regexprep(name,'^.+_',''));
             name  = regexprep(name,'_\d+$','');
-            list = strsplit(model.newMetMiriams{pos,index},';');
+            list = strsplit(model.newMetMiriams{pos,index},'; ');
         elseif strcmp(fieldName,'newRxnMiriams')
             index = str2double(regexprep(name,'^.+_',''));
             name  = regexprep(name,'_\d+$','');
-            list = strsplit(model.newRxnMiriams{pos,index},';');
+            list = strsplit(model.newRxnMiriams{pos,index},'; ');
         elseif strcmp(fieldName,'newGeneMiriams')
             index = str2double(regexprep(name,'^.+_',''));
             name  = regexprep(name,'_\d+$','');
-            list = strsplit(model.newGeneMiriams{pos,index},';');
+            list = strsplit(model.newGeneMiriams{pos,index},'; ');
         elseif strcmp(fieldName,'newCompMiriams')
             index = str2double(regexprep(name,'^.+_',''));
             name  = regexprep(name,'_\d+$','');
-            list = strsplit(model.newCompMiriams{pos,index},';');
+            list = strsplit(model.newCompMiriams{pos,index},'; ');
         else
             list = strrep(field{pos},' ','');     %Exception for eccodes
             list = strsplit(list,';');

--- a/struct_conversion/extractMiriam.m
+++ b/struct_conversion/extractMiriam.m
@@ -85,7 +85,7 @@ for i=1:size(tempMiriams,1)
         if j==1
             miriams{i,1}=strcat(miriamName,'/',tempMiriams{i,1});
         else
-            miriams{i,1}=strcat(miriams{i,1},';',miriamName,'/',tempMiriams{i,j});
+            miriams{i,1}=strcat(miriams{i,1},'; ',miriamName,'/',tempMiriams{i,j});
         end
     end
 end
@@ -93,9 +93,9 @@ end
 %Ensure that cell positions without miriams are blank
 miriams=regexprep(miriams,strcat(miriamName,'/;'),'');
 miriams=regexprep(miriams,strcat('^',miriamName,'/$'),'');
-miriams=regexprep(miriams,strcat(';',miriamName,'/$'),'');
+miriams=regexprep(miriams,strcat('; ',miriamName,'/$'),'');
 
 %Delete middle names:
-miriams=regexprep(miriams,strcat(';',miriamName,'/'),';');
+miriams=regexprep(miriams,strcat('; ',miriamName,'/'),'; ');
 
 end

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -131,8 +131,8 @@ if isRaven
     end
     if isfield(model,'rxnReferences') % Concatenate model.rxnReferences to those extracted from model.rxnMiriams
         if isfield(newModel,'rxnReferences')
-            newModel.rxnReferences = strcat(newModel.rxnReferences,';',model.rxnReferences);
-            newModel.rxnReferences = regexprep(newModel.rxnReferences,'^;$','');
+            newModel.rxnReferences = strcat(newModel.rxnReferences,{'; '},model.rxnReferences);
+            newModel.rxnReferences = regexprep(newModel.rxnReferences,'^; $','');
         else
             newModel.rxnReferences = model.rxnReferences;
         end
@@ -269,7 +269,7 @@ else
     if isfield(model,'rxnECNumbers')
         newModel.eccodes=regexprep(model.rxnECNumbers,'EC|EC:','');
     end
-    if any(isfield(model,[rxnCOBRAfields;'rxnReferences']))
+    if any(isfield(model,rxnCOBRAfields))
         for i=1:numel(model.rxns)
             counter=1;
             newModel.rxnMiriams{i,1}=[];
@@ -289,7 +289,7 @@ else
                     end
                 end
             end
-            for j = 1:length(rxnCOBRAfields)
+            for j = 2:length(rxnCOBRAfields) %Start from 2, as 1 is rxnReferences
                 if isfield(model,rxnCOBRAfields{j})
                     rxnAnnotation = eval(['model.' rxnCOBRAfields{j} '{i}']);
                     if ~isempty(rxnAnnotation)


### PR DESCRIPTION
### Main improvements in this PR:
- fix
  - `ravenCobraWrapper` parsing `rxnReferences`-field and `pubmed` entries in `rxnMiriams`-field. When converting COBRA -> RAVEN, if `rxnReferences` entry is all numeric, it is assumed to be a PubMed ID and kept in `rxnMiriams`, otherwise `rxnReferences` is kept. For RAVEN -> COBRA, `rxnReferences` and `pubmed` entries from `rxnMiriams` are concatenated. Also use `pubmed` instead of `pmid` as indicating for PubMed IDs. This behaviour is now the same as if the model was directly loaded via RAVEN or COBRA.
  - `writeYaml` avoid empty entries.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch