### PR TITLE
feat: confirm single obj func by checkModelStruct

### DIFF
--- a/core/checkModelStruct.m
+++ b/core/checkModelStruct.m
@@ -247,11 +247,11 @@ EM='The following reactions have bounds contradicting their reversibility:';
 dispEM(EM,throwErrors,model.rxns(model.lb<0 & model.rev==0),trimWarnings);
 
 %Multiple or no objective functions not allowed in SBML L3V1 FBCv2
-if find(model.c)>1
-    EM='The model has multiple objective functions, which might be intended, but will not allow export to SBML';
-    dispEM(EM,false);
-else ~any(model.c)
-    EM='The model no objective functions, which might be intended, but will not allow export to SBML';
+if numel(find(model.c))>1
+    EM='The model has multiple objective functions, which might be intended, but will not allow the model to be exported to SBML:';
+    dispEM(EM,false,model.rxns(find(model.c)),trimWarnings);
+elseif ~any(model.c)
+    EM='The model no objective functions in model.c, which might be intended, but will not allow the model to be exported to SBML';
     dispEM(EM,false);
 end
     

--- a/core/checkModelStruct.m
+++ b/core/checkModelStruct.m
@@ -251,7 +251,7 @@ if numel(find(model.c))>1
     EM='The model has multiple objective functions, which might be intended, but will not allow the model to be exported to SBML:';
     dispEM(EM,false,model.rxns(find(model.c)),trimWarnings);
 elseif ~any(model.c)
-    EM='The model no objective functions in model.c, which might be intended, but will not allow the model to be exported to SBML';
+    EM='The model has no objective function in model.c, which might be intended, but will not allow the model to be exported to SBML';
     dispEM(EM,false);
 end
     

--- a/core/checkModelStruct.m
+++ b/core/checkModelStruct.m
@@ -247,7 +247,7 @@ EM='The following reactions have bounds contradicting their reversibility:';
 dispEM(EM,throwErrors,model.rxns(model.lb<0 & model.rev==0),trimWarnings);
 
 %Multiple or no objective functions not allowed in SBML L3V1 FBCv2
-if find(model.c)>1 | 
+if find(model.c)>1
     EM='The model has multiple objective functions, which might be intended, but will not allow export to SBML';
     dispEM(EM,false);
 else ~any(model.c)

--- a/core/checkModelStruct.m
+++ b/core/checkModelStruct.m
@@ -246,6 +246,18 @@ dispEM(EM,throwErrors,model.rxns(model.lb>model.ub),trimWarnings);
 EM='The following reactions have bounds contradicting their reversibility:';
 dispEM(EM,throwErrors,model.rxns(model.lb<0 & model.rev==0),trimWarnings);
 
+%Multiple or no objective functions not allowed in SBML L3V1 FBCv2
+if find(model.c)>1 | 
+    EM='The model has multiple objective functions, which might be intended, but will not allow export to SBML';
+    dispEM(EM,false);
+else ~any(model.c)
+    EM='The model no objective functions, which might be intended, but will not allow export to SBML';
+    dispEM(EM,false);
+end
+    
+EM='The following reactions have contradicting bounds:';
+dispEM(EM,throwErrors,model.rxns(model.lb>model.ub),trimWarnings);
+
 %Mapping of compartments
 if isfield(model,'compOutside')
     EM='The following compartments are in "compOutside" but not in "comps":';

--- a/core/checkModelStruct.m
+++ b/core/checkModelStruct.m
@@ -248,10 +248,10 @@ dispEM(EM,throwErrors,model.rxns(model.lb<0 & model.rev==0),trimWarnings);
 
 %Multiple or no objective functions not allowed in SBML L3V1 FBCv2
 if numel(find(model.c))>1
-    EM='The model has multiple objective functions, which might be intended, but will not allow the model to be exported to SBML:';
+    EM='Multiple objective functions found. This might be intended, but exportModel will fail due to SBML FBCv2 non-compliance:';
     dispEM(EM,false,model.rxns(find(model.c)),trimWarnings);
 elseif ~any(model.c)
-    EM='The model has no objective function in model.c, which might be intended, but will not allow the model to be exported to SBML';
+    EM='No objective function found. This might be intended, but exportModel will fail due to SBML FBCv2 non-compliance';
     dispEM(EM,false);
 end
     

--- a/doc/core/checkModelStruct.html
+++ b/doc/core/checkModelStruct.html
@@ -305,116 +305,128 @@ This function is called by:
 0246 EM=<span class="string">'The following reactions have bounds contradicting their reversibility:'</span>;
 0247 <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,model.rxns(model.lb&lt;0 &amp; model.rev==0),trimWarnings);
 0248 
-0249 <span class="comment">%Mapping of compartments</span>
-0250 <span class="keyword">if</span> isfield(model,<span class="string">'compOutside'</span>)
-0251     EM=<span class="string">'The following compartments are in &quot;compOutside&quot; but not in &quot;comps&quot;:'</span>;
-0252     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,setdiff(model.compOutside,[{<span class="string">''</span>};model.comps]),trimWarnings);
-0253 <span class="keyword">end</span>
-0254 
-0255 <span class="comment">%Met names which start with number</span>
-0256 I=false(numel(model.metNames),1);
-0257 <span class="keyword">for</span> i=1:numel(model.metNames)
-0258     index=strfind(model.metNames{i},<span class="string">' '</span>);
-0259     <span class="keyword">if</span> any(index)
-0260         <span class="keyword">if</span> any(str2double(model.metNames{i}(1:index(1)-1)))
-0261             I(i)=true;
-0262         <span class="keyword">end</span>
-0263     <span class="keyword">end</span>
-0264 <span class="keyword">end</span>
-0265 EM=<span class="string">'The following metabolite names begin with a number directly followed by space:'</span>;
-0266 <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,model.mets(I),trimWarnings);
-0267 
-0268 <span class="comment">%Non-parseable composition</span>
-0269 <span class="keyword">if</span> isfield(model,<span class="string">'metFormulas'</span>)
-0270     [~, ~, exitFlag]=<a href="parseFormulas.html" class="code" title="function [elements, useMat, exitFlag, MW]=parseFormulas(formulas, noPolymers,isInchi,ignoreRX)">parseFormulas</a>(model.metFormulas,true,false);
-0271     EM=<span class="string">'The composition for the following metabolites could not be parsed:'</span>;
-0272     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,model.mets(exitFlag==-1),trimWarnings);
-0273 <span class="keyword">end</span>
-0274 
-0275 <span class="comment">%Check if there are metabolites with different names but the same MIRIAM</span>
-0276 <span class="comment">%codes</span>
-0277 <span class="keyword">if</span> isfield(model,<span class="string">'metMiriams'</span>)
-0278     miriams=containers.Map();
-0279     <span class="keyword">for</span> i=1:numel(model.mets)
-0280         <span class="keyword">if</span> ~isempty(model.metMiriams{i})
-0281             <span class="comment">%Loop through and add for each miriam</span>
-0282             <span class="keyword">for</span> j=1:numel(model.metMiriams{i}.name)
-0283                 <span class="comment">%Get existing metabolite indexes</span>
-0284                 current=strcat(model.metMiriams{i}.name{j},<span class="string">'/'</span>,model.metMiriams{i}.value{j});
-0285                 <span class="keyword">if</span> isKey(miriams,current)
-0286                     existing=miriams(current);
-0287                 <span class="keyword">else</span>
-0288                     existing=[];
-0289                 <span class="keyword">end</span>
-0290                 miriams(current)=[existing;i];
-0291             <span class="keyword">end</span>
-0292         <span class="keyword">end</span>
-0293     <span class="keyword">end</span>
-0294     
-0295     <span class="comment">%Get all keys</span>
-0296     allMiriams=keys(miriams);
-0297     
-0298     hasMultiple=false(numel(allMiriams),1);
-0299     <span class="keyword">for</span> i=1:numel(allMiriams)
-0300         <span class="keyword">if</span> numel(miriams(allMiriams{i}))&gt;1
-0301             <span class="comment">%Check if they all have the same name</span>
-0302             <span class="keyword">if</span> numel(unique(model.metNames(miriams(allMiriams{i}))))&gt;1
-0303                 <span class="keyword">if</span> ~regexp(allMiriams{i},<span class="string">'^sbo\/SBO:'</span>) <span class="comment">% SBO terms are expected to be multiple</span>
-0304                     hasMultiple(i)=true;
-0305                 <span class="keyword">end</span>                
-0306             <span class="keyword">end</span>
-0307         <span class="keyword">end</span>
-0308     <span class="keyword">end</span>
+0249 <span class="comment">%Multiple or no objective functions not allowed in SBML L3V1 FBCv2</span>
+0250 <span class="keyword">if</span> find(model.c)&gt;1 | 
+0251     EM=<span class="string">'The model has multiple objective functions, which might be intended, but will not allow export to SBML'</span>;
+0252     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false);
+0253 <span class="keyword">else</span> ~any(model.c)
+0254     EM=<span class="string">'The model no objective functions, which might be intended, but will not allow export to SBML'</span>;
+0255     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false);
+0256 <span class="keyword">end</span>
+0257     
+0258 EM=<span class="string">'The following reactions have contradicting bounds:'</span>;
+0259 <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,model.rxns(model.lb&gt;model.ub),trimWarnings);
+0260 
+0261 <span class="comment">%Mapping of compartments</span>
+0262 <span class="keyword">if</span> isfield(model,<span class="string">'compOutside'</span>)
+0263     EM=<span class="string">'The following compartments are in &quot;compOutside&quot; but not in &quot;comps&quot;:'</span>;
+0264     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,setdiff(model.compOutside,[{<span class="string">''</span>};model.comps]),trimWarnings);
+0265 <span class="keyword">end</span>
+0266 
+0267 <span class="comment">%Met names which start with number</span>
+0268 I=false(numel(model.metNames),1);
+0269 <span class="keyword">for</span> i=1:numel(model.metNames)
+0270     index=strfind(model.metNames{i},<span class="string">' '</span>);
+0271     <span class="keyword">if</span> any(index)
+0272         <span class="keyword">if</span> any(str2double(model.metNames{i}(1:index(1)-1)))
+0273             I(i)=true;
+0274         <span class="keyword">end</span>
+0275     <span class="keyword">end</span>
+0276 <span class="keyword">end</span>
+0277 EM=<span class="string">'The following metabolite names begin with a number directly followed by space:'</span>;
+0278 <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,model.mets(I),trimWarnings);
+0279 
+0280 <span class="comment">%Non-parseable composition</span>
+0281 <span class="keyword">if</span> isfield(model,<span class="string">'metFormulas'</span>)
+0282     [~, ~, exitFlag]=<a href="parseFormulas.html" class="code" title="function [elements, useMat, exitFlag, MW]=parseFormulas(formulas, noPolymers,isInchi,ignoreRX)">parseFormulas</a>(model.metFormulas,true,false);
+0283     EM=<span class="string">'The composition for the following metabolites could not be parsed:'</span>;
+0284     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,model.mets(exitFlag==-1),trimWarnings);
+0285 <span class="keyword">end</span>
+0286 
+0287 <span class="comment">%Check if there are metabolites with different names but the same MIRIAM</span>
+0288 <span class="comment">%codes</span>
+0289 <span class="keyword">if</span> isfield(model,<span class="string">'metMiriams'</span>)
+0290     miriams=containers.Map();
+0291     <span class="keyword">for</span> i=1:numel(model.mets)
+0292         <span class="keyword">if</span> ~isempty(model.metMiriams{i})
+0293             <span class="comment">%Loop through and add for each miriam</span>
+0294             <span class="keyword">for</span> j=1:numel(model.metMiriams{i}.name)
+0295                 <span class="comment">%Get existing metabolite indexes</span>
+0296                 current=strcat(model.metMiriams{i}.name{j},<span class="string">'/'</span>,model.metMiriams{i}.value{j});
+0297                 <span class="keyword">if</span> isKey(miriams,current)
+0298                     existing=miriams(current);
+0299                 <span class="keyword">else</span>
+0300                     existing=[];
+0301                 <span class="keyword">end</span>
+0302                 miriams(current)=[existing;i];
+0303             <span class="keyword">end</span>
+0304         <span class="keyword">end</span>
+0305     <span class="keyword">end</span>
+0306     
+0307     <span class="comment">%Get all keys</span>
+0308     allMiriams=keys(miriams);
 0309     
-0310     <span class="comment">%Print output</span>
-0311     EM=<span class="string">'The following MIRIAM strings are associated to more than one unique metabolite name:'</span>;
-0312     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,allMiriams(hasMultiple),trimWarnings);
-0313 <span class="keyword">end</span>
-0314 
-0315 <span class="comment">%Check if there are metabolites with different names but the same InChI</span>
-0316 <span class="comment">%codes</span>
-0317 <span class="keyword">if</span> isfield(model,<span class="string">'inchis'</span>)
-0318     inchis=containers.Map();
-0319     <span class="keyword">for</span> i=1:numel(model.mets)
-0320         <span class="keyword">if</span> ~isempty(model.inchis{i})
-0321             <span class="comment">%Get existing metabolite indexes</span>
-0322             <span class="keyword">if</span> isKey(inchis,model.inchis{i})
-0323                 existing=inchis(model.inchis{i});
-0324             <span class="keyword">else</span>
-0325                 existing=[];
-0326             <span class="keyword">end</span>
-0327             inchis(model.inchis{i})=[existing;i];
-0328         <span class="keyword">end</span>
-0329     <span class="keyword">end</span>
-0330     
-0331     <span class="comment">%Get all keys</span>
-0332     allInchis=keys(inchis);
-0333     
-0334     hasMultiple=false(numel(allInchis),1);
-0335     <span class="keyword">for</span> i=1:numel(allInchis)
-0336         <span class="keyword">if</span> numel(inchis(allInchis{i}))&gt;1
-0337             <span class="comment">%Check if they all have the same name</span>
-0338             <span class="keyword">if</span> numel(unique(model.metNames(inchis(allInchis{i}))))&gt;1
-0339                 hasMultiple(i)=true;
-0340             <span class="keyword">end</span>
-0341         <span class="keyword">end</span>
-0342     <span class="keyword">end</span>
-0343     
-0344     <span class="comment">%Print output</span>
-0345     EM=<span class="string">'The following InChI strings are associated to more than one unique metabolite name:'</span>;
-0346     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,allInchis(hasMultiple),trimWarnings);
-0347 <span class="keyword">end</span>
-0348 <span class="keyword">end</span>
-0349 
-0350 <a name="_sub1" href="#_subfunctions" class="code">function I=duplicates(strings)</a>
-0351 I=false(numel(strings),1);
-0352 [J, K]=unique(strings);
-0353 <span class="keyword">if</span> numel(J)~=numel(strings)
-0354     L=1:numel(strings);
-0355     L(K)=[];
-0356     I(L)=true;
-0357 <span class="keyword">end</span>
-0358 <span class="keyword">end</span></pre></div>
+0310     hasMultiple=false(numel(allMiriams),1);
+0311     <span class="keyword">for</span> i=1:numel(allMiriams)
+0312         <span class="keyword">if</span> numel(miriams(allMiriams{i}))&gt;1
+0313             <span class="comment">%Check if they all have the same name</span>
+0314             <span class="keyword">if</span> numel(unique(model.metNames(miriams(allMiriams{i}))))&gt;1
+0315                 <span class="keyword">if</span> ~regexp(allMiriams{i},<span class="string">'^sbo\/SBO:'</span>) <span class="comment">% SBO terms are expected to be multiple</span>
+0316                     hasMultiple(i)=true;
+0317                 <span class="keyword">end</span>                
+0318             <span class="keyword">end</span>
+0319         <span class="keyword">end</span>
+0320     <span class="keyword">end</span>
+0321     
+0322     <span class="comment">%Print output</span>
+0323     EM=<span class="string">'The following MIRIAM strings are associated to more than one unique metabolite name:'</span>;
+0324     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,allMiriams(hasMultiple),trimWarnings);
+0325 <span class="keyword">end</span>
+0326 
+0327 <span class="comment">%Check if there are metabolites with different names but the same InChI</span>
+0328 <span class="comment">%codes</span>
+0329 <span class="keyword">if</span> isfield(model,<span class="string">'inchis'</span>)
+0330     inchis=containers.Map();
+0331     <span class="keyword">for</span> i=1:numel(model.mets)
+0332         <span class="keyword">if</span> ~isempty(model.inchis{i})
+0333             <span class="comment">%Get existing metabolite indexes</span>
+0334             <span class="keyword">if</span> isKey(inchis,model.inchis{i})
+0335                 existing=inchis(model.inchis{i});
+0336             <span class="keyword">else</span>
+0337                 existing=[];
+0338             <span class="keyword">end</span>
+0339             inchis(model.inchis{i})=[existing;i];
+0340         <span class="keyword">end</span>
+0341     <span class="keyword">end</span>
+0342     
+0343     <span class="comment">%Get all keys</span>
+0344     allInchis=keys(inchis);
+0345     
+0346     hasMultiple=false(numel(allInchis),1);
+0347     <span class="keyword">for</span> i=1:numel(allInchis)
+0348         <span class="keyword">if</span> numel(inchis(allInchis{i}))&gt;1
+0349             <span class="comment">%Check if they all have the same name</span>
+0350             <span class="keyword">if</span> numel(unique(model.metNames(inchis(allInchis{i}))))&gt;1
+0351                 hasMultiple(i)=true;
+0352             <span class="keyword">end</span>
+0353         <span class="keyword">end</span>
+0354     <span class="keyword">end</span>
+0355     
+0356     <span class="comment">%Print output</span>
+0357     EM=<span class="string">'The following InChI strings are associated to more than one unique metabolite name:'</span>;
+0358     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,allInchis(hasMultiple),trimWarnings);
+0359 <span class="keyword">end</span>
+0360 <span class="keyword">end</span>
+0361 
+0362 <a name="_sub1" href="#_subfunctions" class="code">function I=duplicates(strings)</a>
+0363 I=false(numel(strings),1);
+0364 [J, K]=unique(strings);
+0365 <span class="keyword">if</span> numel(J)~=numel(strings)
+0366     L=1:numel(strings);
+0367     L(K)=[];
+0368     I(L)=true;
+0369 <span class="keyword">end</span>
+0370 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/core/checkModelStruct.html
+++ b/doc/core/checkModelStruct.html
@@ -307,10 +307,10 @@ This function is called by:
 0248 
 0249 <span class="comment">%Multiple or no objective functions not allowed in SBML L3V1 FBCv2</span>
 0250 <span class="keyword">if</span> numel(find(model.c))&gt;1
