### PR TITLE
Revert "fix: disable adding prefix 'M_' and 'R_' in exprotModel function"

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -222,6 +222,11 @@ for i=1:numel(model.comps)
     end
     
     if isfield(modelSBML.compartment,'metaid')
+        if ~isnan(str2double(model.comps(i)))
+            EM='The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with "c_" string';
+            dispEM(EM,false);
+            model.comps(i)=strcat('c_',model.comps(i));
+        end
         modelSBML.compartment(i).metaid=model.comps{i};
     end
     %Prepare Miriam strings
@@ -276,13 +281,13 @@ for i=1:numel(model.mets)
     end
     
     if isfield(modelSBML.species,'metaid')
-        modelSBML.species(i).metaid=model.mets{i};
+        modelSBML.species(i).metaid=['M_' model.mets{i}];
     end
     if isfield(modelSBML.species, 'name')
         modelSBML.species(i).name=model.metNames{i};
     end
     if isfield(modelSBML.species, 'id')
-        modelSBML.species(i).id=model.mets{i};
+        modelSBML.species(i).id=['M_' model.mets{i}];
     end
     if isfield(modelSBML.species, 'compartment')
         modelSBML.species(i).compartment=model.comps{model.metComps(i)};
@@ -324,7 +329,7 @@ for i=1:numel(model.mets)
                 end
             end
             if ~isempty(model.metMiriams{i}) || hasInchi==true
-                modelSBML.species(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.mets{i} '">'];
+                modelSBML.species(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_M_' model.mets{i} '">'];
                 modelSBML.species(i).annotation=[modelSBML.species(i).annotation '<bqbiol:is><rdf:Bag>'];
                 if ~isempty(model.metMiriams{i})
                     modelSBML.species(i).annotation=[modelSBML.species(i).annotation getMiriam(model.metMiriams{i})];
@@ -470,7 +475,7 @@ for i=1:numel(model.rxns)
     end
     
     if isfield(modelSBML.reaction,'metaid')
-        modelSBML.reaction(i).metaid=model.rxns{i};
+        modelSBML.reaction(i).metaid=['R_' model.rxns{i}];
     end
     
     %Export notes information
@@ -502,7 +507,7 @@ for i=1:numel(model.rxns)
     
     %Export annotation information from rxnMiriams
     if (~isempty(model.rxnMiriams{i}) && isfield(modelSBML.reaction(i),'annotation')) || ~isempty(model.eccodes{i})
-        modelSBML.reaction(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.rxns{i} '">'];
+        modelSBML.reaction(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_R_' model.rxns{i} '">'];
         modelSBML.reaction(i).annotation=[modelSBML.reaction(i).annotation '<bqbiol:is><rdf:Bag>'];
         if ~isempty(model.eccodes{i})
             eccodes=regexp(model.eccodes{i},';','split');
@@ -517,7 +522,7 @@ for i=1:numel(model.rxns)
         modelSBML.reaction(i).name=model.rxnNames{i};
     end
     if isfield(modelSBML.reaction, 'id')
-        modelSBML.reaction(i).id=model.rxns{i};
+        modelSBML.reaction(i).id=['R_' model.rxns{i}];
     end
     
     %Add the information about reactants and products
@@ -569,7 +574,7 @@ if modelHasSubsystems
     modelSBML.groups_group.sboTerm = 633;
     tmpStruct=modelSBML.groups_group;
 
-    rxns=model.rxns;
+    rxns=strcat('R_',model.rxns);
     if ~any(cellfun(@iscell,model.subSystems))
         if ~any(~cellfun(@isempty,model.subSystems))
             subSystems = {};


### PR DESCRIPTION
tldr; release bugfix version 2.5.2 ASAP, keep changes from #353 for minor release 2.6.0.
 
1. As Issue [#353](https://github.com/SysBioChalmers/RAVEN/issues/353) fundamentally changes the output from model I/O, it should be part of minor release 2.6.0 (instead of bug-fix 2.5.2), as [mentioned](https://github.com/SysBioChalmers/RAVEN/pull/356#issuecomment-895504529).
2. PR [#356](https://github.com/SysBioChalmers/RAVEN/issues/356) only addressed `exportModel`, without changing `importModel` and `checkModelStruct`, as should be done to completely solve Issue [#353](https://github.com/SysBioChalmers/RAVEN/issues/353).
3. Meanwhile, PR [#358](https://github.com/SysBioChalmers/RAVEN/issues/358) is on standby (waiting for PR [#357](https://github.com/SysBioChalmers/RAVEN/issues/357) to be reviewed), to release bugfix version 2.5.2. **This release should be made ASAP, as it contains essential fixes. Please review and merge!**
4. As [#353](https://github.com/SysBioChalmers/RAVEN/issues/353) was now already merged to `devel`, _before_ merging [#358](https://github.com/SysBioChalmers/RAVEN/issues/358), the changes from `exportModel` would already be integrated in the bugfix release 2.5.2, contra to point 1 above.
5. To solve this:

- [ ] Revert PR [#356](https://github.com/SysBioChalmers/RAVEN/issues/356) with this PR.
- [ ] Review and merge PR [#357](https://github.com/SysBioChalmers/RAVEN/issues/357).
- [ ] Review and merge PR [#358](https://github.com/SysBioChalmers/RAVEN/issues/358). After this, release 2.5.2 is finalized on `main`, but no need to wait to continue with the next step:
- [ ] Make new PR from [`fix/exprotModel`](https://github.com/SysBioChalmers/RAVEN/tree/fix/exprotModel) branch to `devel`, recreating PR [#356](https://github.com/SysBioChalmers/RAVEN/issues/356) and merge.

Apologies, I should have realized this earlier before approving [#356](https://github.com/SysBioChalmers/RAVEN/issues/356). Mental note: first merge release-related PRs (`devel` --> `main`) before approving new PRs to `devel`.