### PR TITLE
fix: Made the int tolerance less sensitive in ftINIT - there was a pr…

### DIFF
--- a/INIT/ftINITInternalAlg.m
+++ b/INIT/ftINITInternalAlg.m
@@ -382,7 +382,15 @@ else
     prob.csense = '=';
 end
 
-params.intTol = 10^-8; %This value seems to work - making it smaller may slow the solver down.
+params.intTol = 10^-7; %This value is very important. If set too low
+                       %there is a risk that gurobi fails due to numerical
+                       %issues - this happened for Gurobi v. 10.0 with TestModelL.
+                       %On the other hand, it shouldn't be too large
+                       %either. With this value, fluxes of 10-7 can slip
+                       %through, which should be fine. Another option if
+                       %this becomes a problem is to set NumericFocus=2,
+                       %which makes the solver slower but fixes the issue
+                       %with TestModelL.
 
 prob.osense = 1; %minimize
 


### PR DESCRIPTION
### Main improvements in this PR:
Fixed a problem with ftINIT if the user is using Gurobi v. 10. This version of Gurobi is more sensitive to having low int tolerances, so it was increased slightly. The test cases did not pass otherwise. I have been in contact with Gurobi about this.


- [X] Tested my code on my own machine
- [X] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [X] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
