### PR TITLE
fix: readYAMLmodel allows non-used genes

### DIFF
--- a/doc/io/readYAMLmodel.html
+++ b/doc/io/readYAMLmodel.html
@@ -635,93 +635,94 @@ This function is called by:
 0578 <span class="comment">%     end</span>
 0579 <span class="comment">% end</span>
 0580 
-0581 <span class="comment">% Make rxnGeneMat fields</span>
-0582 [genes, rxnGeneMat] = getGenesFromGrRules(model.grRules, model.genes);
-0583 <span class="keyword">if</span> isequal(sort(genes), sort(model.genes))
-0584     model.rxnGeneMat = rxnGeneMat;
-0585     model.genes = genes;
-0586 <span class="keyword">else</span>
-0587     error(<span class="string">'The gene list and grRules are inconsistent.'</span>);
+0581 <span class="comment">% Make rxnGeneMat fields and map to the existing model.genes field</span>
+0582 [genes, rxnGeneMat] = getGenesFromGrRules(model.grRules);
+0583 model.rxnGeneMat = sparse(numel(model.rxns),numel(model.genes));
+0584 [~,geneOrder] = ismember(genes,model.genes);
+0585 <span class="keyword">if</span> any(geneOrder == 0)
+0586     error([<span class="string">'The grRules includes the following gene(s), that are not in '</span><span class="keyword">...</span>
+0587            <span class="string">'the list of model genes: '</span>, genes{~geneOrder}])
 0588 <span class="keyword">end</span>
-0589 
-0590 <span class="comment">% Finalize GECKO model</span>
-0591 <span class="keyword">if</span> isGECKO
-0592     <span class="comment">% Fill in empty fields and empty entries</span>
-0593     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'source'</span>,<span class="string">'notes'</span>,<span class="string">'eccodes'</span>} <span class="comment">% Even keep empty</span>
-0594         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'rxns'</span>,true);
-0595     <span class="keyword">end</span>
-0596     <span class="keyword">for</span> i={<span class="string">'enzymes'</span>,<span class="string">'mw'</span>,<span class="string">'sequence'</span>}
-0597         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'genes'</span>,true);
-0598     <span class="keyword">end</span>
-0599     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'concs'</span>,{<span class="string">'NaN'</span>},<span class="string">'genes'</span>,true);
-0600     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'kcat'</span>,{<span class="string">'0'</span>},<span class="string">'genes'</span>,true);
-0601     <span class="comment">% Change string to double</span>
-0602     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'mw'</span>,<span class="string">'concs'</span>}
-0603         <span class="keyword">if</span> isfield(model.ec,i{1})
-0604             model.ec.(i{1}) = str2double(model.ec.(i{1}));
-0605         <span class="keyword">end</span>
-0606     <span class="keyword">end</span>
-0607     <span class="comment">% Fill rxnEnzMat</span>
-0608     rxnIdx              = cellfun(@isempty, enzStoich(:,1));
-0609     enzStoich(rxnIdx,:) = <span class="string">''</span>;
-0610     rxnIdx              = cell2mat(enzStoich(:,1));
-0611     [~,enzIdx]          = ismember(enzStoich(:,2),model.ec.enzymes);
-0612     coeffs              = cell2mat(enzStoich(:,3));
-0613     model.ec.rxnEnzMat  = zeros(max(rxnIdx), max(enzIdx));
-0614     linearIndices       = sub2ind([max(rxnIdx), max(enzIdx)], rxnIdx, enzIdx);
-0615     model.ec.rxnEnzMat(linearIndices) = coeffs;
-0616     <span class="comment">%Parse ec-codes</span>
-0617     <span class="keyword">if</span> ~isempty(ecGecko)
-0618         locs = cell2mat(ecGecko(:,1));
-0619         <span class="keyword">for</span> i=unique(locs)'
-0620             ecGeckoCat=strjoin(ecGecko(locs==i,2),<span class="string">';'</span>);
-0621             model.ec.eccodes{i,1}=ecGeckoCat;
-0622         <span class="keyword">end</span>
-0623         emptyEc=cellfun(@isempty,model.ec.eccodes);
-0624         model.ec.eccodes(emptyEc)={<span class="string">''</span>};
-0625     <span class="keyword">end</span>
-0626 <span class="keyword">end</span>
-0627 
-0628 <span class="keyword">if</span> verbose
-0629     fprintf(<span class="string">' Done!\n'</span>);
-0630 <span class="keyword">end</span>
+0589 model.rxnGeneMat(:,geneOrder) = rxnGeneMat;
+0590 
+0591 <span class="comment">% Finalize GECKO model</span>
+0592 <span class="keyword">if</span> isGECKO
+0593     <span class="comment">% Fill in empty fields and empty entries</span>
+0594     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'source'</span>,<span class="string">'notes'</span>,<span class="string">'eccodes'</span>} <span class="comment">% Even keep empty</span>
+0595         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'rxns'</span>,true);
+0596     <span class="keyword">end</span>
+0597     <span class="keyword">for</span> i={<span class="string">'enzymes'</span>,<span class="string">'mw'</span>,<span class="string">'sequence'</span>}
+0598         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'genes'</span>,true);
+0599     <span class="keyword">end</span>
+0600     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'concs'</span>,{<span class="string">'NaN'</span>},<span class="string">'genes'</span>,true);
+0601     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'kcat'</span>,{<span class="string">'0'</span>},<span class="string">'genes'</span>,true);
+0602     <span class="comment">% Change string to double</span>
+0603     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'mw'</span>,<span class="string">'concs'</span>}
+0604         <span class="keyword">if</span> isfield(model.ec,i{1})
+0605             model.ec.(i{1}) = str2double(model.ec.(i{1}));
+0606         <span class="keyword">end</span>
+0607     <span class="keyword">end</span>
+0608     <span class="comment">% Fill rxnEnzMat</span>
+0609     rxnIdx              = cellfun(@isempty, enzStoich(:,1));
+0610     enzStoich(rxnIdx,:) = <span class="string">''</span>;
+0611     rxnIdx              = cell2mat(enzStoich(:,1));
+0612     [~,enzIdx]          = ismember(enzStoich(:,2),model.ec.enzymes);
+0613     coeffs              = cell2mat(enzStoich(:,3));
+0614     model.ec.rxnEnzMat  = zeros(max(rxnIdx), max(enzIdx));
+0615     linearIndices       = sub2ind([max(rxnIdx), max(enzIdx)], rxnIdx, enzIdx);
+0616     model.ec.rxnEnzMat(linearIndices) = coeffs;
+0617     <span class="comment">%Parse ec-codes</span>
+0618     <span class="keyword">if</span> ~isempty(ecGecko)
+0619         locs = cell2mat(ecGecko(:,1));
+0620         <span class="keyword">for</span> i=unique(locs)'
+0621             ecGeckoCat=strjoin(ecGecko(locs==i,2),<span class="string">';'</span>);
+0622             model.ec.eccodes{i,1}=ecGeckoCat;
+0623         <span class="keyword">end</span>
+0624         emptyEc=cellfun(@isempty,model.ec.eccodes);
+0625         model.ec.eccodes(emptyEc)={<span class="string">''</span>};
+0626     <span class="keyword">end</span>
+0627 <span class="keyword">end</span>
+0628 
+0629 <span class="keyword">if</span> verbose
+0630     fprintf(<span class="string">' Done!\n'</span>);
 0631 <span class="keyword">end</span>
-0632 
-0633 <a name="_sub1" href="#_subfunctions" class="code">function model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)</a>
-0634 <span class="keyword">if</span> nargin&lt;5
-0635     keepEmpty=false;
-0636 <span class="keyword">end</span>
-0637 <span class="keyword">if</span> isnumeric(emptyEntry)
-0638     emptyCells=isempty(model.(field));
-0639 <span class="keyword">else</span>
-0640     emptyCells=cellfun(@isempty,model.(field));
-0641 <span class="keyword">end</span>
-0642 <span class="keyword">if</span> all(emptyCells) &amp;&amp; ~keepEmpty
-0643     model = rmfield(model, field);
-0644 <span class="keyword">elseif</span> numel(model.(field))&lt;numel(model.(type))
-0645     model.(field)(end+1:numel(model.(type)),1)=emptyEntry;
-0646 <span class="keyword">end</span>
+0632 <span class="keyword">end</span>
+0633 
+0634 <a name="_sub1" href="#_subfunctions" class="code">function model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)</a>
+0635 <span class="keyword">if</span> nargin&lt;5
+0636     keepEmpty=false;
+0637 <span class="keyword">end</span>
+0638 <span class="keyword">if</span> isnumeric(emptyEntry)
+0639     emptyCells=isempty(model.(field));
+0640 <span class="keyword">else</span>
+0641     emptyCells=cellfun(@isempty,model.(field));
+0642 <span class="keyword">end</span>
+0643 <span class="keyword">if</span> all(emptyCells) &amp;&amp; ~keepEmpty
+0644     model = rmfield(model, field);
+0645 <span class="keyword">elseif</span> numel(model.(field))&lt;numel(model.(type))
+0646     model.(field)(end+1:numel(model.(type)),1)=emptyEntry;
 0647 <span class="keyword">end</span>
-0648 
-0649 <a name="_sub2" href="#_subfunctions" class="code">function model = readFieldValue(model, fieldName, value, pos)</a>
-0650 <span class="keyword">if</span> numel(model.(fieldName))&lt;pos-1
-0651     model.(fieldName)(end+1:pos,1) = {<span class="string">''</span>};
-0652 <span class="keyword">end</span>
-0653 model.(fieldName)(pos,1) = {value};
-0654 <span class="keyword">end</span>
-0655 
-0656 <a name="_sub3" href="#_subfunctions" class="code">function [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)</a>
-0657 <span class="keyword">if</span> isempty(key)
-0658     key=miriamKey;
-0659 <span class="keyword">else</span>
-0660     miriamKey=key;
-0661 <span class="keyword">end</span>
-0662 <span class="keyword">if</span> ~isempty(value)
-0663     miriams(entryNumber,1:3) = {pos, key, strip(value)};
-0664 <span class="keyword">else</span>
-0665     entryNumber = entryNumber - 1;
-0666 <span class="keyword">end</span>
-0667 <span class="keyword">end</span></pre></div>
+0648 <span class="keyword">end</span>
+0649 
+0650 <a name="_sub2" href="#_subfunctions" class="code">function model = readFieldValue(model, fieldName, value, pos)</a>
+0651 <span class="keyword">if</span> numel(model.(fieldName))&lt;pos-1
+0652     model.(fieldName)(end+1:pos,1) = {<span class="string">''</span>};
+0653 <span class="keyword">end</span>
+0654 model.(fieldName)(pos,1) = {value};
+0655 <span class="keyword">end</span>
+0656 
+0657 <a name="_sub3" href="#_subfunctions" class="code">function [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)</a>
+0658 <span class="keyword">if</span> isempty(key)
+0659     key=miriamKey;
+0660 <span class="keyword">else</span>
+0661     miriamKey=key;
+0662 <span class="keyword">end</span>
+0663 <span class="keyword">if</span> ~isempty(value)
+0664     miriams(entryNumber,1:3) = {pos, key, strip(value)};
+0665 <span class="keyword">else</span>
+0666     entryNumber = entryNumber - 1;
+0667 <span class="keyword">end</span>
+0668 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/io/writeYAMLmodel.html
+++ b/doc/io/writeYAMLmodel.html
@@ -223,7 +223,7 @@ This function is called by:
 0164     
 0165     <span class="keyword">if</span> strcmp(fieldName,<span class="string">'metMiriams'</span>)
 0166         <span class="keyword">if</span> ~isempty(model.metMiriams{pos})
-0167             fprintf(fid,[<span class="string">'    '</span> name <span class="string">': !!omap\n'</span>]);
+0167             fprintf(fid,<span class="string">'    %s: !!omap\n'</span>,name);
 0168             <span class="keyword">for</span> i=1:size(model.newMetMiriams,2)
 0169                 <span class="comment">%'i' represents the different miriam names, e.g.</span>
 0170                 <span class="comment">%kegg.compound or chebi</span>
@@ -238,7 +238,7 @@ This function is called by:
 0179         
 0180     <span class="keyword">elseif</span> strcmp(fieldName,<span class="string">'rxnMiriams'</span>)
 0181         <span class="keyword">if</span> ~isempty(model.rxnMiriams{pos})
-0182             fprintf(fid,[<span class="string">'    '</span> name <span class="string">': !!omap\n'</span>]);
+0182             fprintf(fid,<span class="string">'    %s: !!omap\n'</span>,name);
 0183             <span class="keyword">for</span> i=1:size(model.newRxnMiriams,2)
 0184                 <span class="keyword">if</span> ~isempty(model.newRxnMiriams{pos,i})
 0185                     <a href="#_sub1" class="code" title="subfunction writeField(model,fid,fieldName,type,pos,name,preserveQuotes)">writeField</a>(model, fid, <span class="string">'newRxnMiriams'</span>, <span class="string">'txt'</span>, pos, [<span class="string">'      - '</span> model.newRxnMiriamNames{i} <span class="string">'_'</span> sprintf(<span class="string">'%d'</span>,i)], preserveQuotes)
@@ -248,7 +248,7 @@ This function is called by:
 0189         
 0190     <span class="keyword">elseif</span> strcmp(fieldName,<span class="string">'geneMiriams'</span>)
 0191         <span class="keyword">if</span> ~isempty(model.geneMiriams{pos})
-0192             fprintf(fid,[<span class="string">'    '</span> name <span class="string">': !!omap\n'</span>]);
+0192             fprintf(fid,<span class="string">'    %s: !!omap\n'</span>,name);
 0193             <span class="keyword">for</span> i=1:size(model.newGeneMiriams,2)
 0194                 <span class="keyword">if</span> ~isempty(model.newGeneMiriams{pos,i})
 0195                     <a href="#_sub1" class="code" title="subfunction writeField(model,fid,fieldName,type,pos,name,preserveQuotes)">writeField</a>(model, fid, <span class="string">'newGeneMiriams'</span>, <span class="string">'txt'</span>, pos, [<span class="string">'      - '</span> model.newGeneMiriamNames{i} <span class="string">'_'</span> sprintf(<span class="string">'%d'</span>,i)], preserveQuotes)
@@ -258,7 +258,7 @@ This function is called by:
 0199         
 0200     <span class="keyword">elseif</span> strcmp(fieldName,<span class="string">'compMiriams'</span>)
 0201         <span class="keyword">if</span> ~isempty(model.compMiriams{pos})
-0202             fprintf(fid,[<span class="string">'    '</span> name <span class="string">': !!omap\n'</span>]);
+0202             fprintf(fid,<span class="string">'    %s: !!omap\n'</span>,name);
 0203             <span class="keyword">for</span> i=1:size(model.newCompMiriams,2)
 0204                 <span class="keyword">if</span> ~isempty(model.newCompMiriams{pos,i})
 0205                     <a href="#_sub1" class="code" title="subfunction writeField(model,fid,fieldName,type,pos,name,preserveQuotes)">writeField</a>(model, fid, <span class="string">'newCompMiriams'</span>, <span class="string">'txt'</span>, pos, [<span class="string">'      - '</span> model.newCompMiriamNames{i} <span class="string">'_'</span> sprintf(<span class="string">'%d'</span>,i)], preserveQuotes)
@@ -268,7 +268,7 @@ This function is called by:
 0209         
 0210     <span class="keyword">elseif</span> strcmp(fieldName,<span class="string">'S'</span>)
 0211         <span class="comment">%S: create header &amp; write each metabolite in a new line</span>
-0212         fprintf(fid,[<span class="string">'    '</span> name <span class="string">': !!omap\n'</span>]);
+0212         fprintf(fid,<span class="string">'    %s: !!omap\n'</span>,name);
 0213         <span class="keyword">if</span> sum(field(:,pos) ~= 0) &gt; 0
 0214             model.mets   = model.mets(field(:,pos) ~= 0);
 0215             model.coeffs = field(field(:,pos) ~= 0,pos);
@@ -282,7 +282,7 @@ This function is called by:
 0223 
 0224     <span class="keyword">elseif</span> strcmp(fieldName,<span class="string">'rxnEnzMat'</span>)
 0225         <span class="comment">%S: create header &amp; write each enzyme in a new line</span>
-0226         fprintf(fid,[<span class="string">'    '</span> name <span class="string">': !!omap\n'</span>]);
+0226         fprintf(fid,<span class="string">'    %s: !!omap\n'</span>,name);
 0227         <span class="keyword">if</span> sum(field(pos,:) ~= 0) &gt; 0
 0228             model.enzymes = model.enzymes(field(pos,:) ~= 0);
 0229             model.coeffs  = field(pos,field(pos,:) ~= 0);
@@ -326,16 +326,16 @@ This function is called by:
 0267             <span class="keyword">if</span> preserveQuotes
 0268                 list = [<span class="string">'&quot;'</span> list{1} <span class="string">'&quot;'</span>];
 0269             <span class="keyword">end</span>
-0270             fprintf(fid,[<span class="string">'    '</span> name <span class="string">': '</span> list <span class="string">'\n'</span>]);
+0270             fprintf(fid,<span class="string">'    %s: %s\n'</span>,name,list);
 0271         <span class="keyword">elseif</span> length(list) &gt; 1 || strcmp(fieldName,<span class="string">'subSystems'</span>)
 0272             <span class="keyword">if</span> preserveQuotes
 0273                 <span class="keyword">for</span> j=1:numel(list)
 0274                     list{j} = [<span class="string">'&quot;'</span> list{j} <span class="string">'&quot;'</span>];
 0275                 <span class="keyword">end</span>
 0276             <span class="keyword">end</span>
-0277             fprintf(fid,[<span class="string">'    '</span> name <span class="string">':\n'</span>]);
+0277             fprintf(fid,<span class="string">'    %s:\n'</span>,name);
 0278             <span class="keyword">for</span> i = 1:length(list)
-0279                 fprintf(fid,[regexprep(name,<span class="string">'(^\s*).*'</span>,<span class="string">'$1'</span>) <span class="string">'        - '</span> list{i} <span class="string">'\n'</span>]);
+0279                 fprintf(fid,<span class="string">'%s        - %s\n'</span>,regexprep(name,<span class="string">'(^\s*).*'</span>,<span class="string">'$1'</span>),list{i});
 0280             <span class="keyword">end</span>
 0281         <span class="keyword">end</span>
 0282         
@@ -354,68 +354,65 @@ This function is called by:
 0295             <span class="keyword">end</span>
 0296         <span class="keyword">end</span>
 0297         <span class="keyword">if</span> ~isempty(value)
-0298             fprintf(fid,[<span class="string">'    '</span> name <span class="string">': '</span> value <span class="string">'\n'</span>]);
+0298             fprintf(fid,<span class="string">'    %s: %s\n'</span>,name,value);
 0299         <span class="keyword">end</span>
 0300     <span class="keyword">end</span>
 0301 <span class="keyword">end</span>
-0302 
+0302 <span class="keyword">end</span>
 0303 
-0304 <span class="keyword">end</span>
-0305 
-0306 <a name="_sub2" href="#_subfunctions" class="code">function writeMetadata(model,fid)</a>
-0307 <span class="comment">% Writes model metadata to the yaml file. This information will eventually</span>
-0308 <span class="comment">% be extracted entirely from the model, but for now, many of the entries</span>
-0309 <span class="comment">% are hard-coded defaults for HumanGEM.</span>
-0310 
-0311 fprintf(fid, <span class="string">'- metaData:\n'</span>);
-0312 fprintf(fid, [<span class="string">'    id: &quot;'</span>,          model.id,          <span class="string">'&quot;\n'</span>]);
-0313 fprintf(fid, [<span class="string">'    name: &quot;'</span>,        model.name, <span class="string">'&quot;\n'</span>]);
-0314 <span class="keyword">if</span> isfield(model,<span class="string">'version'</span>)
-0315     fprintf(fid, [<span class="string">'    version: &quot;'</span>, model.version,     <span class="string">'&quot;\n'</span>]);
-0316 <span class="keyword">end</span>
-0317 fprintf(fid, [<span class="string">'    date: &quot;'</span>,        datestr(now,29),   <span class="string">'&quot;\n'</span>]);  <span class="comment">% 29=YYYY-MM-DD</span>
-0318 <span class="keyword">if</span> isfield(model,<span class="string">'annotation'</span>)
-0319     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'defaultLB'</span>)
-0320         fprintf(fid, [<span class="string">'    defaultLB: &quot;'</span>,    num2str(model.annotation.defaultLB), <span class="string">'&quot;\n'</span>]);
-0321     <span class="keyword">end</span>
-0322     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'defaultUB'</span>)
-0323         fprintf(fid, [<span class="string">'    defaultUB: &quot;'</span>,    num2str(model.annotation.defaultUB), <span class="string">'&quot;\n'</span>]);
-0324     <span class="keyword">end</span>
-0325     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'givenName'</span>)
-0326         fprintf(fid, [<span class="string">'    givenName: &quot;'</span>,    model.annotation.givenName,          <span class="string">'&quot;\n'</span>]);
-0327     <span class="keyword">end</span>
-0328     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'familyName'</span>)
-0329         fprintf(fid, [<span class="string">'    familyName: &quot;'</span>,   model.annotation.familyName,         <span class="string">'&quot;\n'</span>]);
-0330     <span class="keyword">end</span>
-0331     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'authors'</span>)
-0332         fprintf(fid, [<span class="string">'    authors: &quot;'</span>,      model.annotation.authors,            <span class="string">'&quot;\n'</span>]);
-0333     <span class="keyword">end</span>
-0334     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'email'</span>)
-0335         fprintf(fid, [<span class="string">'    email: &quot;'</span>,        model.annotation.email,              <span class="string">'&quot;\n'</span>]);
-0336     <span class="keyword">end</span>
-0337     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'organization'</span>)
-0338         fprintf(fid, [<span class="string">'    organization: &quot;'</span>, model.annotation.organization,       <span class="string">'&quot;\n'</span>]);
-0339     <span class="keyword">end</span>
-0340     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'taxonomy'</span>)
-0341         fprintf(fid, [<span class="string">'    taxonomy: &quot;'</span>,     model.annotation.taxonomy,           <span class="string">'&quot;\n'</span>]);
-0342     <span class="keyword">end</span>
-0343     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'note'</span>)
-0344         fprintf(fid, [<span class="string">'    note: &quot;'</span>,         model.annotation.note,               <span class="string">'&quot;\n'</span>]);
-0345     <span class="keyword">end</span>
-0346     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'sourceUrl'</span>)
-0347         fprintf(fid, [<span class="string">'    sourceUrl: &quot;'</span>,    model.annotation.sourceUrl,          <span class="string">'&quot;\n'</span>]);
-0348     <span class="keyword">end</span>
-0349 <span class="keyword">end</span>
-0350 <span class="keyword">if</span> isfield(model,<span class="string">'ec'</span>)
-0351     <span class="keyword">if</span> model.ec.geckoLight
-0352         geckoLight = <span class="string">'true'</span>;
-0353     <span class="keyword">else</span>
-0354         geckoLight = <span class="string">'false'</span>;
-0355     <span class="keyword">end</span>
-0356     fprintf(fid,[<span class="string">'    geckoLight: &quot;'</span> geckoLight <span class="string">'&quot;\n'</span>]);
-0357 <span class="keyword">end</span>
-0358 <span class="keyword">end</span>
-0359</pre></div>
+0304 <a name="_sub2" href="#_subfunctions" class="code">function writeMetadata(model,fid)</a>
+0305 <span class="comment">% Writes model metadata to the yaml file. This information will eventually</span>
+0306 <span class="comment">% be extracted entirely from the model, but for now, many of the entries</span>
+0307 <span class="comment">% are hard-coded defaults for HumanGEM.</span>
+0308 
+0309 fprintf(fid, <span class="string">'- metaData:\n'</span>);
+0310 fprintf(fid, <span class="string">'    id: &quot;%s&quot;\n'</span>,  model.id);
+0311 fprintf(fid, <span class="string">'    name: &quot;%s&quot;\n'</span>,model.name);
+0312 <span class="keyword">if</span> isfield(model,<span class="string">'version'</span>)
+0313     fprintf(fid, <span class="string">'    version: &quot;%s&quot;\n'</span>,model.version);
+0314 <span class="keyword">end</span>
+0315 fprintf(fid, <span class="string">'    date: &quot;%s&quot;\n'</span>,datestr(now,29));  <span class="comment">% 29=YYYY-MM-DD</span>
+0316 <span class="keyword">if</span> isfield(model,<span class="string">'annotation'</span>)
+0317     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'defaultLB'</span>)
+0318         fprintf(fid, <span class="string">'    defaultLB: &quot;%g&quot;\n'</span>,   model.annotation.defaultLB);
+0319     <span class="keyword">end</span>
+0320     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'defaultUB'</span>)
+0321         fprintf(fid, <span class="string">'    defaultUB: &quot;%g&quot;\n'</span>,   model.annotation.defaultUB);
+0322     <span class="keyword">end</span>
+0323     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'givenName'</span>)
+0324         fprintf(fid, <span class="string">'    givenName: &quot;%s&quot;\n'</span>,   model.annotation.givenName);
+0325     <span class="keyword">end</span>
+0326     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'familyName'</span>)
+0327         fprintf(fid, <span class="string">'    familyName: &quot;%s&quot;\n'</span>,  model.annotation.familyName);
+0328     <span class="keyword">end</span>
+0329     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'authors'</span>)
+0330         fprintf(fid, <span class="string">'    authors: &quot;%s&quot;\n'</span>,     model.annotation.authors);
+0331     <span class="keyword">end</span>
+0332     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'email'</span>)
+0333         fprintf(fid, <span class="string">'    email: &quot;%s&quot;\n'</span>,       model.annotation.email);
+0334     <span class="keyword">end</span>
+0335     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'organization'</span>)
+0336         fprintf(fid, <span class="string">'    organization: &quot;%s&quot;\n'</span>,model.annotation.organization);
+0337     <span class="keyword">end</span>
+0338     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'taxonomy'</span>)
+0339         fprintf(fid, <span class="string">'    taxonomy: &quot;%s&quot;\n'</span>,    model.annotation.taxonomy);
+0340     <span class="keyword">end</span>
+0341     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'note'</span>)
+0342         fprintf(fid, <span class="string">'    note: &quot;%s&quot;\n'</span>,        model.annotation.note);
+0343     <span class="keyword">end</span>
+0344     <span class="keyword">if</span> isfield(model.annotation,<span class="string">'sourceUrl'</span>)
+0345         fprintf(fid, <span class="string">'    sourceUrl: &quot;%s&quot;\n'</span>,   model.annotation.sourceUrl);
+0346     <span class="keyword">end</span>
+0347 <span class="keyword">end</span>
+0348 <span class="keyword">if</span> isfield(model,<span class="string">'ec'</span>)
+0349     <span class="keyword">if</span> model.ec.geckoLight
+0350         geckoLight = <span class="string">'true'</span>;
+0351     <span class="keyword">else</span>
+0352         geckoLight = <span class="string">'false'</span>;
+0353     <span class="keyword">end</span>
+0354     fprintf(fid,<span class="string">'    geckoLight: &quot;%s&quot;\n'</span>,geckoLight);
+0355 <span class="keyword">end</span>
+0356 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/io/readYAMLmodel.m
+++ b/io/readYAMLmodel.m
@@ -578,14 +578,15 @@ end
 %     end
 % end
 
-% Make rxnGeneMat fields
-[genes, rxnGeneMat] = getGenesFromGrRules(model.grRules, model.genes);
-if isequal(sort(genes), sort(model.genes))
-    model.rxnGeneMat = rxnGeneMat;
-    model.genes = genes;
-else
-    error('The gene list and grRules are inconsistent.');
+% Make rxnGeneMat fields and map to the existing model.genes field
+[genes, rxnGeneMat] = getGenesFromGrRules(model.grRules);
+model.rxnGeneMat = sparse(numel(model.rxns),numel(model.genes));
+[~,geneOrder] = ismember(genes,model.genes);
+if any(geneOrder == 0)
+    error(['The grRules includes the following gene(s), that are not in '...
+           'the list of model genes: ', genes{~geneOrder}])
 end
+model.rxnGeneMat(:,geneOrder) = rxnGeneMat;
 
 % Finalize GECKO model
 if isGECKO

--- a/io/writeYAMLmodel.m
+++ b/io/writeYAMLmodel.m
@@ -164,7 +164,7 @@ if isfield(model,fieldName)
     
     if strcmp(fieldName,'metMiriams')
         if ~isempty(model.metMiriams{pos})
-            fprintf(fid,['    ' name ': !!omap\n']);
+            fprintf(fid,'    %s: !!omap\n',name);
             for i=1:size(model.newMetMiriams,2)
                 %'i' represents the different miriam names, e.g.
                 %kegg.compound or chebi
@@ -179,7 +179,7 @@ if isfield(model,fieldName)
         
     elseif strcmp(fieldName,'rxnMiriams')
         if ~isempty(model.rxnMiriams{pos})
-            fprintf(fid,['    ' name ': !!omap\n']);
+            fprintf(fid,'    %s: !!omap\n',name);
             for i=1:size(model.newRxnMiriams,2)
                 if ~isempty(model.newRxnMiriams{pos,i})
                     writeField(model, fid, 'newRxnMiriams', 'txt', pos, ['      - ' model.newRxnMiriamNames{i} '_' sprintf('%d',i)], preserveQuotes)
@@ -189,7 +189,7 @@ if isfield(model,fieldName)
         
     elseif strcmp(fieldName,'geneMiriams')
         if ~isempty(model.geneMiriams{pos})
-            fprintf(fid,['    ' name ': !!omap\n']);
+            fprintf(fid,'    %s: !!omap\n',name);
             for i=1:size(model.newGeneMiriams,2)
                 if ~isempty(model.newGeneMiriams{pos,i})
                     writeField(model, fid, 'newGeneMiriams', 'txt', pos, ['      - ' model.newGeneMiriamNames{i} '_' sprintf('%d',i)], preserveQuotes)
@@ -199,7 +199,7 @@ if isfield(model,fieldName)
         
     elseif strcmp(fieldName,'compMiriams')
         if ~isempty(model.compMiriams{pos})
-            fprintf(fid,['    ' name ': !!omap\n']);
+            fprintf(fid,'    %s: !!omap\n',name);
             for i=1:size(model.newCompMiriams,2)
                 if ~isempty(model.newCompMiriams{pos,i})
                     writeField(model, fid, 'newCompMiriams', 'txt', pos, ['      - ' model.newCompMiriamNames{i} '_' sprintf('%d',i)], preserveQuotes)
@@ -209,7 +209,7 @@ if isfield(model,fieldName)
         
     elseif strcmp(fieldName,'S')
         %S: create header & write each metabolite in a new line
-        fprintf(fid,['    ' name ': !!omap\n']);
+        fprintf(fid,'    %s: !!omap\n',name);
         if sum(field(:,pos) ~= 0) > 0
             model.mets   = model.mets(field(:,pos) ~= 0);
             model.coeffs = field(field(:,pos) ~= 0,pos);
@@ -223,7 +223,7 @@ if isfield(model,fieldName)
 
     elseif strcmp(fieldName,'rxnEnzMat')
         %S: create header & write each enzyme in a new line
-        fprintf(fid,['    ' name ': !!omap\n']);
+        fprintf(fid,'    %s: !!omap\n',name);
         if sum(field(pos,:) ~= 0) > 0
             model.enzymes = model.enzymes(field(pos,:) ~= 0);
             model.coeffs  = field(pos,field(pos,:) ~= 0);
@@ -267,16 +267,16 @@ if isfield(model,fieldName)
             if preserveQuotes
                 list = ['"' list{1} '"'];
             end
-            fprintf(fid,['    ' name ': ' list '\n']);
+            fprintf(fid,'    %s: %s\n',name,list);
         elseif length(list) > 1 || strcmp(fieldName,'subSystems')
             if preserveQuotes
                 for j=1:numel(list)
                     list{j} = ['"' list{j} '"'];
                 end
             end
-            fprintf(fid,['    ' name ':\n']);
+            fprintf(fid,'    %s:\n',name);
             for i = 1:length(list)
-                fprintf(fid,[regexprep(name,'(^\s*).*','$1') '        - ' list{i} '\n']);
+                fprintf(fid,'%s        - %s\n',regexprep(name,'(^\s*).*','$1'),list{i});
             end
         end
         
@@ -295,12 +295,10 @@ if isfield(model,fieldName)
             end
         end
         if ~isempty(value)
-            fprintf(fid,['    ' name ': ' value '\n']);
+            fprintf(fid,'    %s: %s\n',name,value);
         end
     end
 end
-
-
 end
 
 function writeMetadata(model,fid)
@@ -309,42 +307,42 @@ function writeMetadata(model,fid)
 % are hard-coded defaults for HumanGEM.
 
 fprintf(fid, '- metaData:\n');
-fprintf(fid, ['    id: "',          model.id,          '"\n']);
-fprintf(fid, ['    name: "',        model.name, '"\n']);
+fprintf(fid, '    id: "%s"\n',  model.id);
+fprintf(fid, '    name: "%s"\n',model.name);
 if isfield(model,'version')
-    fprintf(fid, ['    version: "', model.version,     '"\n']);
+    fprintf(fid, '    version: "%s"\n',model.version);
 end
-fprintf(fid, ['    date: "',        datestr(now,29),   '"\n']);  % 29=YYYY-MM-DD
+fprintf(fid, '    date: "%s"\n',datestr(now,29));  % 29=YYYY-MM-DD
 if isfield(model,'annotation')
     if isfield(model.annotation,'defaultLB')
-        fprintf(fid, ['    defaultLB: "',    num2str(model.annotation.defaultLB), '"\n']);
+        fprintf(fid, '    defaultLB: "%g"\n',   model.annotation.defaultLB);
     end
     if isfield(model.annotation,'defaultUB')
-        fprintf(fid, ['    defaultUB: "',    num2str(model.annotation.defaultUB), '"\n']);
+        fprintf(fid, '    defaultUB: "%g"\n',   model.annotation.defaultUB);
     end
     if isfield(model.annotation,'givenName')
-        fprintf(fid, ['    givenName: "',    model.annotation.givenName,          '"\n']);
+        fprintf(fid, '    givenName: "%s"\n',   model.annotation.givenName);
     end
     if isfield(model.annotation,'familyName')
-        fprintf(fid, ['    familyName: "',   model.annotation.familyName,         '"\n']);
+        fprintf(fid, '    familyName: "%s"\n',  model.annotation.familyName);
     end
     if isfield(model.annotation,'authors')
-        fprintf(fid, ['    authors: "',      model.annotation.authors,            '"\n']);
+        fprintf(fid, '    authors: "%s"\n',     model.annotation.authors);
     end
     if isfield(model.annotation,'email')
-        fprintf(fid, ['    email: "',        model.annotation.email,              '"\n']);
+        fprintf(fid, '    email: "%s"\n',       model.annotation.email);
     end
     if isfield(model.annotation,'organization')
-        fprintf(fid, ['    organization: "', model.annotation.organization,       '"\n']);
+        fprintf(fid, '    organization: "%s"\n',model.annotation.organization);
     end
     if isfield(model.annotation,'taxonomy')
-        fprintf(fid, ['    taxonomy: "',     model.annotation.taxonomy,           '"\n']);
+        fprintf(fid, '    taxonomy: "%s"\n',    model.annotation.taxonomy);
     end
     if isfield(model.annotation,'note')
-        fprintf(fid, ['    note: "',         model.annotation.note,               '"\n']);
+        fprintf(fid, '    note: "%s"\n',        model.annotation.note);
     end
     if isfield(model.annotation,'sourceUrl')
-        fprintf(fid, ['    sourceUrl: "',    model.annotation.sourceUrl,          '"\n']);
+        fprintf(fid, '    sourceUrl: "%s"\n',   model.annotation.sourceUrl);
     end
 end
 if isfield(model,'ec')
@@ -353,7 +351,6 @@ if isfield(model,'ec')
     else
         geckoLight = 'false';
     end
-    fprintf(fid,['    geckoLight: "' geckoLight '"\n']);
+    fprintf(fid,'    geckoLight: "%s"\n',geckoLight);
 end
 end
-


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `readYAMLmodel` allows for a model that has gene entries that are not present in any grRules: these are unused genes and should be allowed. This also prevents a bug where gene annotations are wrongly assigned.
  - `writeYAMLmodel` correct parsing of text to avoid escape characters (e.g. SMILES may contain `\C`).

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch
