### PR TITLE
fix: getModelFromHomology deals with complexes

### DIFF
--- a/core/deleteUnusedGenes.m
+++ b/core/deleteUnusedGenes.m
@@ -1,13 +1,18 @@
-function reducedModel=deleteUnusedGenes(model)
+function reducedModel=deleteUnusedGenes(model,verbose)
 % deleteUnusedGenes
 %   Deletes all genes that are not associated to any reaction
 %
 %   model           a model structure
+%   verbose         0 for silent; 1 for printing number of deleted genes;
+%                   2 for printing the list of deleted genes (opt, default 1)
 %
 %   reducedModel    an updated model structure
 %
 %   Usage: reducedModel=deleteUnusedGenes(model)
 
+if nargin<2
+    verbose=1;
+end
 reducedModel=model;
 
 %Find all genes that are not used
@@ -15,11 +20,18 @@ reducedModel=model;
 toKeep=false(numel(reducedModel.genes),1);
 toKeep(b)=true;
 
+switch verbose
+    case 1
+        disp('Number of unused genes removed from the model:')
+        disp(numel(toKeep(~toKeep)))
+    case 2
+        disp('The following genes were removed from the model:')
+        disp(reducedModel.genes(~toKeep))
+    case 0
+end
+        
 reducedModel.genes=reducedModel.genes(toKeep);
 reducedModel.rxnGeneMat=reducedModel.rxnGeneMat(:,toKeep);
-
-disp('Number of unused genes removed from the model:')
-disp(numel(toKeep(~toKeep)))
 
 if isfield(reducedModel,'geneShortNames')
     reducedModel.geneShortNames=reducedModel.geneShortNames(toKeep);

--- a/core/getModelFromHomology.m
+++ b/core/getModelFromHomology.m
@@ -363,12 +363,13 @@ end
 for i=1:numel(models)
     a=ismember(models{useOrderIndexes(i)}.genes,allGenes{i+1});
     
-    %Don't remove reactions with complexes if not all genes in the complex
-    %should be deleted. NOTE: This means that not all the genes in 'a' are
-    %guaranteed to be deleted. This approach works fine for 'and'
-    %complexes, but there should be a check that it doesn't keep 'or' genes
-    %if it doesn't have to!
-    models{useOrderIndexes(i)}=removeGenes(models{useOrderIndexes(i)},~a,true,true,false);
+    %Remove reactions that are not associated to any of the genes in
+    %allGenes, thereby also keeping complexes where only for one of the
+    %genes was matched
+    b = models{useOrderIndexes(i)}.rxnGeneMat(:,~a);
+    [b,~] = unique(b); % Reactions to remove
+    
+    models{useOrderIndexes(i)}=removeReactions(models{useOrderIndexes(i)},b,true,true,true);
 end
 
 %Since mergeModels function will be used in the end, the models are
@@ -516,6 +517,7 @@ draftModel.rxnNotes=cell(length(draftModel.rxns),1);
 draftModel.rxnNotes(:)={'Included by getModelFromHomology'};
 draftModel.rxnConfidenceScores=NaN(length(draftModel.rxns),1);
 draftModel.rxnConfidenceScores(:)=2;
+draftModel=deleteUnusedGenes(draftModel,0);
 %Standardize grRules and notify if problematic grRules are found
 [draftModel.grRules,draftModel.rxnGeneMat]=standardizeGrRules(draftModel,false);
 end


### PR DESCRIPTION
### Main improvements in this PR:
- feat:
  - `deleteUnusedGenes` has flag for verbosity 
- fix:
  - `getModelFromHomology` keeps reactions with complex grRules if homology was found for at least one of the original genes.

Originally, `getModelFromHomology` was intended to have  this behaviour, where the other (non-homology) genes would then be prefixed with `OLD_`. Later changes on `removeGenes` resulted in too many reactions being deleted. This is now fixed.

Assume the following grRule: `(A and B) or (A and C)`, and only for gene `A` a homolog is found for in the new model: `Anew`

Previous behaviour: the associated reaction will be removed, as gene B and C have no homologs and `(Anew and ... ) or (Anew and ... )` does not have a functional complex.

New behaviour: the associated reaction will be kept, and new grRule is defined as `(Anew and OLD_B) or (Anew and OLD_C)`.

Manual curation should then be performed to see if B and C homologs can be found in the new genome anyway, or whether B and C are actually not required in the new organism.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
