### PR TITLE
fix: checkInstallation printOrange function

### DIFF
--- a/doc/installation/checkInstallation.html
+++ b/doc/installation/checkInstallation.html
@@ -57,7 +57,7 @@ This function is called by:
 
 <h2><a name="_subfunctions"></a>SUBFUNCTIONS <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
 <ul style="list-style-image:url(../matlabicon.gif)">
-<li><a href="#_sub1" class="code">function res = interpretResults(results)</a></li><li><a href="#_sub2" class="code">function str = myStr(InputStr,len)</a></li><li><a href="#_sub3" class="code">function status = makeBinaryExecutable()</a></li></ul>
+<li><a href="#_sub1" class="code">function res = interpretResults(results)</a></li><li><a href="#_sub2" class="code">function str = myStr(InputStr,len)</a></li><li><a href="#_sub3" class="code">function status = makeBinaryExecutable()</a></li><li><a href="#_sub4" class="code">function printOrange(stringToPrint)</a></li></ul>
 
 <h2><a name="_source"></a>SOURCE CODE <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
 <div class="fragment"><pre>0001 <a name="_sub0" href="#_subfunctions" class="code">function currVer = checkInstallation(developMode)</a>
@@ -112,13 +112,13 @@ This function is called by:
 0050             <span class="keyword">for</span> i=1:3
 0051                 <span class="keyword">if</span> currVerNum(i)&lt;newVerNum(i)
 0052                     fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Latest RAVEN release available'</span>,40) <span class="string">'%f'</span>])
-0053                     printOrange([newVer,<span class="string">'\n'</span>])
+0053                     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>([newVer,<span class="string">'\n'</span>])
 0054                     hasGit=isfolder(fullfile(ravenDir,<span class="string">'.git'</span>));
 0055                     <span class="keyword">if</span> hasGit
-0056                         printOrange(<span class="string">'     Run git pull in your favourite git client\n'</span>)
-0057                         printOrange(<span class="string">'     to get the latest RAVEN release\n'</span>);
+0056                         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     Run git pull in your favourite git client\n'</span>)
+0057                         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     to get the latest RAVEN release\n'</span>);
 0058                     <span class="keyword">else</span>
-0059                         printOrange([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'     Instructions on how to upgrade'</span>,40) <span class="string">'%f'</span>])
+0059                         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'     Instructions on how to upgrade'</span>,40) <span class="string">'%f'</span>])
 0060                         fprintf(<span class="string">'&lt;a href=&quot;https://github.com/SysBioChalmers/RAVEN/wiki/Installation#upgrade-to-latest-raven-release&quot;&gt;here&lt;/a&gt;\n'</span>);
 0061                     <span class="keyword">end</span>
 0062                     <span class="keyword">break</span>
@@ -128,8 +128,8 @@ This function is called by:
 0066             <span class="keyword">end</span>
 0067         <span class="keyword">catch</span>
 0068             fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Checking for latest RAVEN release'</span>,40) <span class="string">'%f'</span>])
-0069             printOrange(<span class="string">'Fail\n'</span>);
-0070             printOrange(<span class="string">'     Cannot reach GitHub for release info\n'</span>);
+0069             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>);
+0070             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     Cannot reach GitHub for release info\n'</span>);
 0071         <span class="keyword">end</span>
 0072     <span class="keyword">end</span>
 0073 <span class="keyword">else</span>
@@ -156,12 +156,12 @@ This function is called by:
 0094         savepath
 0095         fprintf(<span class="string">'Pass\n'</span>)   
 0096     <span class="keyword">catch</span>
-0097         printOrange(<span class="string">'Fail\n'</span>)
+0097         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0098         fprintf([<span class="string">'   You might have to rerun checkInstallation again\n'</span><span class="keyword">...</span>
 0099                  <span class="string">'   next time you start up MATLAB\n'</span>])        
 0100     <span class="keyword">end</span>
 0101 <span class="keyword">catch</span>
-0102     printOrange(<span class="string">'Fail\n'</span>)
+0102     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0103 <span class="keyword">end</span>
 0104 
 0105 <span class="keyword">if</span> isunix
@@ -170,7 +170,7 @@ This function is called by:
 0108     <span class="keyword">if</span> status == 0
 0109         fprintf(<span class="string">'Pass\n'</span>)
 0110     <span class="keyword">else</span>
-0111         printOrange(<span class="string">'Fail\n'</span>)
+0111         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0112     <span class="keyword">end</span>
 0113 <span class="keyword">end</span>
 0114 
@@ -182,7 +182,7 @@ This function is called by:
 0120     addJavaPaths();
 0121     fprintf(<span class="string">'Pass\n'</span>)
 0122 <span class="keyword">catch</span>
-0123     printOrange(<span class="string">'Fail\n'</span>)
+0123     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0124 <span class="keyword">end</span>
 0125 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking libSBML version'</span>,40) <span class="string">'%f'</span>])
 0126 <span class="keyword">try</span>
@@ -191,11 +191,11 @@ This function is called by:
 0129         libSBMLver=OutputSBML; <span class="comment">% Only works in libSBML 5.17.0+</span>
 0130         fprintf([libSBMLver.libSBML_version_string <span class="string">'\n'</span>]);
 0131     <span class="keyword">catch</span>
-0132         printOrange(<span class="string">'Fail\n'</span>)
+0132         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0133         fprintf(<span class="string">'   An older libSBML version was found, update to version 5.17.0 or higher for a significant improvement of model import\n'</span>);
 0134     <span class="keyword">end</span>
 0135 <span class="keyword">catch</span>
-0136     printOrange(<span class="string">'Fail\n'</span>)
+0136     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0137     fprintf(<span class="string">'   Download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n'</span>);
 0138 <span class="keyword">end</span>
 0139 fprintf(<span class="string">' &gt; Checking model import and export\n'</span>)
@@ -205,7 +205,7 @@ This function is called by:
 0143 <span class="keyword">if</span> res(1).Passed == 1
 0144     fprintf(<span class="string">'Pass\n'</span>)
 0145 <span class="keyword">else</span>
-0146     printOrange(<span class="string">'Fail\n'</span>)
+0146     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0147     addList = matlab.addons.installedAddons;
 0148     <span class="keyword">if</span> any(strcmpi(addList.Name,<span class="string">'Text Analytics Toolbox'</span>))
 0149         fprintf([<span class="string">'   Excel import/export is incompatible with MATLAB Text Analytics Toolbox.\n'</span> <span class="keyword">...</span>
@@ -217,21 +217,21 @@ This function is called by:
 0155 <span class="keyword">if</span> res(3).Passed == 1
 0156     fprintf(<span class="string">'Pass\n'</span>)
 0157 <span class="keyword">else</span>
-0158     printOrange(<span class="string">'Fail\n'</span>)
+0158     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0159 <span class="keyword">end</span>
 0160 
 0161 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Import SBML format'</span>,40) <span class="string">'%f'</span>])
 0162 <span class="keyword">if</span> res(2).Passed == 1
 0163     fprintf(<span class="string">'Pass\n'</span>)
 0164 <span class="keyword">else</span>
-0165     printOrange(<span class="string">'Fail\n'</span>)
+0165     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0166 <span class="keyword">end</span>
 0167 
 0168 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Export SBML format'</span>,40) <span class="string">'%f'</span>])
 0169 <span class="keyword">if</span> res(4).Passed == 1
 0170     fprintf(<span class="string">'Pass\n'</span>)
 0171 <span class="keyword">else</span>
-0172     printOrange(<span class="string">'Fail\n'</span>)
+0172     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0173 <span class="keyword">end</span>
 0174 
 0175 <span class="keyword">if</span> res(1).Passed~=1 &amp;&amp; res(3).Passed~=1 &amp;&amp; exist(<span class="string">'vaderSentimentScores.m'</span>,<span class="string">'file'</span>)==2
@@ -259,28 +259,28 @@ This function is called by:
 0197 <span class="keyword">if</span> res(1).Passed == 1
 0198     fprintf(<span class="string">'Pass\n'</span>)
 0199 <span class="keyword">else</span>
-0200     printOrange(<span class="string">'Fail\n'</span>)
+0200     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0201 <span class="keyword">end</span>
 0202 
 0203 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; gurobi'</span>,40) <span class="string">'%f'</span>])
 0204 <span class="keyword">if</span> res(2).Passed == 1
 0205     fprintf(<span class="string">'Pass\n'</span>)
 0206 <span class="keyword">else</span>
-0207     printOrange(<span class="string">'Fail\n'</span>)
+0207     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0208 <span class="keyword">end</span>
 0209 
 0210 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; soplex'</span>,40) <span class="string">'%f'</span>])
 0211 <span class="keyword">if</span> res(3).Passed == 1
 0212     fprintf(<span class="string">'Pass\n'</span>)
 0213 <span class="keyword">else</span>
-0214     printOrange(<span class="string">'Fail\n'</span>)
+0214     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0215 <span class="keyword">end</span>
 0216 
 0217 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; cobra'</span>,40) <span class="string">'%f'</span>])
 0218 <span class="keyword">if</span> res(4).Passed == 1
 0219     fprintf(<span class="string">'Pass\n'</span>)
 0220 <span class="keyword">else</span>
-0221     printOrange(<span class="string">'Fail\n'</span>)
+0221     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0222 <span class="keyword">end</span>
 0223 fprintf([<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Set RAVEN solver'</span>,40) <span class="string">'%f'</span>])
 0224 <span class="keyword">try</span>
@@ -358,7 +358,7 @@ This function is called by:
 0296     fprintf(<span class="string">'Pass\n'</span>);
 0297     res=true;
 0298 <span class="keyword">else</span>
-0299     printOrange(<span class="string">'Fail\n'</span>)
+0299     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0300     fprintf(<span class="string">'   Download/compile the binary and rerun checkInstallation\n'</span>);
 0301     res=false;
 0302 <span class="keyword">end</span>
@@ -400,7 +400,19 @@ This function is called by:
 0338         warning(<span class="string">'Failed to make %s executable: %s '</span>,binList{i},strip(cmdout))
 0339     <span class="keyword">end</span>
 0340 <span class="keyword">end</span>
-0341 <span class="keyword">end</span></pre></div>
+0341 <span class="keyword">end</span>
+0342 
+0343 <a name="_sub4" href="#_subfunctions" class="code">function printOrange(stringToPrint)</a>
+0344 <span class="comment">% printOrange</span>
+0345 <span class="comment">%   Duplicate of RAVEN/core/printOrange is also kept here, as this function</span>
+0346 <span class="comment">%   should be able to run before adding RAVEN to the MATLAB path.</span>
+0347 <span class="keyword">try</span> useDesktop = usejava(<span class="string">'desktop'</span>); <span class="keyword">catch</span>, useDesktop = false; <span class="keyword">end</span>
+0348 <span class="keyword">if</span> useDesktop
+0349     fprintf([<span class="string">'[\b'</span> stringToPrint,<span class="string">']\b'</span>])
+0350 <span class="keyword">else</span>
+0351     fprintf(stringToPrint)
+0352 <span class="keyword">end</span>
+0353 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -339,3 +339,15 @@ for i=1:numel(binList)
     end
 end
 end
+
+function printOrange(stringToPrint)
+% printOrange
+%   Duplicate of RAVEN/core/printOrange is also kept here, as this function
+%   should be able to run before adding RAVEN to the MATLAB path.
+try useDesktop = usejava('desktop'); catch, useDesktop = false; end
+if useDesktop
+    fprintf(['[\b' stringToPrint,']\b'])
+else
+    fprintf(stringToPrint)
+end
+end


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `checkInstallation` find `printOrange` on new RAVEN installations (solves #492)

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch
