### PR TITLE
fix: addRxns new subSystems as cell arrays

### DIFF
--- a/core/addRxns.m
+++ b/core/addRxns.m
@@ -370,7 +370,7 @@ if isfield(rxnsToAdd,'subSystems')
     if ~isfield(newModel,'subSystems')
         newModel.subSystems=celllargefiller;
     end
-    newModel.subSystems=[newModel.subSystems;rxnsToAdd.subSystems(:)];
+    newModel.subSystems=[newModel.subSystems;rxnsToAdd.subSystems];
 else
     %Fill with standard if it doesn't exist
     if isfield(newModel,'subSystems')

--- a/doc/core/addRxns.html
+++ b/doc/core/addRxns.html
@@ -514,7 +514,7 @@ This function is called by:
 0370     <span class="keyword">if</span> ~isfield(newModel,<span class="string">'subSystems'</span>)
 0371         newModel.subSystems=celllargefiller;
 0372     <span class="keyword">end</span>
-0373     newModel.subSystems=[newModel.subSystems;rxnsToAdd.subSystems(:)];
+0373     newModel.subSystems=[newModel.subSystems;rxnsToAdd.subSystems];
 0374 <span class="keyword">else</span>
 0375     <span class="comment">%Fill with standard if it doesn't exist</span>
 0376     <span class="keyword">if</span> isfield(newModel,<span class="string">'subSystems'</span>)


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `addRxns` new subSystems should be cell arrays

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
