### PR TITLE
fix: disable adding prefix 'M_' and 'R_' in exprotModel function

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -281,13 +281,13 @@ for i=1:numel(model.mets)
     end
     
     if isfield(modelSBML.species,'metaid')
-        modelSBML.species(i).metaid=['M_' model.mets{i}];
+        modelSBML.species(i).metaid=model.mets{i};
     end
     if isfield(modelSBML.species, 'name')
         modelSBML.species(i).name=model.metNames{i};
     end
     if isfield(modelSBML.species, 'id')
-        modelSBML.species(i).id=['M_' model.mets{i}];
+        modelSBML.species(i).id=model.mets{i};
     end
     if isfield(modelSBML.species, 'compartment')
         modelSBML.species(i).compartment=model.comps{model.metComps(i)};
@@ -329,7 +329,7 @@ for i=1:numel(model.mets)
                 end
             end
             if ~isempty(model.metMiriams{i}) || hasInchi==true
-                modelSBML.species(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_M_' model.mets{i} '">'];
+                modelSBML.species(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.mets{i} '">'];
                 modelSBML.species(i).annotation=[modelSBML.species(i).annotation '<bqbiol:is><rdf:Bag>'];
                 if ~isempty(model.metMiriams{i})
                     modelSBML.species(i).annotation=[modelSBML.species(i).annotation getMiriam(model.metMiriams{i})];
@@ -475,7 +475,7 @@ for i=1:numel(model.rxns)
     end
     
     if isfield(modelSBML.reaction,'metaid')
-        modelSBML.reaction(i).metaid=['R_' model.rxns{i}];
+        modelSBML.reaction(i).metaid=model.rxns{i};
     end
     
     %Export notes information
@@ -522,7 +522,7 @@ for i=1:numel(model.rxns)
         modelSBML.reaction(i).name=model.rxnNames{i};
     end
     if isfield(modelSBML.reaction, 'id')
-        modelSBML.reaction(i).id=['R_' model.rxns{i}];
+        modelSBML.reaction(i).id=model.rxns{i};
     end
     
     %Add the information about reactants and products
@@ -574,7 +574,7 @@ if modelHasSubsystems
     modelSBML.groups_group.sboTerm = 633;
     tmpStruct=modelSBML.groups_group;
 
-    rxns=strcat('R_',model.rxns);
+    rxns=model.rxns;
     if ~any(cellfun(@iscell,model.subSystems))
         if ~any(~cellfun(@isempty,model.subSystems))
             subSystems = {};

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -222,11 +222,6 @@ for i=1:numel(model.comps)
     end
     
     if isfield(modelSBML.compartment,'metaid')
-        if ~isnan(str2double(model.comps(i)))
-            EM='The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with "c_" string';
-            dispEM(EM,false);
-            model.comps(i)=strcat('c_',model.comps(i));
-        end
         modelSBML.compartment(i).metaid=model.comps{i};
     end
     %Prepare Miriam strings
@@ -507,7 +502,7 @@ for i=1:numel(model.rxns)
     
     %Export annotation information from rxnMiriams
     if (~isempty(model.rxnMiriams{i}) && isfield(modelSBML.reaction(i),'annotation')) || ~isempty(model.eccodes{i})
-        modelSBML.reaction(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_R_' model.rxns{i} '">'];
+        modelSBML.reaction(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.rxns{i} '">'];
         modelSBML.reaction(i).annotation=[modelSBML.reaction(i).annotation '<bqbiol:is><rdf:Bag>'];
         if ~isempty(model.eccodes{i})
             eccodes=regexp(model.eccodes{i},';','split');


### PR DESCRIPTION
### Main improvements in this PR:
* This PR modify `exportModel` function to stop adding by prefix `M_` and `R_` to metabolite and reactions ids, as proposed in #353

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
