### PR TITLE
doc: remove reference to mosek and output MATLAB release

### DIFF
--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -22,6 +22,8 @@ else
     fprintf('\n*** THE RAVEN TOOLBOX - DEVELOPMENT VERSION ***\n\n');
 end
 
+fprintf(['MATLAB R' version('-release') ' detected\n\n']);
+
 fprintf('Checking if RAVEN is on the MATLAB path...\t\t\t\t\t\t\t\t\t');
 if ismember(ravenDir,paths)
     fprintf('OK\n');
@@ -118,7 +120,7 @@ else
     setRavenSolver(curSolv);
     fprintf(['WARNING: No working solver was found!\n'...
         'Install the solver, set it using setRavenSolver(''solverName'') and run checkInstallation again\n'...
-        'Available solverName options are ''mosek'', ''gurobi'' and ''cobra''\n\n']);
+        'Available solverName options are ''gurobi'' and ''cobra''\n\n']);
 end
 
 if ismac


### PR DESCRIPTION
### Main improvements in this PR:
doc:
- `checkInstallation`: remove the remaining reference to mosek solver
- `checkInstallation`: add reporting of MATLAB release

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
