### PR TITLE
fix: executable binaries on Mac

### DIFF
--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -291,19 +291,18 @@ end
 end
 
 function status = makeBinaryExecutable()
-if isunix
-    if ismac
-        binEnd='.mac';
-    else
-        binEnd='';
-    end
-else
+if ispc
     status = 0; % No need to run on Windows
     return;
+elseif ismac
+    binaryEnd='.mac';
+else
+    binaryEnd='';
 end
-binaryList = {'TranslateSBML','OutputSBML','blastp','makeblastdb',...
-              'diamond','glpkcc','cd-hit','hmmbuild','hmmsearch',...
-              'mafft.bat','mafft'}
+
+binaryList = {'blastp','makeblastdb','diamond','cd-hit','hmmbuild','hmmsearch'};
+binaryList = strcat(binaryList,binaryEnd);
+binaryList = [binaryList, 'TranslateSBML','OutputSBML','glpkcc','mafft.bat'];
 for i=1:numel(binaryList)
     binPath = which(binaryList{i});
     [status,cmdout] = system(['chmod +x ' binPath]);

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -61,6 +61,16 @@ fprintf([myStr(' > Checking MATLAB release',40) '%f'])
 fprintf([version('-release') '\n'])
 fprintf([myStr(' > Checking system architecture',40) '%f'])
 fprintf([computer('arch'),'\n'])
+if isunix
+    fprintf([myStr('   > Make binaries executable',40) '%f'])
+    status = makeBinaryExecutable();
+    if status == 0
+        fprintf('Pass\n')
+    else
+        fprintf('Fail\n')
+    end
+end
+fprintf([computer('arch'),'\n'])
 fprintf([myStr(' > Set RAVEN in MATLAB path',40) '%f'])
 subpath=regexp(genpath(ravenDir),pathsep,'split'); %List all subdirectories
 pathsToKeep=cellfun(@(x) ~contains(x,'.git'),subpath) & cellfun(@(x) ~contains(x,'doc'),subpath);
@@ -259,7 +269,7 @@ checkFunctionUniqueness();
 fprintf('\n*** checkInstallation complete ***\n\n');
 end
 
-function res=interpretResults(results)
+function res = interpretResults(results)
 if results.Failed==0 && results.Incomplete==0
     fprintf('Pass\n');
     res=true;
@@ -277,5 +287,28 @@ if lenDiff < 0
     warning('String too long');
 else
     str = [str blanks(lenDiff)];
+end
+end
+
+function status = makeBinaryExecutable()
+if isunix
+    if ismac
+        binEnd='.mac';
+    else
+        binEnd='';
+    end
+else
+    status = 0; % No need to run on Windows
+    return;
+end
+binaryList = {'TranslateSBML','OutputSBML','blastp','makeblastdb',...
+              'diamond','glpkcc','cd-hit','hmmbuild','hmmsearch',...
+              'mafft.bat','mafft'}
+for i=1:numel(binaryList)
+    binPath = which(binaryList{i});
+    [status,cmdout] = system(['chmod +x ' binPath]);
+    if status ~= 0
+        error('Failed to make %s executable: %s ',binaryList{i},strip(cmdout))
+    end
 end
 end

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -70,7 +70,6 @@ if isunix
         fprintf('Fail\n')
     end
 end
-fprintf([computer('arch'),'\n'])
 fprintf([myStr(' > Set RAVEN in MATLAB path',40) '%f'])
 subpath=regexp(genpath(ravenDir),pathsep,'split'); %List all subdirectories
 pathsToKeep=cellfun(@(x) ~contains(x,'.git'),subpath) & cellfun(@(x) ~contains(x,'doc'),subpath);
@@ -305,7 +304,7 @@ binaryList = strcat(binaryList,binaryEnd);
 binaryList = [binaryList, 'TranslateSBML','OutputSBML','glpkcc','mafft.bat'];
 for i=1:numel(binaryList)
     binPath = which(binaryList{i});
-    [status,cmdout] = system(['chmod +x ' binPath]);
+    [status,cmdout] = system(['chmod +x "' binPath '"']);
     if status ~= 0
         error('Failed to make %s executable: %s ',binaryList{i},strip(cmdout))
     end


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `checkInstallation` ensures that binaries (blastp etc.) and MEX files (TranslateSBML etc.) are executable on Mac, as this is not the case if RAVEN is installed as [MATLAB Add-On](https://se.mathworks.com/matlabcentral/fileexchange/112330-raven-toolbox)

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