-0251     EM=<span class="string">'The model has multiple objective functions, which might be intended, but will not allow the model to be exported to SBML:'</span>;
+0251     EM=<span class="string">'Multiple objective functions found. This might be intended, but exportModel will fail due to SBML FBCv2 non-compliance:'</span>;
 0252     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,model.rxns(find(model.c)),trimWarnings);
 0253 <span class="keyword">elseif</span> ~any(model.c)
-0254     EM=<span class="string">'The model has no objective function in model.c, which might be intended, but will not allow the model to be exported to SBML'</span>;
+0254     EM=<span class="string">'No objective function found. This might be intended, but exportModel will fail due to SBML FBCv2 non-compliance'</span>;
 0255     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false);
 0256 <span class="keyword">end</span>
 0257     

--- a/doc/core/checkModelStruct.html
+++ b/doc/core/checkModelStruct.html
@@ -306,7 +306,7 @@ This function is called by:
 0247 <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,model.rxns(model.lb&lt;0 &amp; model.rev==0),trimWarnings);
 0248 
 0249 <span class="comment">%Multiple or no objective functions not allowed in SBML L3V1 FBCv2</span>
-0250 <span class="keyword">if</span> find(model.c)&gt;1 | 
+0250 <span class="keyword">if</span> find(model.c)&gt;1
 0251     EM=<span class="string">'The model has multiple objective functions, which might be intended, but will not allow export to SBML'</span>;
 0252     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false);
 0253 <span class="keyword">else</span> ~any(model.c)

--- a/doc/core/checkModelStruct.html
+++ b/doc/core/checkModelStruct.html
@@ -306,11 +306,11 @@ This function is called by:
 0247 <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,throwErrors,model.rxns(model.lb&lt;0 &amp; model.rev==0),trimWarnings);
 0248 
 0249 <span class="comment">%Multiple or no objective functions not allowed in SBML L3V1 FBCv2</span>
-0250 <span class="keyword">if</span> find(model.c)&gt;1
-0251     EM=<span class="string">'The model has multiple objective functions, which might be intended, but will not allow export to SBML'</span>;
-0252     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false);
-0253 <span class="keyword">else</span> ~any(model.c)
-0254     EM=<span class="string">'The model no objective functions, which might be intended, but will not allow export to SBML'</span>;
+0250 <span class="keyword">if</span> numel(find(model.c))&gt;1
+0251     EM=<span class="string">'The model has multiple objective functions, which might be intended, but will not allow the model to be exported to SBML:'</span>;
+0252     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,model.rxns(find(model.c)),trimWarnings);
+0253 <span class="keyword">elseif</span> ~any(model.c)
+0254     EM=<span class="string">'The model no objective functions in model.c, which might be intended, but will not allow the model to be exported to SBML'</span>;
 0255     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false);
 0256 <span class="keyword">end</span>
 0257     

--- a/doc/core/checkModelStruct.html
+++ b/doc/core/checkModelStruct.html
@@ -310,7 +310,7 @@ This function is called by:
 0251     EM=<span class="string">'The model has multiple objective functions, which might be intended, but will not allow the model to be exported to SBML:'</span>;
 0252     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,model.rxns(find(model.c)),trimWarnings);
 0253 <span class="keyword">elseif</span> ~any(model.c)
-0254     EM=<span class="string">'The model no objective functions in model.c, which might be intended, but will not allow the model to be exported to SBML'</span>;
+0254     EM=<span class="string">'The model has no objective function in model.c, which might be intended, but will not allow the model to be exported to SBML'</span>;
 0255     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false);
 0256 <span class="keyword">end</span>
 0257     

--- a/doc/external/kegg/getKEGGModelForOrganism.html
+++ b/doc/external/kegg/getKEGGModelForOrganism.html
@@ -1249,7 +1249,7 @@ This function is called by:
 0933     <span class="keyword">end</span>
 0934     fprintf(<span class="string">'\b\b\b\b\b\b\b\b\b\b\b\b\b\b\bCOMPLETE\n'</span>);
 0935 <span class="keyword">else</span>
-0936     fprintf([<span class="string">'Querying &lt;strong&gt;'</span> fastaFile <span class="string">'&lt;/strong&gt; against the KEGG Orthology specific HMMs... COMPLETE\n'</span>]);
+0936     fprintf([<span class="string">'Querying &lt;strong&gt;'</span> strrep(fastaFile,<span class="string">'\'</span>,<span class="string">'/'</span>) <span class="string">'&lt;/strong&gt; against the KEGG Orthology specific HMMs... COMPLETE\n'</span>]);
 0937 <span class="keyword">end</span>
 0938 
 0939 

--- a/doc/installation/checkInstallation.html
+++ b/doc/installation/checkInstallation.html
@@ -72,177 +72,179 @@ This function is called by:
 0022     fprintf(<span class="string">'\n*** THE RAVEN TOOLBOX - DEVELOPMENT VERSION ***\n\n'</span>);
 0023 <span class="keyword">end</span>
 0024 
-0025 fprintf(<span class="string">'Checking if RAVEN is on the MATLAB path...\t\t\t\t\t\t\t\t\t'</span>);
-0026 <span class="keyword">if</span> ismember(ravenDir,paths)
-0027     fprintf(<span class="string">'OK\n'</span>);
-0028 <span class="keyword">else</span>
-0029     fprintf(<span class="string">'OK (just added)\n'</span>);
-0030     subpath=regexp(genpath(ravenDir),pathsep,<span class="string">'split'</span>); <span class="comment">%List all subdirectories</span>
-0031     pathsToKeep=cellfun(@(x) isempty(strfind(x,<span class="string">'.git'</span>)),subpath) &amp; cellfun(@(x) isempty(strfind(x,<span class="string">'doc'</span>)),subpath);
-0032     addpath(strjoin(subpath(pathsToKeep),pathsep));
-0033     savepath
-0034 <span class="keyword">end</span>
-0035 
-0036 <span class="comment">%Add the required classes to the static Java path if not already added</span>
-0037 addJavaPaths();
-0038 
-0039 excelFile=fullfile(ravenDir,<span class="string">'tutorial'</span>,<span class="string">'empty.xlsx'</span>);
-0040 xmlFile=fullfile(ravenDir,<span class="string">'tutorial'</span>,<span class="string">'empty.xml'</span>);
-0041 matFile=fullfile(ravenDir,<span class="string">'tutorial'</span>,<span class="string">'empty.mat'</span>);
-0042 
-0043 <span class="comment">%Check if it is possible to parse an Excel file</span>
-0044 fprintf(<span class="string">'Checking if it is possible to parse a model in Microsoft Excel format...\t'</span>);
-0045 <span class="keyword">try</span>
-0046     importExcelModel(excelFile,false,false,true);
-0047     fprintf(<span class="string">'OK\n'</span>);
-0048 <span class="keyword">catch</span>
-0049     fprintf(<span class="string">'Not OK\n'</span>);
-0050 <span class="keyword">end</span>
-0051 
-0052 <span class="comment">%Check if it is possible to import an SBML model using libSBML</span>
-0053 fprintf(<span class="string">'Checking if it is possible to import an SBML model using libSBML...\t\t\t'</span>);
-0054 <span class="keyword">try</span>
-0055     importModel(xmlFile);
-0056     <span class="keyword">try</span>
-0057         libSBMLver=OutputSBML; <span class="comment">% Only works in libSBML 5.17.0+</span>
-0058         fprintf(<span class="string">'OK\n'</span>);
-0059     <span class="keyword">catch</span>
-0060         fprintf([<span class="string">'Not OK\n\n'</span><span class="keyword">...</span>
-0061             <span class="string">'An older libSBML version was found, update to version 5.17.0 or higher\n'</span><span class="keyword">...</span>
-0062             <span class="string">'for a significant improvement of model import\n\n'</span>]);
-0063     <span class="keyword">end</span>
-0064 <span class="keyword">catch</span>
-0065     fprintf([<span class="string">'Not OK\nTo import SBML models, download libSBML from\n'</span><span class="keyword">...</span>
-0066         <span class="string">'http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n'</span>]);
-0067 <span class="keyword">end</span>
-0068 
-0069 <span class="comment">%Define values for keepSolver and workingSolvers, needed for solver</span>
-0070 <span class="comment">%functionality check</span>
-0071 keepSolver=false;
-0072 workingSolvers=<span class="string">''</span>;
-0073 <span class="comment">%Get current solver. Set it to 'none', if it is not set</span>
-0074 <span class="keyword">if</span> ~ispref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>)
-0075     fprintf(<span class="string">'Solver found in preferences... NONE\n'</span>);
-0076     setRavenSolver(<span class="string">'none'</span>);
-0077     curSolv=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0078 <span class="keyword">else</span>
+0025 fprintf([<span class="string">'MATLAB R'</span> version(<span class="string">'-release'</span>) <span class="string">' detected\n\n'</span>]);
+0026 
+0027 fprintf(<span class="string">'Checking if RAVEN is on the MATLAB path...\t\t\t\t\t\t\t\t\t'</span>);
+0028 <span class="keyword">if</span> ismember(ravenDir,paths)
+0029     fprintf(<span class="string">'OK\n'</span>);
+0030 <span class="keyword">else</span>
+0031     fprintf(<span class="string">'OK (just added)\n'</span>);
+0032     subpath=regexp(genpath(ravenDir),pathsep,<span class="string">'split'</span>); <span class="comment">%List all subdirectories</span>
+0033     pathsToKeep=cellfun(@(x) isempty(strfind(x,<span class="string">'.git'</span>)),subpath) &amp; cellfun(@(x) isempty(strfind(x,<span class="string">'doc'</span>)),subpath);
+0034     addpath(strjoin(subpath(pathsToKeep),pathsep));
+0035     savepath
+0036 <span class="keyword">end</span>
+0037 
+0038 <span class="comment">%Add the required classes to the static Java path if not already added</span>
+0039 addJavaPaths();
+0040 
+0041 excelFile=fullfile(ravenDir,<span class="string">'tutorial'</span>,<span class="string">'empty.xlsx'</span>);
+0042 xmlFile=fullfile(ravenDir,<span class="string">'tutorial'</span>,<span class="string">'empty.xml'</span>);
+0043 matFile=fullfile(ravenDir,<span class="string">'tutorial'</span>,<span class="string">'empty.mat'</span>);
+0044 
+0045 <span class="comment">%Check if it is possible to parse an Excel file</span>
+0046 fprintf(<span class="string">'Checking if it is possible to parse a model in Microsoft Excel format...\t'</span>);
+0047 <span class="keyword">try</span>
+0048     importExcelModel(excelFile,false,false,true);
+0049     fprintf(<span class="string">'OK\n'</span>);
+0050 <span class="keyword">catch</span>
+0051     fprintf(<span class="string">'Not OK\n'</span>);
+0052 <span class="keyword">end</span>
+0053 
+0054 <span class="comment">%Check if it is possible to import an SBML model using libSBML</span>
+0055 fprintf(<span class="string">'Checking if it is possible to import an SBML model using libSBML...\t\t\t'</span>);
+0056 <span class="keyword">try</span>
+0057     importModel(xmlFile);
+0058     <span class="keyword">try</span>
+0059         libSBMLver=OutputSBML; <span class="comment">% Only works in libSBML 5.17.0+</span>
+0060         fprintf(<span class="string">'OK\n'</span>);
+0061     <span class="keyword">catch</span>
+0062         fprintf([<span class="string">'Not OK\n\n'</span><span class="keyword">...</span>
+0063             <span class="string">'An older libSBML version was found, update to version 5.17.0 or higher\n'</span><span class="keyword">...</span>
+0064             <span class="string">'for a significant improvement of model import\n\n'</span>]);
+0065     <span class="keyword">end</span>
+0066 <span class="keyword">catch</span>
+0067     fprintf([<span class="string">'Not OK\nTo import SBML models, download libSBML from\n'</span><span class="keyword">...</span>
+0068         <span class="string">'http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n'</span>]);
+0069 <span class="keyword">end</span>
+0070 
+0071 <span class="comment">%Define values for keepSolver and workingSolvers, needed for solver</span>
+0072 <span class="comment">%functionality check</span>
+0073 keepSolver=false;
+0074 workingSolvers=<span class="string">''</span>;
+0075 <span class="comment">%Get current solver. Set it to 'none', if it is not set</span>
+0076 <span class="keyword">if</span> ~ispref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>)
+0077     fprintf(<span class="string">'Solver found in preferences... NONE\n'</span>);
+0078     setRavenSolver(<span class="string">'none'</span>);
 0079     curSolv=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0080     fprintf([<span class="string">'Solver found in preferences... '</span>,curSolv,<span class="string">'\n'</span>]);
-0081 <span class="keyword">end</span>
-0082 
-0083 <span class="comment">%Check if it is possible to solve an LP problem using different solvers</span>
-0084 solver={<span class="string">'gurobi'</span>,<span class="string">'cobra'</span>};
-0085 
-0086 <span class="keyword">for</span> i=1:numel(solver)
-0087     fprintf([<span class="string">'Checking if it is possible to solve an LP problem using '</span>,solver{i},<span class="string">'...\t\t\t'</span>]);
-0088     <span class="keyword">try</span>
-0089         setRavenSolver(solver{i});
-0090         load(matFile);
-0091         solveLP(emptyModel);
-0092         workingSolvers=strcat(workingSolvers,<span class="string">';'</span>,solver{i});
-0093         fprintf(<span class="string">'OK\n'</span>);
-0094         <span class="keyword">if</span> strcmp(curSolv,solver{i})
-0095             keepSolver=true;
-0096         <span class="keyword">end</span>
-0097     <span class="keyword">catch</span>
-0098         fprintf(<span class="string">'Not OK\n'</span>);
-0099     <span class="keyword">end</span>
-0100 <span class="keyword">end</span>
-0101 
-0102 <span class="keyword">if</span> keepSolver
-0103     <span class="comment">%The solver set in curSolv is functional, so the settings are restored</span>
-0104     <span class="comment">%to the ones which were set before running checkInstallation</span>
-0105     setRavenSolver(curSolv);
-0106     fprintf([<span class="string">'Preferred solver... KEPT\nSolver saved as preference... '</span>,curSolv,<span class="string">'\n\n'</span>]);
-0107 <span class="keyword">elseif</span> ~isempty(workingSolvers)
-0108     <span class="comment">%There are working solvers, but the none of them is the solver defined</span>
-0109     <span class="comment">%by curSolv. The first working solver is therefore set as RAVEN solver</span>
-0110     workingSolvers=regexprep(workingSolvers,<span class="string">'^;'</span>,<span class="string">''</span>);
-0111     workingSolvers=regexprep(workingSolvers,<span class="string">';.+$'</span>,<span class="string">''</span>);
-0112     <span class="comment">%Only one working solver should be left by now in workingSolvers</span>
-0113     setRavenSolver(workingSolvers);
-0114     fprintf([<span class="string">'Preferred solver... NEW\nSolver saved as preference... '</span>,workingSolvers,<span class="string">'\n\n'</span>]);
-0115 <span class="keyword">else</span>
-0116     <span class="comment">%No functional solvers were found, so the setting is restored back to</span>
-0117     <span class="comment">%original</span>
-0118     setRavenSolver(curSolv);
-0119     fprintf([<span class="string">'WARNING: No working solver was found!\n'</span><span class="keyword">...</span>
-0120         <span class="string">'Install the solver, set it using setRavenSolver(''solverName'') and run checkInstallation again\n'</span><span class="keyword">...</span>
-0121         <span class="string">'Available solverName options are ''mosek'', ''gurobi'' and ''cobra''\n\n'</span>]);
-0122 <span class="keyword">end</span>
-0123 
-0124 <span class="keyword">if</span> ismac
-0125     binEnd=<span class="string">'.mac'</span>;
-0126 <span class="keyword">elseif</span> isunix
-0127     binEnd=<span class="string">''</span>;
-0128 <span class="keyword">elseif</span> ispc
-0129     binEnd=<span class="string">'.exe'</span>;
-0130 <span class="keyword">end</span>
-0131 fprintf(<span class="string">'Checking essential binary executables:\n'</span>);
-0132 fprintf(<span class="string">'NOTE: Broken binary executables &lt;strong&gt;must be fixed&lt;/strong&gt; before running RAVEN\n'</span>);
-0133 fprintf([<span class="string">'\tmakeblastdb'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t'</span>]);
-0134 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'makeblastdb'</span> binEnd]) <span class="string">'&quot;'</span>]);
-0135 <span class="keyword">if</span> res==1
-0136     fprintf(<span class="string">'OK\n'</span>);
-0137 <span class="keyword">else</span>
-0138     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
-0139 <span class="keyword">end</span>
-0140 fprintf([<span class="string">'\tblastp'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
-0141 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'blastp'</span> binEnd]) <span class="string">'&quot;'</span>]);
-0142 <span class="keyword">if</span> res==1
-0143     fprintf(<span class="string">'OK\n'</span>);
-0144 <span class="keyword">else</span>
-0145     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
-0146 <span class="keyword">end</span>
-0147 fprintf([<span class="string">'\tdiamond'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
-0148 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot;'</span>]);
-0149 <span class="keyword">if</span> res==1
-0150     fprintf(<span class="string">'OK\n'</span>);
-0151 <span class="keyword">else</span>
-0152     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
-0153 <span class="keyword">end</span>
-0154 fprintf([<span class="string">'\thmmsearch'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t'</span>]);
-0155 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'hmmer'</span>,[<span class="string">'hmmsearch'</span> binEnd]) <span class="string">'&quot;'</span>]);
-0156 <span class="keyword">if</span> res==1
-0157     fprintf(<span class="string">'OK\n'</span>);
-0158 <span class="keyword">else</span>
-0159     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
-0160 <span class="keyword">end</span>
-0161 fprintf(<span class="string">'Checking non-essential/development binary executables:\n'</span>);
-0162 fprintf(<span class="string">'NOTE: Only fix these binaries if planning to use KEGG FTP dump files in getKEGGModelForOrganism\n'</span>);
-0163 fprintf([<span class="string">'\tcd-hit'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
-0164 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'cd-hit'</span>,[<span class="string">'cd-hit'</span> binEnd]) <span class="string">'&quot;'</span>]);
-0165 <span class="keyword">if</span> res==1
-0166     fprintf(<span class="string">'OK\n'</span>);
-0167 <span class="keyword">else</span>
-0168     fprintf(<span class="string">'Not OK! If necessary, download/compile the binary and run checkInstallation again\n'</span>);
-0169 <span class="keyword">end</span>
-0170 fprintf(<span class="string">'\tmafft.bat...\t\t\t\t\t\t\t\t'</span>);
-0171 <span class="keyword">if</span> ismac
-0172     [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'mafft'</span>,<span class="string">'mafft-mac'</span>,<span class="string">'mafft.bat'</span>) <span class="string">'&quot; --help '</span>]);
-0173 <span class="keyword">elseif</span> isunix
-0174     [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'mafft'</span>,<span class="string">'mafft-linux64'</span>,<span class="string">'mafft.bat'</span>) <span class="string">'&quot; --help '</span>]);
-0175 <span class="keyword">elseif</span> ispc
-0176     [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'mafft'</span>,<span class="string">'mafft-win'</span>,<span class="string">'mafft.bat'</span>) <span class="string">'&quot; --help '</span>]);
-0177 <span class="keyword">end</span>
-0178 <span class="keyword">if</span> res==1
-0179     fprintf(<span class="string">'OK\n'</span>);
-0180 <span class="keyword">else</span>
-0181     fprintf(<span class="string">'Not OK! If necessary, download/compile the binary and run checkInstallation again\n'</span>);
-0182 <span class="keyword">end</span>
-0183 fprintf([<span class="string">'\thmmbuild'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
-0184 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'hmmer'</span>,[<span class="string">'hmmbuild'</span> binEnd]) <span class="string">'&quot;'</span>]);
-0185 <span class="keyword">if</span> res==1
-0186     fprintf(<span class="string">'OK\n\n'</span>);
-0187 <span class="keyword">else</span>
-0188     fprintf(<span class="string">'Not OK! If necessary, download/compile the binary and run checkInstallation again\n'</span>);
-0189 <span class="keyword">end</span>
-0190 
-0191 fprintf(<span class="string">'Checking whether RAVEN functions are non-redundant across MATLAB path...\t'</span>);
-0192 <a href="checkFunctionUniqueness.html" class="code" title="function checkFunctionUniqueness()">checkFunctionUniqueness</a>();
-0193 
-0194 fprintf(<span class="string">'\n*** checkInstallation complete ***\n\n'</span>);
-0195 <span class="keyword">end</span></pre></div>
+0080 <span class="keyword">else</span>
+0081     curSolv=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0082     fprintf([<span class="string">'Solver found in preferences... '</span>,curSolv,<span class="string">'\n'</span>]);
+0083 <span class="keyword">end</span>
+0084 
+0085 <span class="comment">%Check if it is possible to solve an LP problem using different solvers</span>
+0086 solver={<span class="string">'gurobi'</span>,<span class="string">'cobra'</span>};
+0087 
+0088 <span class="keyword">for</span> i=1:numel(solver)
+0089     fprintf([<span class="string">'Checking if it is possible to solve an LP problem using '</span>,solver{i},<span class="string">'...\t\t\t'</span>]);
+0090     <span class="keyword">try</span>
+0091         setRavenSolver(solver{i});
+0092         load(matFile);
+0093         solveLP(emptyModel);
+0094         workingSolvers=strcat(workingSolvers,<span class="string">';'</span>,solver{i});
+0095         fprintf(<span class="string">'OK\n'</span>);
+0096         <span class="keyword">if</span> strcmp(curSolv,solver{i})
+0097             keepSolver=true;
+0098         <span class="keyword">end</span>
+0099     <span class="keyword">catch</span>
+0100         fprintf(<span class="string">'Not OK\n'</span>);
+0101     <span class="keyword">end</span>
+0102 <span class="keyword">end</span>
+0103 
+0104 <span class="keyword">if</span> keepSolver
+0105     <span class="comment">%The solver set in curSolv is functional, so the settings are restored</span>
+0106     <span class="comment">%to the ones which were set before running checkInstallation</span>
+0107     setRavenSolver(curSolv);
+0108     fprintf([<span class="string">'Preferred solver... KEPT\nSolver saved as preference... '</span>,curSolv,<span class="string">'\n\n'</span>]);
+0109 <span class="keyword">elseif</span> ~isempty(workingSolvers)
+0110     <span class="comment">%There are working solvers, but the none of them is the solver defined</span>
+0111     <span class="comment">%by curSolv. The first working solver is therefore set as RAVEN solver</span>
+0112     workingSolvers=regexprep(workingSolvers,<span class="string">'^;'</span>,<span class="string">''</span>);
+0113     workingSolvers=regexprep(workingSolvers,<span class="string">';.+$'</span>,<span class="string">''</span>);
+0114     <span class="comment">%Only one working solver should be left by now in workingSolvers</span>
+0115     setRavenSolver(workingSolvers);
+0116     fprintf([<span class="string">'Preferred solver... NEW\nSolver saved as preference... '</span>,workingSolvers,<span class="string">'\n\n'</span>]);
+0117 <span class="keyword">else</span>
+0118     <span class="comment">%No functional solvers were found, so the setting is restored back to</span>
+0119     <span class="comment">%original</span>
+0120     setRavenSolver(curSolv);
+0121     fprintf([<span class="string">'WARNING: No working solver was found!\n'</span><span class="keyword">...</span>
+0122         <span class="string">'Install the solver, set it using setRavenSolver(''solverName'') and run checkInstallation again\n'</span><span class="keyword">...</span>
+0123         <span class="string">'Available solverName options are ''gurobi'' and ''cobra''\n\n'</span>]);
+0124 <span class="keyword">end</span>
+0125 
+0126 <span class="keyword">if</span> ismac
+0127     binEnd=<span class="string">'.mac'</span>;
+0128 <span class="keyword">elseif</span> isunix
+0129     binEnd=<span class="string">''</span>;
+0130 <span class="keyword">elseif</span> ispc
+0131     binEnd=<span class="string">'.exe'</span>;
+0132 <span class="keyword">end</span>
+0133 fprintf(<span class="string">'Checking essential binary executables:\n'</span>);
+0134 fprintf(<span class="string">'NOTE: Broken binary executables &lt;strong&gt;must be fixed&lt;/strong&gt; before running RAVEN\n'</span>);
+0135 fprintf([<span class="string">'\tmakeblastdb'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t'</span>]);
+0136 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'makeblastdb'</span> binEnd]) <span class="string">'&quot;'</span>]);
+0137 <span class="keyword">if</span> res==1
+0138     fprintf(<span class="string">'OK\n'</span>);
+0139 <span class="keyword">else</span>
+0140     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
+0141 <span class="keyword">end</span>
+0142 fprintf([<span class="string">'\tblastp'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
+0143 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'blastp'</span> binEnd]) <span class="string">'&quot;'</span>]);
+0144 <span class="keyword">if</span> res==1
+0145     fprintf(<span class="string">'OK\n'</span>);
+0146 <span class="keyword">else</span>
+0147     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
+0148 <span class="keyword">end</span>
+0149 fprintf([<span class="string">'\tdiamond'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
+0150 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot;'</span>]);
+0151 <span class="keyword">if</span> res==1
+0152     fprintf(<span class="string">'OK\n'</span>);
+0153 <span class="keyword">else</span>
+0154     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
+0155 <span class="keyword">end</span>
+0156 fprintf([<span class="string">'\thmmsearch'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t'</span>]);
+0157 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'hmmer'</span>,[<span class="string">'hmmsearch'</span> binEnd]) <span class="string">'&quot;'</span>]);
+0158 <span class="keyword">if</span> res==1
+0159     fprintf(<span class="string">'OK\n'</span>);
+0160 <span class="keyword">else</span>
+0161     fprintf(<span class="string">'Not OK! Download/compile the binary and run checkInstallation again\n'</span>);
+0162 <span class="keyword">end</span>
+0163 fprintf(<span class="string">'Checking non-essential/development binary executables:\n'</span>);
+0164 fprintf(<span class="string">'NOTE: Only fix these binaries if planning to use KEGG FTP dump files in getKEGGModelForOrganism\n'</span>);
+0165 fprintf([<span class="string">'\tcd-hit'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
+0166 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'cd-hit'</span>,[<span class="string">'cd-hit'</span> binEnd]) <span class="string">'&quot;'</span>]);
+0167 <span class="keyword">if</span> res==1
+0168     fprintf(<span class="string">'OK\n'</span>);
+0169 <span class="keyword">else</span>
+0170     fprintf(<span class="string">'Not OK! If necessary, download/compile the binary and run checkInstallation again\n'</span>);
+0171 <span class="keyword">end</span>
+0172 fprintf(<span class="string">'\tmafft.bat...\t\t\t\t\t\t\t\t'</span>);
+0173 <span class="keyword">if</span> ismac
+0174     [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'mafft'</span>,<span class="string">'mafft-mac'</span>,<span class="string">'mafft.bat'</span>) <span class="string">'&quot; --help '</span>]);
+0175 <span class="keyword">elseif</span> isunix
+0176     [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'mafft'</span>,<span class="string">'mafft-linux64'</span>,<span class="string">'mafft.bat'</span>) <span class="string">'&quot; --help '</span>]);
+0177 <span class="keyword">elseif</span> ispc
+0178     [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'mafft'</span>,<span class="string">'mafft-win'</span>,<span class="string">'mafft.bat'</span>) <span class="string">'&quot; --help '</span>]);
+0179 <span class="keyword">end</span>
+0180 <span class="keyword">if</span> res==1
+0181     fprintf(<span class="string">'OK\n'</span>);
+0182 <span class="keyword">else</span>
+0183     fprintf(<span class="string">'Not OK! If necessary, download/compile the binary and run checkInstallation again\n'</span>);
+0184 <span class="keyword">end</span>
+0185 fprintf([<span class="string">'\thmmbuild'</span> binEnd <span class="string">'...\t\t\t\t\t\t\t\t'</span>]);
+0186 [res,~]=system([<span class="string">'&quot;'</span> fullfile(ravenDir,<span class="string">'software'</span>,<span class="string">'hmmer'</span>,[<span class="string">'hmmbuild'</span> binEnd]) <span class="string">'&quot;'</span>]);
+0187 <span class="keyword">if</span> res==1
+0188     fprintf(<span class="string">'OK\n\n'</span>);
+0189 <span class="keyword">else</span>
+0190     fprintf(<span class="string">'Not OK! If necessary, download/compile the binary and run checkInstallation again\n'</span>);
+0191 <span class="keyword">end</span>
+0192 
+0193 fprintf(<span class="string">'Checking whether RAVEN functions are non-redundant across MATLAB path...\t'</span>);
+0194 <a href="checkFunctionUniqueness.html" class="code" title="function checkFunctionUniqueness()">checkFunctionUniqueness</a>();
+0195 
+0196 fprintf(<span class="string">'\n*** checkInstallation complete ***\n\n'</span>);
+0197 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/io/exportModel.html
+++ b/doc/io/exportModel.html
@@ -281,7 +281,7 @@ This function is called by:
 0222     <span class="keyword">end</span>
 0223     
 0224     <span class="keyword">if</span> isfield(modelSBML.compartment,<span class="string">'metaid'</span>)
-0225         <span class="keyword">if</span> regexp(model.comps(i),<span class="string">'^[^a-zA-Z_]'</span>)
+0225         <span class="keyword">if</span> regexp(model.comps{i},<span class="string">'^[^a-zA-Z_]'</span>)
 0226             EM=<span class="string">'The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with &quot;c_&quot; string'</span>;
 0227             dispEM(EM,false);
 0228             model.comps(i)=strcat(<span class="string">'c_'</span>,model.comps(i));

--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -222,7 +222,7 @@ for i=1:numel(model.comps)
     end
     
     if isfield(modelSBML.compartment,'metaid')
-        if regexp(model.comps(i),'^[^a-zA-Z_]')
+        if regexp(model.comps{i},'^[^a-zA-Z_]')
             EM='The compartment IDs are in numeric format. For the compliance with SBML specifications, compartment IDs will be preceded with "c_" string';
             dispEM(EM,false);
             model.comps(i)=strcat('c_',model.comps(i));


### PR DESCRIPTION
### Main improvements in this PR:
- feat:
  - `checkModelStruct` confirms whether only one objective function is given, otherwise a warning is thrown (SBML L3V1 FBCv2 only allows 1 objective function) (solves #378)
- fix:
  - `exportModel` correctly checks for prefixes in model.comps.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR