### PR TITLE
refactor: convertToIrrev speedup

### DIFF
--- a/core/convertToIrrev.m
+++ b/core/convertToIrrev.m
@@ -14,12 +14,12 @@ function irrevModel=convertToIrrev(model,rxns)
 %   Usage: irrevModel=convertToIrrev(model,rxns)
 
 if nargin<2
-    rxns=model.rxns;
+    I=true(numel(model.rxns),1);
+else
+    I=getIndexes(model,rxns,'rxns',true);
 end
 
 irrevModel=model;
-
-I=getIndexes(model,rxns,'rxns',true);
 
 revIndexesBool=model.rev~=0 & I;
 revIndexes=find(revIndexesBool);


### PR DESCRIPTION
### Main improvements in this PR:
- refactor:
  - `convertToIrrev` when converting all reactions to irreversible. This reduces running time of `solveLP(model,1)` by ~50% on a yeast model.

**I hereby confirm that I have:**

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR