### PR TITLE
fix: exportModel correct prefix compartment IDs

### DIFF
--- a/doc/io/exportModel.html
+++ b/doc/io/exportModel.html
@@ -281,7 +281,7 @@ This function is called by:
 0222     <span class="keyword">end</span>
 0223     
 0224     <span class="keyword">if</span> isfield(modelSBML.compartment,<span class="string">'metaid'</span>)
-0225         <span class="keyword">if</span> any(regexp(model.comps(i),<span class="string">'^\d'</span>))
+0225         <span class="keyword">if</span> regexp(model.comps(i),<span class="string">'^[^a-zA-Z_]'</span>)
 0226             EM=<span class="string">'The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with &quot;c_&quot; string'</span>;
 0227             dispEM(EM,false);
 0228             model.comps(i)=strcat(<span class="string">'c_'</span>,model.comps(i));

--- a/doc/io/exportModel.html
+++ b/doc/io/exportModel.html
@@ -281,7 +281,7 @@ This function is called by:
 0222     <span class="keyword">end</span>
 0223     
 0224     <span class="keyword">if</span> isfield(modelSBML.compartment,<span class="string">'metaid'</span>)
-0225         <span class="keyword">if</span> ~isnan(str2double(model.comps(i)))
+0225         <span class="keyword">if</span> any(regexp(model.comps(i),<span class="string">'^\d'</span>))
 0226             EM=<span class="string">'The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with &quot;c_&quot; string'</span>;
 0227             dispEM(EM,false);
 0228             model.comps(i)=strcat(<span class="string">'c_'</span>,model.comps(i));

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -222,7 +222,7 @@ for i=1:numel(model.comps)
     end
     
     if isfield(modelSBML.compartment,'metaid')
-        if any(regexp(model.comps(i),'^\d'))
+        if regexp(model.comps(i),'^[^a-zA-Z_]')
             EM='The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with "c_" string';
             dispEM(EM,false);
             model.comps(i)=strcat('c_',model.comps(i));

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -222,7 +222,7 @@ for i=1:numel(model.comps)
     end
     
     if isfield(modelSBML.compartment,'metaid')
-        if ~isnan(str2double(model.comps(i)))
+        if any(regexp(model.comps(i),'^\d'))
             EM='The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with "c_" string';
             dispEM(EM,false);
             model.comps(i)=strcat('c_',model.comps(i));


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `exportModel` correct handling if a compartment ID is `i` (solves #366)

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR