### PR TITLE
fix: binary executable in mac

### DIFF
--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -322,10 +322,10 @@ binList = {fullfile(binDir,'blast+','blastp');
            fullfile(binDir,'GLPKmex','glpkcc');
            fullfile(binDir,'libSBML','TranslateSBML');
            fullfile(binDir,'libSBML','OutputSBML');
-           fullfile(binDir,'mafft-linux64','mafft.bat');
-           fullfile(binDir,'mafft-mac','mafft.bat');};
+           fullfile(binDir,'mafft','mafft-linux64','mafft.bat');
+           fullfile(binDir,'mafft','mafft-mac','mafft.bat');};
 if ismac
-    binList(1:5) = strcat(binList(1:5),'.mac');
+    binList(1:6) = strcat(binList(1:6),'.mac');
     binList(10) = [];
 else
     binList(9) = [];


### PR DESCRIPTION
### Main improvements in this PR:

- fix bug where `checkInstallation` failed to do function find the path for binaries on Mac

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->

- [x] Tested my code on my own machine
- [x] Followed the [development guidelines](https://github.com/SysBioChalmers/RAVEN/wiki/DevGuidelines).
- [x] Selected `devel` as a target branch
- [ ] If needed, asked first in the [Gitter chat room](https://gitter.im/SysBioChalmers/RAVEN) about this PR
