### PR TITLE
fix: relative paths on mac

### DIFF
--- a/doc/installation/checkInstallation.html
+++ b/doc/installation/checkInstallation.html
@@ -52,7 +52,7 @@ This function is called by:
 
 <h2><a name="_subfunctions"></a>SUBFUNCTIONS <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
 <ul style="list-style-image:url(../matlabicon.gif)">
-<li><a href="#_sub1" class="code">function interpretResults(results)</a></li><li><a href="#_sub2" class="code">function str = myStr(InputStr,len)</a></li></ul>
+<li><a href="#_sub1" class="code">function res=interpretResults(results)</a></li><li><a href="#_sub2" class="code">function str = myStr(InputStr,len)</a></li></ul>
 
 <h2><a name="_source"></a>SOURCE CODE <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
 <div class="fragment"><pre>0001 <a name="_sub0" href="#_subfunctions" class="code">function checkInstallation(develMode)</a>
@@ -73,229 +73,265 @@ This function is called by:
 0016     develMode=false;
 0017 <span class="keyword">end</span>
 0018 
-0019 <span class="comment">%Check if RAVEN is in the MATLAB path list</span>
-0020 paths=textscan(path,<span class="string">'%s'</span>,<span class="string">'delimiter'</span>, pathsep);
-0021 paths=paths{1};
+0019 <span class="comment">%Get the RAVEN path</span>
+0020 [ST, I]=dbstack(<span class="string">'-completenames'</span>);
+0021 [ravenDir,~,~]=fileparts(fileparts(ST(I).file));
 0022 
-0023 <span class="comment">%Get the RAVEN path</span>
-0024 [ST, I]=dbstack(<span class="string">'-completenames'</span>);
-0025 [ravenDir,~,~]=fileparts(fileparts(ST(I).file));
-0026 
-0027 fprintf(<span class="string">'\n*** THE RAVEN TOOLBOX ***\n\n'</span>);
-0028 <span class="comment">%Print the RAVEN version if it is not the development version</span>
-0029 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking RAVEN release:'</span>,40) <span class="string">'%f'</span>])
-0030 <span class="keyword">if</span> exist(fullfile(ravenDir,<span class="string">'version.txt'</span>), <span class="string">'file'</span>) == 2
-0031     fprintf([fgetl(fopen(fullfile(ravenDir,<span class="string">'version.txt'</span>))) <span class="string">'\n'</span>]);
-0032     fclose(<span class="string">'all'</span>);
-0033 <span class="keyword">else</span>
-0034     fprintf(<span class="string">'DEVELOPMENT\n'</span>);
-0035 <span class="keyword">end</span>
-0036 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking MATLAB release:'</span>,40) <span class="string">'%f'</span>])
-0037 fprintf([version(<span class="string">'-release'</span>) <span class="string">'\n'</span>])
-0038 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Set RAVEN in MATLAB path:'</span>,40) <span class="string">'%f'</span>])
-0039 subpath=regexp(genpath(ravenDir),pathsep,<span class="string">'split'</span>); <span class="comment">%List all subdirectories</span>
-0040 pathsToKeep=cellfun(@(x) isempty(strfind(x,<span class="string">'.git'</span>)),subpath) &amp; cellfun(@(x) isempty(strfind(x,<span class="string">'doc'</span>)),subpath);
-0041 addpath(strjoin(subpath(pathsToKeep),pathsep));
-0042 savepath
-0043 fprintf(<span class="string">'Pass\n'</span>);
-0044 
-0045 <span class="comment">%Check if it is possible to parse an Excel file</span>
-0046 fprintf(<span class="string">'\n=== Model import and export ===\n'</span>);
-0047 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Add Java paths for Excel format:'</span>,40) <span class="string">'%f'</span>])
-0048 <span class="keyword">try</span>
-0049     <span class="comment">%Add the required classes to the static Java path if not already added</span>
-0050     addJavaPaths();
-0051     fprintf(<span class="string">'Pass\n'</span>)
-0052 <span class="keyword">catch</span>
-0053     fprintf(<span class="string">'Fail\n'</span>)
-0054 <span class="keyword">end</span>
-0055 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Check libSBML version:'</span>,40) <span class="string">'%f'</span>])
-0056 <span class="keyword">try</span>
-0057     evalc(<span class="string">'importModel(fullfile(ravenDir,''tutorial'',''empty.xml''))'</span>);
-0058     <span class="keyword">try</span>
-0059         libSBMLver=OutputSBML; <span class="comment">% Only works in libSBML 5.17.0+</span>
-0060         fprintf([libSBMLver.libSBML_version_string <span class="string">'\n'</span>]);
-0061     <span class="keyword">catch</span>
-0062         fprintf(<span class="string">'Fail\n'</span>)
-0063         fprintf(<span class="string">'   An older libSBML version was found, update to version 5.17.0 or higher for a significant improvement of model import\n'</span>);
-0064     <span class="keyword">end</span>
-0065 <span class="keyword">catch</span>
-0066     fprintf(<span class="string">'Fail\n'</span>)
-0067     fprintf(<span class="string">'   Download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n'</span>);
-0068 <span class="keyword">end</span>
-0069 fprintf(<span class="string">' &gt; Checking model import and export:\n'</span>)
-0070 res=runtests(<span class="string">'importExportTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
-0071 
-0072 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Import Excel format:'</span>,40) <span class="string">'%f'</span>])
-0073 <span class="keyword">if</span> res(1).Passed == 1
-0074     fprintf(<span class="string">'Pass\n'</span>)
-0075 <span class="keyword">else</span>
-0076     fprintf(<span class="string">'Fail\n'</span>)
-0077 <span class="keyword">end</span>
-0078 
-0079 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Export Excel format:'</span>,40) <span class="string">'%f'</span>])
-0080 <span class="keyword">if</span> res(3).Passed == 1
-0081     fprintf(<span class="string">'Pass\n'</span>)
-0082 <span class="keyword">else</span>
-0083     fprintf(<span class="string">'Fail\n'</span>)
-0084 <span class="keyword">end</span>
-0085 
-0086 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Import SBML format:'</span>,40) <span class="string">'%f'</span>])
-0087 <span class="keyword">if</span> res(2).Passed == 1
-0088     fprintf(<span class="string">'Pass\n'</span>)
-0089 <span class="keyword">else</span>
+0023 fprintf(<span class="string">'\n*** THE RAVEN TOOLBOX ***\n\n'</span>);
+0024 <span class="comment">%Print the RAVEN version if it is not the development version</span>
+0025 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking RAVEN release'</span>,40) <span class="string">'%f'</span>]);
+0026 <span class="keyword">if</span> exist(fullfile(ravenDir,<span class="string">'version.txt'</span>), <span class="string">'file'</span>) == 2
+0027     currVer = fgetl(fopen(fullfile(ravenDir,<span class="string">'version.txt'</span>)));
+0028     fclose(<span class="string">'all'</span>);
+0029     fprintf([currVer <span class="string">'\n'</span>]);
+0030     <span class="keyword">try</span>
+0031         newVer=strtrim(webread(<span class="string">'https://raw.githubusercontent.com/SysBioChalmers/RAVEN/main/version.txt'</span>));
+0032         newVerNum=str2double(strsplit(newVer,<span class="string">'.'</span>));
+0033         currVer=str2double(strsplit(currVer,<span class="string">'.'</span>));
+0034         <span class="keyword">for</span> i=1:3
+0035             <span class="keyword">if</span> currVer(i)&lt;newVerNum(i)
+0036                 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Latest RAVEN release available'</span>,40) <span class="string">'%f'</span>])
+0037                 fprintf([newVer,<span class="string">'\n'</span>])
+0038                 hasGit=exist(fullfile(ravenDir,<span class="string">'.git'</span>),<span class="string">'file'</span>);
+0039                 <span class="keyword">if</span> hasGit==7
+0040                     fprintf(<span class="string">'     Run git pull in your favourite git client\n'</span>)
+0041                     fprintf(<span class="string">'     to get the latest RAVEN release\n'</span>);
+0042                 <span class="keyword">else</span>
+0043                     fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'     Instructions on how to upgrade'</span>,40) <span class="string">'%f'</span>])
+0044                     fprintf(<span class="string">'&lt;a href=&quot;https://github.com/SysBioChalmers/RAVEN/wiki/Installation#upgrade-to-latest-raven-release&quot;&gt;here&lt;/a&gt;\n'</span>);
+0045                 <span class="keyword">end</span>
+0046                 <span class="keyword">break</span>
+0047             <span class="keyword">elseif</span> i==3
+0048                 fprintf(<span class="string">'   &gt; You are running the latest RAVEN release\n'</span>);
+0049             <span class="keyword">end</span>
+0050         <span class="keyword">end</span>
+0051     <span class="keyword">catch</span>
+0052         fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Checking for latest RAVEN release'</span>,40) <span class="string">'%f'</span>])
+0053         fprintf(<span class="string">'Fail\n'</span>);
+0054         fprintf(<span class="string">'     Cannot reach GitHub for release info\n'</span>);
+0055     <span class="keyword">end</span>
+0056 <span class="keyword">else</span>
+0057     fprintf(<span class="string">'DEVELOPMENT\n'</span>);
+0058 <span class="keyword">end</span>
+0059 
+0060 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking MATLAB release'</span>,40) <span class="string">'%f'</span>])
+0061 fprintf([version(<span class="string">'-release'</span>) <span class="string">'\n'</span>])
+0062 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Set RAVEN in MATLAB path'</span>,40) <span class="string">'%f'</span>])
+0063 subpath=regexp(genpath(ravenDir),pathsep,<span class="string">'split'</span>); <span class="comment">%List all subdirectories</span>
+0064 pathsToKeep=cellfun(@(x) ~contains(x,<span class="string">'.git'</span>),subpath) &amp; cellfun(@(x) ~contains(x,<span class="string">'doc'</span>),subpath);
+0065 addpath(strjoin(subpath(pathsToKeep),pathsep));
+0066 savepath
+0067 fprintf(<span class="string">'Pass\n'</span>);
+0068 
+0069 <span class="comment">%Check if it is possible to parse an Excel file</span>
+0070 fprintf(<span class="string">'\n=== Model import and export ===\n'</span>);
+0071 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Add Java paths for Excel format'</span>,40) <span class="string">'%f'</span>])
+0072 <span class="keyword">try</span>
+0073     <span class="comment">%Add the required classes to the static Java path if not already added</span>
+0074     addJavaPaths();
+0075     fprintf(<span class="string">'Pass\n'</span>)
+0076 <span class="keyword">catch</span>
+0077     fprintf(<span class="string">'Fail\n'</span>)
+0078 <span class="keyword">end</span>
+0079 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking libSBML version'</span>,40) <span class="string">'%f'</span>])
+0080 <span class="keyword">try</span>
+0081     evalc(<span class="string">'importModel(fullfile(ravenDir,''tutorial'',''empty.xml''))'</span>);
+0082     <span class="keyword">try</span>
+0083         libSBMLver=OutputSBML; <span class="comment">% Only works in libSBML 5.17.0+</span>
+0084         fprintf([libSBMLver.libSBML_version_string <span class="string">'\n'</span>]);
+0085     <span class="keyword">catch</span>
+0086         fprintf(<span class="string">'Fail\n'</span>)
+0087         fprintf(<span class="string">'   An older libSBML version was found, update to version 5.17.0 or higher for a significant improvement of model import\n'</span>);
+0088     <span class="keyword">end</span>
+0089 <span class="keyword">catch</span>
 0090     fprintf(<span class="string">'Fail\n'</span>)
-0091 <span class="keyword">end</span>
-0092 
-0093 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Export SBML format:'</span>,40) <span class="string">'%f'</span>])
-0094 <span class="keyword">if</span> res(4).Passed == 1
-0095     fprintf(<span class="string">'Pass\n'</span>)
-0096 <span class="keyword">else</span>
-0097     fprintf(<span class="string">'Fail\n'</span>)
-0098 <span class="keyword">end</span>
-0099 
-0100 <span class="keyword">if</span> res(1).Passed~=1 &amp;&amp; res(3).Passed~=1 &amp;&amp; exist(<span class="string">'vaderSentimentScores.m'</span>)==2
-0101     fprintf([<span class="string">'   &gt; MATLAB Text Analytics Toolbox found. This should be\n'</span><span class="keyword">...</span>
-0102              <span class="string">'     uninstalled if you want to read/write Excel files.\n'</span><span class="keyword">...</span>
-0103              <span class="string">'     See RAVEN GitHub Issues page for instructions.\n'</span>])
-0104 <span class="keyword">end</span>
-0105 
-0106 <span class="comment">%Check if it is possible to import an YAML model</span>
-0107 <span class="comment">% fprintf(' &gt; Checking import of model in YAML format:\t\t\t');</span>
-0108 <span class="comment">% try</span>
-0109 <span class="comment">%     readYaml(ymlFile,true);</span>
-0110 <span class="comment">%     fprintf('Pass\n');</span>
-0111 <span class="comment">% catch</span>
-0112 <span class="comment">%     fprintf('Fail\n');</span>
-0113 <span class="comment">% end</span>
-0114 
-0115 fprintf(<span class="string">'\n=== Model solvers ===\n'</span>);
+0091     fprintf(<span class="string">'   Download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n'</span>);
+0092 <span class="keyword">end</span>
+0093 fprintf(<span class="string">' &gt; Checking model import and export\n'</span>)
+0094 res=runtests(<span class="string">'importExportTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0095 
+0096 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Import Excel format'</span>,40) <span class="string">'%f'</span>])
+0097 <span class="keyword">if</span> res(1).Passed == 1
+0098     fprintf(<span class="string">'Pass\n'</span>)
+0099 <span class="keyword">else</span>
+0100     fprintf(<span class="string">'Fail\n'</span>)
+0101 <span class="keyword">end</span>
+0102 
+0103 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Export Excel format'</span>,40) <span class="string">'%f'</span>])
+0104 <span class="keyword">if</span> res(3).Passed == 1
+0105     fprintf(<span class="string">'Pass\n'</span>)
+0106 <span class="keyword">else</span>
+0107     fprintf(<span class="string">'Fail\n'</span>)
+0108 <span class="keyword">end</span>
+0109 
+0110 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Import SBML format'</span>,40) <span class="string">'%f'</span>])
+0111 <span class="keyword">if</span> res(2).Passed == 1
+0112     fprintf(<span class="string">'Pass\n'</span>)
+0113 <span class="keyword">else</span>
+0114     fprintf(<span class="string">'Fail\n'</span>)
+0115 <span class="keyword">end</span>
 0116 
-0117 <span class="comment">%Get current solver. Set it to 'none', if it is not set</span>
-0118 fprintf(<span class="string">' &gt; Checking for functional LP solvers:\n'</span>)
-0119 res=runtests(<span class="string">'solverTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
-0120 
-0121 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; glpk:'</span>,40) <span class="string">'%f'</span>])
-0122 <span class="keyword">if</span> res(1).Passed == 1
-0123     fprintf(<span class="string">'Pass\n'</span>)
-0124 <span class="keyword">else</span>
-0125     fprintf(<span class="string">'Fail\n'</span>)
-0126 <span class="keyword">end</span>
-0127 
-0128 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; gurobi:'</span>,40) <span class="string">'%f'</span>])
-0129 <span class="keyword">if</span> res(2).Passed == 1
-0130     fprintf(<span class="string">'Pass\n'</span>)
-0131 <span class="keyword">else</span>
-0132     fprintf(<span class="string">'Fail\n'</span>)
-0133 <span class="keyword">end</span>
-0134 
-0135 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; cobra:'</span>,40) <span class="string">'%f'</span>])
-0136 <span class="keyword">if</span> res(3).Passed == 1
-0137     fprintf(<span class="string">'Pass\n'</span>)
-0138 <span class="keyword">else</span>
-0139     fprintf(<span class="string">'Fail\n'</span>)
-0140 <span class="keyword">end</span>
-0141 
-0142 fprintf(<span class="string">' &gt; Checking for functional MILP solvers:\n'</span>)
-0143 res=runtests(<span class="string">'fillGapsSmallTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0117 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Export SBML format'</span>,40) <span class="string">'%f'</span>])
+0118 <span class="keyword">if</span> res(4).Passed == 1
+0119     fprintf(<span class="string">'Pass\n'</span>)
+0120 <span class="keyword">else</span>
+0121     fprintf(<span class="string">'Fail\n'</span>)
+0122 <span class="keyword">end</span>
+0123 
+0124 <span class="keyword">if</span> res(1).Passed~=1 &amp;&amp; res(3).Passed~=1 &amp;&amp; exist(<span class="string">'vaderSentimentScores.m'</span>,<span class="string">'file'</span>)==2
+0125     fprintf([<span class="string">'   &gt; MATLAB Text Analytics Toolbox found. This should be\n'</span><span class="keyword">...</span>
+0126              <span class="string">'     uninstalled if you want to read/write Excel files.\n'</span><span class="keyword">...</span>
+0127              <span class="string">'     See RAVEN GitHub Issues page for instructions.\n'</span>])
+0128 <span class="keyword">end</span>
+0129 
+0130 <span class="comment">%Check if it is possible to import an YAML model</span>
+0131 <span class="comment">% fprintf(' &gt; Checking import of model in YAML format:\t\t\t');</span>
+0132 <span class="comment">% try</span>
+0133 <span class="comment">%     readYaml(ymlFile,true);</span>
+0134 <span class="comment">%     fprintf('Pass\n');</span>
+0135 <span class="comment">% catch</span>
+0136 <span class="comment">%     fprintf('Fail\n');</span>
+0137 <span class="comment">% end</span>
+0138 
+0139 fprintf(<span class="string">'\n=== Model solvers ===\n'</span>);
+0140 
+0141 <span class="comment">%Get current solver. Set it to 'none', if it is not set</span>
+0142 fprintf(<span class="string">' &gt; Checking for functional LP solvers\n'</span>)
+0143 res=runtests(<span class="string">'solverTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
 0144 
-0145 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; glpk:'</span>,40) <span class="string">'%f'</span>])
+0145 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; glpk'</span>,40) <span class="string">'%f'</span>])
 0146 <span class="keyword">if</span> res(1).Passed == 1
 0147     fprintf(<span class="string">'Pass\n'</span>)
 0148 <span class="keyword">else</span>
 0149     fprintf(<span class="string">'Fail\n'</span>)
 0150 <span class="keyword">end</span>
 0151 
-0152 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; gurobi:'</span>,40) <span class="string">'%f'</span>])
+0152 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; gurobi'</span>,40) <span class="string">'%f'</span>])
 0153 <span class="keyword">if</span> res(2).Passed == 1
 0154     fprintf(<span class="string">'Pass\n'</span>)
 0155 <span class="keyword">else</span>
 0156     fprintf(<span class="string">'Fail\n'</span>)
 0157 <span class="keyword">end</span>
 0158 
-0159 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; cobra:'</span>,40) <span class="string">'%f'</span>])
+0159 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; cobra'</span>,40) <span class="string">'%f'</span>])
 0160 <span class="keyword">if</span> res(3).Passed == 1
 0161     fprintf(<span class="string">'Pass\n'</span>)
 0162 <span class="keyword">else</span>
 0163     fprintf(<span class="string">'Fail\n'</span>)
 0164 <span class="keyword">end</span>
 0165 
-0166 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Set RAVEN solver:'</span>,40) <span class="string">'%f'</span>])
-0167 <span class="keyword">try</span>
-0168     oldSolver=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0169     solverIdx=find(strcmp(oldSolver,{<span class="string">'glpk'</span>,<span class="string">'gurobi'</span>,<span class="string">'cobra'</span>}));
-0170 <span class="keyword">catch</span>
-0171     solverIdx=0;
-0172 <span class="keyword">end</span>
-0173 <span class="comment">% Do not change old solver if functional</span>
-0174 <span class="keyword">if</span> solverIdx~=0 &amp;&amp; res(solverIdx).Passed == 1
-0175     fprintf([oldSolver <span class="string">'\n'</span>])
-0176 <span class="comment">% Order of preference: gurobi &gt; glpk &gt; cobra</span>
-0177 <span class="keyword">elseif</span> res(2).Passed == 1
-0178     fprintf(<span class="string">'gurobi\n'</span>)
-0179     setRavenSolver(<span class="string">'gurobi'</span>);
-0180 <span class="keyword">elseif</span> res(1).Passed == 1
-0181     fprintf(<span class="string">'glpk\n'</span>)
-0182     setRavenSolver(<span class="string">'glpk'</span>);
-0183 <span class="keyword">elseif</span> res(3).Passed == 1
-0184     fprintf(<span class="string">'cobra\n'</span>)
-0185     setRavenSolver(<span class="string">'cobra'</span>);
+0166 fprintf(<span class="string">' &gt; Checking for functional MILP solvers\n'</span>)
+0167 res=runtests(<span class="string">'fillGapsSmallTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0168 
+0169 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; glpk'</span>,40) <span class="string">'%f'</span>])
+0170 <span class="keyword">if</span> res(1).Passed == 1
+0171     fprintf(<span class="string">'Pass\n'</span>)
+0172 <span class="keyword">else</span>
+0173     fprintf(<span class="string">'Fail\n'</span>)
+0174 <span class="keyword">end</span>
+0175 
+0176 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; gurobi'</span>,40) <span class="string">'%f'</span>])
+0177 <span class="keyword">if</span> res(2).Passed == 1
+0178     fprintf(<span class="string">'Pass\n'</span>)
+0179 <span class="keyword">else</span>
+0180     fprintf(<span class="string">'Fail\n'</span>)
+0181 <span class="keyword">end</span>
+0182 
+0183 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; cobra'</span>,40) <span class="string">'%f'</span>])
+0184 <span class="keyword">if</span> res(3).Passed == 1
+0185     fprintf(<span class="string">'Pass\n'</span>)
 0186 <span class="keyword">else</span>
-0187     fprintf(<span class="string">'None, no functional solvers\n'</span>)
-0188     fprintf(<span class="string">'    The glpk should always be working, check your RAVEN installation to make sure all files are present\n'</span>)
-0189 <span class="keyword">end</span>
-0190 
-0191 fprintf(<span class="string">'\n=== Essential binary executables ===\n'</span>);
-0192 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking BLAST+:'</span>,40) <span class="string">'%f'</span>])
-0193 res=runtests(<span class="string">'blastPlusTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
-0194 <a href="#_sub1" class="code" title="subfunction interpretResults(results)">interpretResults</a>(res);
-0195 
-0196 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking DIAMOND:'</span>,40) <span class="string">'%f'</span>])
-0197 res=runtests(<span class="string">'diamondTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
-0198 <a href="#_sub1" class="code" title="subfunction interpretResults(results)">interpretResults</a>(res);
-0199 
-0200 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking HMMER:'</span>,40) <span class="string">'%f'</span>])
-0201 res=runtests(<span class="string">'hmmerTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
-0202 <a href="#_sub1" class="code" title="subfunction interpretResults(results)">interpretResults</a>(res);
-0203 
-0204 <span class="keyword">if</span> develMode
-0205     fprintf(<span class="string">'\n=== Development binary executables ===\n'</span>);
-0206     fprintf(<span class="string">'NOTE: These binaries are only required when using KEGG FTP dump files in getKEGGModelForOrganism\n'</span>);
-0207 
-0208     fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking CD-HIT:'</span>,40) <span class="string">'%f'</span>])
-0209     res=runtests(<span class="string">'cdhitTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
-0210     <a href="#_sub1" class="code" title="subfunction interpretResults(results)">interpretResults</a>(res);
-0211 
-0212     fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking MAFFT:'</span>,40) <span class="string">'%f'</span>])
-0213     res=runtests(<span class="string">'mafftTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
-0214     <a href="#_sub1" class="code" title="subfunction interpretResults(results)">interpretResults</a>(res);
-0215 <span class="keyword">end</span>
-0216 
-0217 fprintf(<span class="string">'\n=== Compatibility ===\n'</span>);
-0218 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking function uniqueness:'</span>,40) <span class="string">'%f'</span>])
-0219 <a href="checkFunctionUniqueness.html" class="code" title="function checkFunctionUniqueness()">checkFunctionUniqueness</a>();
-0220 
-0221 fprintf(<span class="string">'\n*** checkInstallation complete ***\n\n'</span>);
-0222 <span class="keyword">end</span>
-0223 
-0224 <a name="_sub1" href="#_subfunctions" class="code">function interpretResults(results)</a>
-0225 <span class="keyword">if</span> results.Failed==0 &amp;&amp; results.Incomplete==0
-0226     fprintf(<span class="string">'Pass\n'</span>);
-0227 <span class="keyword">else</span>
-0228     fprintf(<span class="string">'Fail\n'</span>)
-0229     fprintf(<span class="string">'   Download/compile the binary and rerun checkInstallation\n'</span>);
-0230 <span class="keyword">end</span>
-0231 <span class="keyword">end</span>
-0232 
-0233 <a name="_sub2" href="#_subfunctions" class="code">function str = myStr(InputStr,len)</a>
-0234 str=InputStr;
-0235 lenDiff = len - length(str);
-0236 <span class="keyword">if</span> lenDiff &lt; 0
-0237     warning(<span class="string">'String too long'</span>);
-0238 <span class="keyword">else</span>
-0239     str = [str blanks(lenDiff)];
-0240 <span class="keyword">end</span>
-0241 <span class="keyword">end</span></pre></div>
+0187     fprintf(<span class="string">'Fail\n'</span>)
+0188 <span class="keyword">end</span>
+0189 
+0190 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Set RAVEN solver'</span>,40) <span class="string">'%f'</span>])
+0191 <span class="keyword">try</span>
+0192     oldSolver=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0193     solverIdx=find(strcmp(oldSolver,{<span class="string">'glpk'</span>,<span class="string">'gurobi'</span>,<span class="string">'cobra'</span>}));
+0194 <span class="keyword">catch</span>
+0195     solverIdx=0;
+0196 <span class="keyword">end</span>
+0197 <span class="comment">% Do not change old solver if functional</span>
+0198 <span class="keyword">if</span> solverIdx~=0 &amp;&amp; res(solverIdx).Passed == 1
+0199     fprintf([oldSolver <span class="string">'\n'</span>])
+0200 <span class="comment">% Order of preference: gurobi &gt; glpk &gt; cobra</span>
+0201 <span class="keyword">elseif</span> res(2).Passed == 1
+0202     fprintf(<span class="string">'gurobi\n'</span>)
+0203     setRavenSolver(<span class="string">'gurobi'</span>);
+0204 <span class="keyword">elseif</span> res(1).Passed == 1
+0205     fprintf(<span class="string">'glpk\n'</span>)
+0206     setRavenSolver(<span class="string">'glpk'</span>);
+0207 <span class="keyword">elseif</span> res(3).Passed == 1
+0208     fprintf(<span class="string">'cobra\n'</span>)
+0209     setRavenSolver(<span class="string">'cobra'</span>);
+0210 <span class="keyword">else</span>
+0211     fprintf(<span class="string">'None, no functional solvers\n'</span>)
+0212     fprintf(<span class="string">'    The glpk should always be working, check your RAVEN installation to make sure all files are present\n'</span>)
+0213 <span class="keyword">end</span>
+0214 
+0215 fprintf(<span class="string">'\n=== Essential binary executables ===\n'</span>);
+0216 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking BLAST+'</span>,40) <span class="string">'%f'</span>])
+0217 res=runtests(<span class="string">'blastPlusTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0218 res=<a href="#_sub1" class="code" title="subfunction res=interpretResults(results)">interpretResults</a>(res);
+0219 <span class="keyword">if</span> res==false
+0220     fprintf(<span class="string">'   This is essential to run getBlast()\n'</span>)
+0221 <span class="keyword">end</span>
+0222 
+0223 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking DIAMOND'</span>,40) <span class="string">'%f'</span>])
+0224 res=runtests(<span class="string">'diamondTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0225 res=<a href="#_sub1" class="code" title="subfunction res=interpretResults(results)">interpretResults</a>(res);
+0226 <span class="keyword">if</span> res==false
+0227     fprintf(<span class="string">'   This is essential to run the getDiamond()\n'</span>)
+0228 <span class="keyword">end</span>
+0229 
+0230 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking HMMER'</span>,40) <span class="string">'%f'</span>])
+0231 res=runtests(<span class="string">'hmmerTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0232 res=<a href="#_sub1" class="code" title="subfunction res=interpretResults(results)">interpretResults</a>(res);
+0233 <span class="keyword">if</span> res==false
+0234     fprintf([<span class="string">'   This is essential to run getKEGGModelFromHomology()\n'</span><span class="keyword">...</span>
+0235              <span class="string">'   when using a FASTA file as input\n'</span>])
+0236 <span class="keyword">end</span>
+0237 
+0238 <span class="keyword">if</span> develMode
+0239     fprintf(<span class="string">'\n=== Development binary executables ===\n'</span>);
+0240     fprintf(<span class="string">'NOTE: These binaries are only required when using KEGG FTP dump files in getKEGGModelForOrganism\n'</span>);
+0241 
+0242     fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking CD-HIT'</span>,40) <span class="string">'%f'</span>])
+0243     res=runtests(<span class="string">'cdhitTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0244     <a href="#_sub1" class="code" title="subfunction res=interpretResults(results)">interpretResults</a>(res);
+0245 
+0246     fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking MAFFT'</span>,40) <span class="string">'%f'</span>])
+0247     res=runtests(<span class="string">'mafftTests.m'</span>,<span class="string">'OutputDetail'</span>,0);
+0248     <a href="#_sub1" class="code" title="subfunction res=interpretResults(results)">interpretResults</a>(res);
+0249 <span class="keyword">end</span>
+0250 
+0251 fprintf(<span class="string">'\n=== Compatibility ===\n'</span>);
+0252 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking function uniqueness'</span>,40) <span class="string">'%f'</span>])
+0253 <a href="checkFunctionUniqueness.html" class="code" title="function checkFunctionUniqueness()">checkFunctionUniqueness</a>();
+0254 
+0255 fprintf(<span class="string">'\n*** checkInstallation complete ***\n\n'</span>);
+0256 <span class="keyword">end</span>
+0257 
+0258 <a name="_sub1" href="#_subfunctions" class="code">function res=interpretResults(results)</a>
+0259 <span class="keyword">if</span> results.Failed==0 &amp;&amp; results.Incomplete==0
+0260     fprintf(<span class="string">'Pass\n'</span>);
+0261     res=true;
+0262 <span class="keyword">else</span>
+0263     fprintf(<span class="string">'Fail\n'</span>)
+0264     fprintf(<span class="string">'   Download/compile the binary and rerun checkInstallation\n'</span>);
+0265     res=false;
+0266 <span class="keyword">end</span>
+0267 <span class="keyword">end</span>
+0268 
+0269 <a name="_sub2" href="#_subfunctions" class="code">function str = myStr(InputStr,len)</a>
+0270 str=InputStr;
+0271 lenDiff = len - length(str);
+0272 <span class="keyword">if</span> lenDiff &lt; 0
+0273     warning(<span class="string">'String too long'</span>);
+0274 <span class="keyword">else</span>
+0275     str = [str blanks(lenDiff)];
+0276 <span class="keyword">end</span>
+0277 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/io/checkFileExistence.html
+++ b/doc/io/checkFileExistence.html
@@ -116,7 +116,7 @@ This function is called by:
 0047 <span class="keyword">if</span> ispc <span class="comment">% full path starts like &quot;C:\&quot;</span>
 0048     inCurrDir = cellfun(@isempty,regexpi(files,<span class="string">'^[a-z]\:\\'</span>));
 0049 <span class="keyword">else</span> <span class="comment">%isunix full path starts like &quot;/&quot;</span>
-0050     inCurrDir = cellfun(@isempty,regexpi(files,<span class="string">'\/'</span>));
+0050     inCurrDir = cellfun(@isempty,regexpi(files,<span class="string">'^\/'</span>));
 0051 <span class="keyword">end</span>
 0052 files(inCurrDir) = fullfile(cd,files(inCurrDir));
 0053 

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -16,35 +16,59 @@ if nargin<1
     develMode=false;
 end
 
-%Check if RAVEN is in the MATLAB path list
-paths=textscan(path,'%s','delimiter', pathsep);
-paths=paths{1};
-
 %Get the RAVEN path
 [ST, I]=dbstack('-completenames');
 [ravenDir,~,~]=fileparts(fileparts(ST(I).file));
 
 fprintf('\n*** THE RAVEN TOOLBOX ***\n\n');
 %Print the RAVEN version if it is not the development version
-fprintf([myStr(' > Checking RAVEN release:',40) '%f'])
+fprintf([myStr(' > Checking RAVEN release',40) '%f']);
 if exist(fullfile(ravenDir,'version.txt'), 'file') == 2
-    fprintf([fgetl(fopen(fullfile(ravenDir,'version.txt'))) '\n']);
+    currVer = fgetl(fopen(fullfile(ravenDir,'version.txt')));
     fclose('all');
+    fprintf([currVer '\n']);
+    try
+        newVer=strtrim(webread('https://raw.githubusercontent.com/SysBioChalmers/RAVEN/main/version.txt'));
+        newVerNum=str2double(strsplit(newVer,'.'));
+        currVer=str2double(strsplit(currVer,'.'));
+        for i=1:3
+            if currVer(i)<newVerNum(i)
+                fprintf([myStr('   > Latest RAVEN release available',40) '%f'])
+                fprintf([newVer,'\n'])
+                hasGit=exist(fullfile(ravenDir,'.git'),'file');
+                if hasGit==7
+                    fprintf('     Run git pull in your favourite git client\n')
+                    fprintf('     to get the latest RAVEN release\n');
+                else
+                    fprintf([myStr('     Instructions on how to upgrade',40) '%f'])
+                    fprintf('<a href="https://github.com/SysBioChalmers/RAVEN/wiki/Installation#upgrade-to-latest-raven-release">here</a>\n');
+                end
+                break
+            elseif i==3
+                fprintf('   > You are running the latest RAVEN release\n');
+            end
+        end
+    catch
+        fprintf([myStr('   > Checking for latest RAVEN release',40) '%f'])
+        fprintf('Fail\n');
+        fprintf('     Cannot reach GitHub for release info\n');
+    end
 else
     fprintf('DEVELOPMENT\n');
 end
-fprintf([myStr(' > Checking MATLAB release:',40) '%f'])
+
+fprintf([myStr(' > Checking MATLAB release',40) '%f'])
 fprintf([version('-release') '\n'])
-fprintf([myStr(' > Set RAVEN in MATLAB path:',40) '%f'])
+fprintf([myStr(' > Set RAVEN in MATLAB path',40) '%f'])
 subpath=regexp(genpath(ravenDir),pathsep,'split'); %List all subdirectories
-pathsToKeep=cellfun(@(x) isempty(strfind(x,'.git')),subpath) & cellfun(@(x) isempty(strfind(x,'doc')),subpath);
+pathsToKeep=cellfun(@(x) ~contains(x,'.git'),subpath) & cellfun(@(x) ~contains(x,'doc'),subpath);
 addpath(strjoin(subpath(pathsToKeep),pathsep));
 savepath
 fprintf('Pass\n');
 
 %Check if it is possible to parse an Excel file
 fprintf('\n=== Model import and export ===\n');
-fprintf([myStr(' > Add Java paths for Excel format:',40) '%f'])
+fprintf([myStr(' > Add Java paths for Excel format',40) '%f'])
 try
     %Add the required classes to the static Java path if not already added
     addJavaPaths();
@@ -52,7 +76,7 @@ try
 catch
     fprintf('Fail\n')
 end
-fprintf([myStr(' > Check libSBML version:',40) '%f'])
+fprintf([myStr(' > Checking libSBML version',40) '%f'])
 try
     evalc('importModel(fullfile(ravenDir,''tutorial'',''empty.xml''))');
     try
@@ -66,38 +90,38 @@ catch
     fprintf('Fail\n')
     fprintf('   Download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n');
 end
-fprintf(' > Checking model import and export:\n')
+fprintf(' > Checking model import and export\n')
 res=runtests('importExportTests.m','OutputDetail',0);
 
-fprintf([myStr('   > Import Excel format:',40) '%f'])
+fprintf([myStr('   > Import Excel format',40) '%f'])
 if res(1).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr('   > Export Excel format:',40) '%f'])
+fprintf([myStr('   > Export Excel format',40) '%f'])
 if res(3).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr('   > Import SBML format:',40) '%f'])
+fprintf([myStr('   > Import SBML format',40) '%f'])
 if res(2).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr('   > Export SBML format:',40) '%f'])
+fprintf([myStr('   > Export SBML format',40) '%f'])
 if res(4).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-if res(1).Passed~=1 && res(3).Passed~=1 && exist('vaderSentimentScores.m')==2
+if res(1).Passed~=1 && res(3).Passed~=1 && exist('vaderSentimentScores.m','file')==2
     fprintf(['   > MATLAB Text Analytics Toolbox found. This should be\n'...
              '     uninstalled if you want to read/write Excel files.\n'...
              '     See RAVEN GitHub Issues page for instructions.\n'])
@@ -115,55 +139,55 @@ end
 fprintf('\n=== Model solvers ===\n');
 
 %Get current solver. Set it to 'none', if it is not set
-fprintf(' > Checking for functional LP solvers:\n')
+fprintf(' > Checking for functional LP solvers\n')
 res=runtests('solverTests.m','OutputDetail',0);
 
-fprintf([myStr('   > glpk:',40) '%f'])
+fprintf([myStr('   > glpk',40) '%f'])
 if res(1).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr('   > gurobi:',40) '%f'])
+fprintf([myStr('   > gurobi',40) '%f'])
 if res(2).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr('   > cobra:',40) '%f'])
+fprintf([myStr('   > cobra',40) '%f'])
 if res(3).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf(' > Checking for functional MILP solvers:\n')
+fprintf(' > Checking for functional MILP solvers\n')
 res=runtests('fillGapsSmallTests.m','OutputDetail',0);
 
-fprintf([myStr('   > glpk:',40) '%f'])
+fprintf([myStr('   > glpk',40) '%f'])
 if res(1).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr('   > gurobi:',40) '%f'])
+fprintf([myStr('   > gurobi',40) '%f'])
 if res(2).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr('   > cobra:',40) '%f'])
+fprintf([myStr('   > cobra',40) '%f'])
 if res(3).Passed == 1
     fprintf('Pass\n')
 else
     fprintf('Fail\n')
 end
 
-fprintf([myStr(' > Set RAVEN solver:',40) '%f'])
+fprintf([myStr(' > Set RAVEN solver',40) '%f'])
 try
     oldSolver=getpref('RAVEN','solver');
     solverIdx=find(strcmp(oldSolver,{'glpk','gurobi','cobra'}));
@@ -189,44 +213,56 @@ else
 end
 
 fprintf('\n=== Essential binary executables ===\n');
-fprintf([myStr(' > Checking BLAST+:',40) '%f'])
+fprintf([myStr(' > Checking BLAST+',40) '%f'])
 res=runtests('blastPlusTests.m','OutputDetail',0);
-interpretResults(res);
+res=interpretResults(res);
+if res==false
+    fprintf('   This is essential to run getBlast()\n')
+end
 
-fprintf([myStr(' > Checking DIAMOND:',40) '%f'])
+fprintf([myStr(' > Checking DIAMOND',40) '%f'])
 res=runtests('diamondTests.m','OutputDetail',0);
-interpretResults(res);
+res=interpretResults(res);
+if res==false
+    fprintf('   This is essential to run the getDiamond()\n')
+end
 
-fprintf([myStr(' > Checking HMMER:',40) '%f'])
+fprintf([myStr(' > Checking HMMER',40) '%f'])
 res=runtests('hmmerTests.m','OutputDetail',0);
-interpretResults(res);
+res=interpretResults(res);
+if res==false
+    fprintf(['   This is essential to run getKEGGModelFromHomology()\n'...
+             '   when using a FASTA file as input\n'])
+end
 
 if develMode
     fprintf('\n=== Development binary executables ===\n');
     fprintf('NOTE: These binaries are only required when using KEGG FTP dump files in getKEGGModelForOrganism\n');
 
-    fprintf([myStr(' > Checking CD-HIT:',40) '%f'])
+    fprintf([myStr(' > Checking CD-HIT',40) '%f'])
     res=runtests('cdhitTests.m','OutputDetail',0);
     interpretResults(res);
 
-    fprintf([myStr(' > Checking MAFFT:',40) '%f'])
+    fprintf([myStr(' > Checking MAFFT',40) '%f'])
     res=runtests('mafftTests.m','OutputDetail',0);
     interpretResults(res);
 end
 
 fprintf('\n=== Compatibility ===\n');
-fprintf([myStr(' > Checking function uniqueness:',40) '%f'])
+fprintf([myStr(' > Checking function uniqueness',40) '%f'])
 checkFunctionUniqueness();
 
 fprintf('\n*** checkInstallation complete ***\n\n');
 end
 
-function interpretResults(results)
+function res=interpretResults(results)
 if results.Failed==0 && results.Incomplete==0
     fprintf('Pass\n');
+    res=true;
 else
     fprintf('Fail\n')
     fprintf('   Download/compile the binary and rerun checkInstallation\n');
+    res=false;
 end
 end
 

--- a/io/checkFileExistence.m
+++ b/io/checkFileExistence.m
@@ -47,7 +47,7 @@ filesOriginal = files;
 if ispc % full path starts like "C:\"
     inCurrDir = cellfun(@isempty,regexpi(files,'^[a-z]\:\\'));
 else %isunix full path starts like "/"
-    inCurrDir = cellfun(@isempty,regexpi(files,'\/'));
+    inCurrDir = cellfun(@isempty,regexpi(files,'^\/'));
 end
 files(inCurrDir) = fullfile(cd,files(inCurrDir));
 


### PR DESCRIPTION
### Main improvements in this PR:
- fix
  - correctly parse relative paths to model files on Mac/Unix (e.g. by `importModel`)
- feature
  - `checkInstallation` checks if a new RAVEN version is available on GitHub, and gives instructions on how to proceed

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
