### PR TITLE
fix: resume field `b` in fitTasks

### DIFF
--- a/core/fitTasks.m
+++ b/core/fitTasks.m
@@ -326,5 +326,6 @@ for i=1:numel(taskStructure)
         dispEM(EM,false);
     end
 end
+model.b(:,2) = [];  % resume field b
 outModel=model;
 end


### PR DESCRIPTION
### Main improvements in this PR:
- fix bug in `fitTasks` that is failed to do restore field `b` in the end. This is discovered by the issue [#22](https://github.com/SysBioChalmers/Mouse-GEM/issues/22) reported in Mouse-GEM 

**I hereby confirm that I have:**

- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
