### PR TITLE
fix: readYAMLmodel always make c-field

### DIFF
--- a/core/addRxnsGenesMets.m
+++ b/core/addRxnsGenesMets.m
@@ -74,7 +74,8 @@ end
 
 [~, rxnIdx]=ismember(rxns,sourceModel.rxns); % Get rxnIDs
 if any(rxnIdx==0)
-    error('Not all reaction IDs could be found in the source model')
+    dispEM('The following reaction IDs could not be found in the source model:',true,...
+        rxns(rxnIdx==0));
 end
 
 % Add new metabolites

--- a/core/standardizeGrRules.m
+++ b/core/standardizeGrRules.m
@@ -70,6 +70,8 @@ if isfield(model,'grRules')
             end
         end
     end
+else
+    error('The model does not have a grRules field.')
 end
 
 end

--- a/doc/core/addRxnsGenesMets.html
+++ b/doc/core/addRxnsGenesMets.html
@@ -161,113 +161,114 @@ This function is called by:
 0074 
 0075 [~, rxnIdx]=ismember(rxns,sourceModel.rxns); <span class="comment">% Get rxnIDs</span>
 0076 <span class="keyword">if</span> any(rxnIdx==0)
-0077     error(<span class="string">'Not all reaction IDs could be found in the source model'</span>)
-0078 <span class="keyword">end</span>
-0079 
-0080 <span class="comment">% Add new metabolites</span>
-0081 metIdx=find(any(sourceModel.S(:,rxnIdx),2)); <span class="comment">% Get metabolite IDs</span>
-0082 <span class="comment">% Many of the metabolites in are already in the draft model, so only add</span>
-0083 <span class="comment">% the new metabolites</span>
-0084 
-0085 <span class="comment">% Match by metNames[metComps]. First make these structures for each model.</span>
-0086 metCompsN =cellstr(num2str(model.metComps));
-0087 map=containers.Map(cellstr(num2str(transpose([1:length(model.comps)]))),model.comps);
-0088 metCompsN = map.values(metCompsN);
-0089 metCompsN = strcat(model.metNames,<span class="string">'['</span>,metCompsN,<span class="string">']'</span>);
-0090 
-0091 sourcemetCompsN=cellstr(num2str(sourceModel.metComps));
-0092 map=containers.Map(cellstr(num2str(transpose([1:length(sourceModel.comps)]))),sourceModel.comps);
-0093 sourcemetCompsN = map.values(sourcemetCompsN);
-0094 sourcemetCompsN=strcat(sourceModel.metNames,<span class="string">'['</span>,sourcemetCompsN,<span class="string">']'</span>);
-0095 
-0096 newMetCompsN=sourcemetCompsN(metIdx);
-0097 notNewMet=newMetCompsN(ismember(newMetCompsN,metCompsN));
-0098 
-0099 <span class="keyword">if</span> ~isempty(notNewMet)
-0100     fprintf(<span class="string">'\nThe following metabolites were already present in the model and will not be added:\n'</span>)
-0101     fprintf([strjoin(transpose(notNewMet),<span class="string">'\n'</span>) <span class="string">'\n'</span>])
-0102 <span class="keyword">end</span>
-0103 
-0104 metIdx=metIdx(~ismember(sourcemetCompsN(metIdx),metCompsN));
-0105 
-0106 <span class="keyword">if</span> ~isempty(metIdx)
-0107     fprintf(<span class="string">'\nThe following metabolites will be added to the model:\n'</span>)
-0108     fprintf([strjoin(transpose(sourcemetCompsN(metIdx)),<span class="string">'\n'</span>) <span class="string">'\n'</span>])
-0109     
-0110     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'mets'</span>)
-0111         metsToAdd.mets=sourceModel.mets(metIdx);
-0112     <span class="keyword">end</span>
-0113     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metNames'</span>)
-0114         metsToAdd.metNames=sourceModel.metNames(metIdx);
-0115     <span class="keyword">end</span>
-0116     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metFormulas'</span>)
-0117         metsToAdd.metFormulas=sourceModel.metFormulas(metIdx);
-0118     <span class="keyword">end</span>
-0119     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metCharges'</span>)
-0120         metsToAdd.metCharges=sourceModel.metCharges(metIdx);
-0121     <span class="keyword">end</span>
-0122     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metMiriams'</span>)
-0123         metsToAdd.metMiriams=sourceModel.metMiriams(metIdx);
-0124     <span class="keyword">end</span>
-0125     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metNotes'</span>)
-0126         metsToAdd.metNotes=sourceModel.metNotes(metIdx);
-0127     <span class="keyword">end</span>
-0128     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'inchis'</span>)
-0129         metsToAdd.inchis=sourceModel.inchis(metIdx);
-0130     <span class="keyword">end</span>
-0131     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metSmiles'</span>)
-0132         metsToAdd.metSmiles=sourceModel.metSmiles(metIdx);
-0133     <span class="keyword">end</span>
-0134     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metDeltaG'</span>)
-0135         metsToAdd.metDeltaG=sourceModel.metDeltaG(metIdx);
-0136     <span class="keyword">end</span>
-0137     
-0138     metsToAdd.compartments=strtrim(cellstr(num2str(sourceModel.metComps(metIdx)))); <span class="comment">% Convert from compartment string to compartment number</span>
-0139     [~,idx]=ismember(metsToAdd.compartments,strsplit(num2str(1:length(sourceModel.comps)))); <span class="comment">% Match compartment number to compartment abbreviation</span>
-0140     metsToAdd.compartments=sourceModel.comps(idx); <span class="comment">% Fill in compartment abbreviations</span>
-0141     
-0142     model=<a href="addMets.html" class="code" title="function newModel=addMets(model,metsToAdd,copyInfo,prefix)">addMets</a>(model,metsToAdd);
-0143 <span class="keyword">end</span>
-0144 fprintf(<span class="string">'\nNumber of metabolites added to the model:\n'</span>)
-0145 fprintf([num2str(numel(metIdx)),<span class="string">'\n'</span>])
-0146 
-0147 <span class="comment">% Add new genes</span>
-0148 <span class="keyword">if</span> ~islogical(addGene) | addGene ~= false
-0149     <span class="keyword">if</span> ischar(addGene)
-0150         rxnToAdd.grRules={addGene};
-0151     <span class="keyword">elseif</span> iscell(addGene)
-0152         rxnToAdd.grRules=addGene(~notNewRxn); 
-0153     <span class="keyword">else</span>
-0154         rxnToAdd.grRules=sourceModel.grRules(rxnIdx); <span class="comment">% Get the relevant grRules</span>
-0155     <span class="keyword">end</span>
-0156 <span class="keyword">end</span>
-0157 <span class="comment">% Add new reactions</span>
-0158 rxnToAdd.equations=<a href="constructEquations.html" class="code" title="function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sortMetNames,useMetID,useFormula,useRevField)">constructEquations</a>(sourceModel,rxnIdx);
-0159 rxnToAdd.rxnNames=sourceModel.rxnNames(rxnIdx);
-0160 rxnToAdd.rxns=sourceModel.rxns(rxnIdx);
-0161 rxnToAdd.lb=sourceModel.lb(rxnIdx);
-0162 rxnToAdd.ub=sourceModel.ub(rxnIdx);
-0163 rxnToAdd.rxnNotes(:)=rxnNote(~notNewRxn);
-0164 rxnToAdd.rxnConfidenceScores=NaN(1,numel(rxnToAdd.rxns));
-0165 <span class="keyword">if</span> ~isnumeric(confidence)
-0166     EM=<span class="string">'confidence score must be numeric'</span>;
-0167     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM, true);
-0168 <span class="keyword">end</span>
-0169 rxnToAdd.rxnConfidenceScores(:)=confidence;
-0170 <span class="keyword">if</span> isfield(sourceModel,<span class="string">'rxnDeltaG'</span>)
-0171     rxnToAdd.rxnDeltaG=sourceModel.rxnDeltaG(rxnIdx);
-0172 <span class="keyword">end</span>
-0173 <span class="keyword">if</span> isfield(sourceModel,<span class="string">'subSystems'</span>)
-0174     rxnToAdd.subSystems=sourceModel.subSystems(rxnIdx);
-0175 <span class="keyword">end</span>
-0176 <span class="keyword">if</span> isfield(sourceModel,<span class="string">'eccodes'</span>)
-0177     rxnToAdd.eccodes=sourceModel.eccodes(rxnIdx);
-0178 <span class="keyword">end</span>
-0179 model=<a href="addRxns.html" class="code" title="function newModel=addRxns(model,rxnsToAdd,eqnType,compartment,allowNewMets,allowNewGenes)">addRxns</a>(model,rxnToAdd,3,<span class="string">''</span>,false,true);
-0180 
-0181 fprintf(<span class="string">'\nNumber of reactions added to the model:\n'</span>)
-0182 fprintf([num2str(numel(rxnIdx)),<span class="string">'\n'</span>])
-0183 <span class="keyword">end</span></pre></div>
+0077     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(<span class="string">'The following reaction IDs could not be found in the source model:'</span>,true,<span class="keyword">...</span>
+0078         rxns(rxnIdx==0));
+0079 <span class="keyword">end</span>
+0080 
+0081 <span class="comment">% Add new metabolites</span>
+0082 metIdx=find(any(sourceModel.S(:,rxnIdx),2)); <span class="comment">% Get metabolite IDs</span>
+0083 <span class="comment">% Many of the metabolites in are already in the draft model, so only add</span>
+0084 <span class="comment">% the new metabolites</span>
+0085 
+0086 <span class="comment">% Match by metNames[metComps]. First make these structures for each model.</span>
+0087 metCompsN =cellstr(num2str(model.metComps));
+0088 map=containers.Map(cellstr(num2str(transpose([1:length(model.comps)]))),model.comps);
+0089 metCompsN = map.values(metCompsN);
+0090 metCompsN = strcat(model.metNames,<span class="string">'['</span>,metCompsN,<span class="string">']'</span>);
+0091 
+0092 sourcemetCompsN=cellstr(num2str(sourceModel.metComps));
+0093 map=containers.Map(cellstr(num2str(transpose([1:length(sourceModel.comps)]))),sourceModel.comps);
+0094 sourcemetCompsN = map.values(sourcemetCompsN);
+0095 sourcemetCompsN=strcat(sourceModel.metNames,<span class="string">'['</span>,sourcemetCompsN,<span class="string">']'</span>);
+0096 
+0097 newMetCompsN=sourcemetCompsN(metIdx);
+0098 notNewMet=newMetCompsN(ismember(newMetCompsN,metCompsN));
+0099 
+0100 <span class="keyword">if</span> ~isempty(notNewMet)
+0101     fprintf(<span class="string">'\nThe following metabolites were already present in the model and will not be added:\n'</span>)
+0102     fprintf([strjoin(transpose(notNewMet),<span class="string">'\n'</span>) <span class="string">'\n'</span>])
+0103 <span class="keyword">end</span>
+0104 
+0105 metIdx=metIdx(~ismember(sourcemetCompsN(metIdx),metCompsN));
+0106 
+0107 <span class="keyword">if</span> ~isempty(metIdx)
+0108     fprintf(<span class="string">'\nThe following metabolites will be added to the model:\n'</span>)
+0109     fprintf([strjoin(transpose(sourcemetCompsN(metIdx)),<span class="string">'\n'</span>) <span class="string">'\n'</span>])
+0110     
+0111     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'mets'</span>)
+0112         metsToAdd.mets=sourceModel.mets(metIdx);
+0113     <span class="keyword">end</span>
+0114     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metNames'</span>)
+0115         metsToAdd.metNames=sourceModel.metNames(metIdx);
+0116     <span class="keyword">end</span>
+0117     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metFormulas'</span>)
+0118         metsToAdd.metFormulas=sourceModel.metFormulas(metIdx);
+0119     <span class="keyword">end</span>
+0120     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metCharges'</span>)
+0121         metsToAdd.metCharges=sourceModel.metCharges(metIdx);
+0122     <span class="keyword">end</span>
+0123     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metMiriams'</span>)
+0124         metsToAdd.metMiriams=sourceModel.metMiriams(metIdx);
+0125     <span class="keyword">end</span>
+0126     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metNotes'</span>)
+0127         metsToAdd.metNotes=sourceModel.metNotes(metIdx);
+0128     <span class="keyword">end</span>
+0129     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'inchis'</span>)
+0130         metsToAdd.inchis=sourceModel.inchis(metIdx);
+0131     <span class="keyword">end</span>
+0132     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metSmiles'</span>)
+0133         metsToAdd.metSmiles=sourceModel.metSmiles(metIdx);
+0134     <span class="keyword">end</span>
+0135     <span class="keyword">if</span> isfield(sourceModel,<span class="string">'metDeltaG'</span>)
+0136         metsToAdd.metDeltaG=sourceModel.metDeltaG(metIdx);
+0137     <span class="keyword">end</span>
+0138     
+0139     metsToAdd.compartments=strtrim(cellstr(num2str(sourceModel.metComps(metIdx)))); <span class="comment">% Convert from compartment string to compartment number</span>
+0140     [~,idx]=ismember(metsToAdd.compartments,strsplit(num2str(1:length(sourceModel.comps)))); <span class="comment">% Match compartment number to compartment abbreviation</span>
+0141     metsToAdd.compartments=sourceModel.comps(idx); <span class="comment">% Fill in compartment abbreviations</span>
+0142     
+0143     model=<a href="addMets.html" class="code" title="function newModel=addMets(model,metsToAdd,copyInfo,prefix)">addMets</a>(model,metsToAdd);
+0144 <span class="keyword">end</span>
+0145 fprintf(<span class="string">'\nNumber of metabolites added to the model:\n'</span>)
+0146 fprintf([num2str(numel(metIdx)),<span class="string">'\n'</span>])
+0147 
+0148 <span class="comment">% Add new genes</span>
+0149 <span class="keyword">if</span> ~islogical(addGene) | addGene ~= false
+0150     <span class="keyword">if</span> ischar(addGene)
+0151         rxnToAdd.grRules={addGene};
+0152     <span class="keyword">elseif</span> iscell(addGene)
+0153         rxnToAdd.grRules=addGene(~notNewRxn); 
+0154     <span class="keyword">else</span>
+0155         rxnToAdd.grRules=sourceModel.grRules(rxnIdx); <span class="comment">% Get the relevant grRules</span>
+0156     <span class="keyword">end</span>
+0157 <span class="keyword">end</span>
+0158 <span class="comment">% Add new reactions</span>
+0159 rxnToAdd.equations=<a href="constructEquations.html" class="code" title="function equationStrings=constructEquations(model,rxns,useComps,sortRevRxns,sortMetNames,useMetID,useFormula,useRevField)">constructEquations</a>(sourceModel,rxnIdx);
+0160 rxnToAdd.rxnNames=sourceModel.rxnNames(rxnIdx);
+0161 rxnToAdd.rxns=sourceModel.rxns(rxnIdx);
+0162 rxnToAdd.lb=sourceModel.lb(rxnIdx);
+0163 rxnToAdd.ub=sourceModel.ub(rxnIdx);
+0164 rxnToAdd.rxnNotes(:)=rxnNote(~notNewRxn);
+0165 rxnToAdd.rxnConfidenceScores=NaN(1,numel(rxnToAdd.rxns));
+0166 <span class="keyword">if</span> ~isnumeric(confidence)
+0167     EM=<span class="string">'confidence score must be numeric'</span>;
+0168     <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM, true);
+0169 <span class="keyword">end</span>
+0170 rxnToAdd.rxnConfidenceScores(:)=confidence;
+0171 <span class="keyword">if</span> isfield(sourceModel,<span class="string">'rxnDeltaG'</span>)
+0172     rxnToAdd.rxnDeltaG=sourceModel.rxnDeltaG(rxnIdx);
+0173 <span class="keyword">end</span>
+0174 <span class="keyword">if</span> isfield(sourceModel,<span class="string">'subSystems'</span>)
+0175     rxnToAdd.subSystems=sourceModel.subSystems(rxnIdx);
+0176 <span class="keyword">end</span>
+0177 <span class="keyword">if</span> isfield(sourceModel,<span class="string">'eccodes'</span>)
+0178     rxnToAdd.eccodes=sourceModel.eccodes(rxnIdx);
+0179 <span class="keyword">end</span>
+0180 model=<a href="addRxns.html" class="code" title="function newModel=addRxns(model,rxnsToAdd,eqnType,compartment,allowNewMets,allowNewGenes)">addRxns</a>(model,rxnToAdd,3,<span class="string">''</span>,false,true);
+0181 
+0182 fprintf(<span class="string">'\nNumber of reactions added to the model:\n'</span>)
+0183 fprintf([num2str(numel(rxnIdx)),<span class="string">'\n'</span>])
+0184 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/core/getAllowedBounds.html
+++ b/doc/core/getAllowedBounds.html
@@ -61,7 +61,7 @@ This function is called by:
 
 <h2><a name="_subfunctions"></a>SUBFUNCTIONS <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
 <ul style="list-style-image:url(../matlabicon.gif)">
-<li><a href="#_sub1" class="code">function nUpdateWaitbarParallel(~)</a></li><li><a href="#_sub2" class="code">function nUpdateWaitbar(p,N,h)</a></li></ul>
+<li><a href="#_sub1" class="code">function updateProgressParallel(~)</a></li></ul>
 
 <h2><a name="_source"></a>SOURCE CODE <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
 <div class="fragment"><pre>0001 <a name="_sub0" href="#_subfunctions" class="code">function [minFluxes, maxFluxes, exitFlags]=getAllowedBounds(model,rxns,runParallel)</a>
@@ -88,10 +88,10 @@ This function is called by:
 0022 <span class="comment">% Usage: [minFluxes, maxFluxes, exitFlags] = getAllowedBounds(model, rxns, runParallel)</span>
 0023 
 0024 <span class="keyword">if</span> nargin&lt;2
-0025     rxns=1:numel(model.rxns);
+0025     rxns = 1:numel(model.rxns);
 0026 <span class="keyword">elseif</span> ~islogical(rxns) &amp;&amp; ~isnumeric(rxns)
-0027     rxns=<a href="convertCharArray.html" class="code" title="function inputConverted = convertCharArray(funcInput)">convertCharArray</a>(rxns);
-0028     rxns=<a href="getIndexes.html" class="code" title="function indexes=getIndexes(model, objects, type, returnLogical)">getIndexes</a>(model,rxns, <span class="string">'rxns'</span>);
+0027     rxns = <a href="convertCharArray.html" class="code" title="function inputConverted = convertCharArray(funcInput)">convertCharArray</a>(rxns);
+0028     rxns = <a href="getIndexes.html" class="code" title="function indexes=getIndexes(model, objects, type, returnLogical)">getIndexes</a>(model,rxns, <span class="string">'rxns'</span>);
 0029 <span class="keyword">end</span>
 0030 <span class="keyword">if</span> nargin&lt;3
 0031     runParallel = true;
@@ -104,79 +104,73 @@ This function is called by:
 0038     <span class="keyword">end</span>
 0039 <span class="keyword">end</span>
 0040 
-0041 minFluxes=zeros(numel(rxns),1);
-0042 maxFluxes=zeros(numel(rxns),1);
-0043 exitFlags=zeros(numel(rxns),2);
-0044 c=zeros(numel(model.rxns),1);
+0041 minFluxes = zeros(numel(rxns),1);
+0042 maxFluxes = zeros(numel(rxns),1);
+0043 exitFlags = zeros(numel(rxns),2);
+0044 c = zeros(numel(model.rxns),1);
 0045 
-0046 N = numel(rxns);
-0047 p = 1;
-0048 h = waitbar(0, <span class="string">'Please wait ...'</span>);
-0049 <span class="keyword">if</span> runParallel
-0050     D = parallel.pool.DataQueue;
-0051     afterEach(D, @<a href="#_sub1" class="code" title="subfunction nUpdateWaitbarParallel(~)">nUpdateWaitbarParallel</a>);
-0052     parfor i=1:N
-0053         tmpModel=model;
-0054         tmpModel.c=c;
-0055 
-0056         <span class="comment">%Get minimal flux</span>
-0057         tmpModel.c(rxns(i))=-1;
-0058         solMin=solveLP(tmpModel);
-0059         <span class="keyword">if</span> ~isempty(solMin.f)
-0060             minFluxes(i)=solMin.x(rxns(i));
-0061         <span class="keyword">else</span>
-0062             minFluxes(i)=NaN;
-0063         <span class="keyword">end</span>
-0064 
-0065         <span class="comment">%Get maximal flux</span>
-0066         tmpModel.c(rxns(i))=1;
-0067         solMax=solveLP(tmpModel);
-0068         exitFlags(i,:)=[solMin.stat solMax.stat];
-0069         <span class="keyword">if</span> ~isempty(solMax.f)
-0070             maxFluxes(i)=solMax.x(rxns(i));
-0071         <span class="keyword">else</span>
-0072             maxFluxes(i)=NaN;
-0073         <span class="keyword">end</span>
-0074         send(D, i);
-0075     <span class="keyword">end</span>
-0076 <span class="keyword">else</span>
-0077     <span class="keyword">for</span> i=1:N
-0078         tmpModel=model;
-0079         tmpModel.c=c;
-0080 
-0081         <span class="comment">%Get minimal flux</span>
-0082         tmpModel.c(rxns(i))=-1;
-0083         solMin=solveLP(tmpModel);
-0084         <span class="keyword">if</span> ~isempty(solMin.f)
-0085             minFluxes(i)=solMin.x(rxns(i));
-0086         <span class="keyword">else</span>
-0087             minFluxes(i)=NaN;
-0088         <span class="keyword">end</span>
-0089 
-0090         <span class="comment">%Get maximal flux</span>
-0091         tmpModel.c(rxns(i))=1;
-0092         solMax=solveLP(tmpModel);
-0093         exitFlags(i,:)=[solMin.stat solMax.stat];
-0094         <span class="keyword">if</span> ~isempty(solMax.f)
-0095             maxFluxes(i)=solMax.x(rxns(i));
-0096         <span class="keyword">else</span>
-0097             maxFluxes(i)=NaN;
-0098         <span class="keyword">end</span>
-0099         <a href="#_sub2" class="code" title="subfunction nUpdateWaitbar(p,N,h)">nUpdateWaitbar</a>(p,N,h);
-0100     <span class="keyword">end</span>
-0101 <span class="keyword">end</span>
-0102 close(h)
-0103 
-0104 <a name="_sub1" href="#_subfunctions" class="code">function nUpdateWaitbarParallel(~)</a>
-0105 waitbar(p/N, h);
-0106 p = p + 1;
-0107 <span class="keyword">end</span>
-0108 
-0109 <a name="_sub2" href="#_subfunctions" class="code">function nUpdateWaitbar(p,N,h)</a>
-0110 waitbar(p/N, h);
-0111 p = p + 1;
-0112 <span class="keyword">end</span>
-0113 <span class="keyword">end</span></pre></div>
+0046 p = 1;
+0047 progressbar(<span class="string">'Calculating the minimal and maximal fluxes'</span>)
+0048 <span class="keyword">if</span> runParallel
+0049     D = parallel.pool.DataQueue;
+0050     afterEach(D, @<a href="#_sub1" class="code" title="subfunction updateProgressParallel(~)">updateProgressParallel</a>);
+0051     parfor i = 1:numel(rxns)
+0052         tmpModel = model;
+0053         tmpModel.c = c;
+0054 
+0055         <span class="comment">% Get minimal flux</span>
+0056         tmpModel.c(rxns(i)) = -1;
+0057         solMin = solveLP(tmpModel);
+0058         <span class="keyword">if</span> ~isempty(solMin.f)
+0059             minFluxes(i) = solMin.x(rxns(i));
+0060         <span class="keyword">else</span>
+0061             minFluxes(i) = NaN;
+0062         <span class="keyword">end</span>
+0063 
+0064         <span class="comment">% Get maximal flux</span>
+0065         tmpModel.c(rxns(i)) = 1;
+0066         solMax=solveLP(tmpModel);
+0067         exitFlags(i,:) = [solMin.stat solMax.stat];
+0068         <span class="keyword">if</span> ~isempty(solMax.f)
+0069             maxFluxes(i) = solMax.x(rxns(i));
+0070         <span class="keyword">else</span>
+0071             maxFluxes(i) = NaN;
+0072         <span class="keyword">end</span>
+0073         send(D, i);
+0074     <span class="keyword">end</span>
+0075 <span class="keyword">else</span>
+0076     <span class="keyword">for</span> i = 1:numel(rxns)
+0077         tmpModel = model;
+0078         tmpModel.c = c;
+0079 
+0080         <span class="comment">% Get minimal flux</span>
+0081         tmpModel.c(rxns(i)) = -1;
+0082         solMin=solveLP(tmpModel);
+0083         <span class="keyword">if</span> ~isempty(solMin.f)
+0084             minFluxes(i) = solMin.x(rxns(i));
+0085         <span class="keyword">else</span>
+0086             minFluxes(i) = NaN;
+0087         <span class="keyword">end</span>
+0088 
+0089         <span class="comment">% Get maximal flux</span>
+0090         tmpModel.c(rxns(i)) = 1;
+0091         solMax = solveLP(tmpModel);
+0092         exitFlags(i,:) = [solMin.stat solMax.stat];
+0093         <span class="keyword">if</span> ~isempty(solMax.f)
+0094             maxFluxes(i) = solMax.x(rxns(i));
+0095         <span class="keyword">else</span>
+0096             maxFluxes(i) = NaN;
+0097         <span class="keyword">end</span>
+0098         progressbar(i/numel(rxns))
+0099     <span class="keyword">end</span>
+0100 <span class="keyword">end</span>
+0101 progressbar(1) <span class="comment">% Make sure it closes</span>
+0102 
+0103     <a name="_sub1" href="#_subfunctions" class="code">function updateProgressParallel(~)</a>
+0104         progressbar(p/numel(rxns))
+0105         p = p + 1;
+0106     <span class="keyword">end</span>
+0107 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/core/standardizeGrRules.html
+++ b/doc/core/standardizeGrRules.html
@@ -136,102 +136,104 @@ This function is called by:
 0070             <span class="keyword">end</span>
 0071         <span class="keyword">end</span>
 0072     <span class="keyword">end</span>
-0073 <span class="keyword">end</span>
-0074 
+0073 <span class="keyword">else</span>
+0074     error(<span class="string">'The model does not have a grRules field.'</span>)
 0075 <span class="keyword">end</span>
-0076 <span class="comment">%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%</span>
-0077 <span class="comment">%Function that gets a cell array with all the simple geneSets in a given</span>
-0078 <span class="comment">%grRule string</span>
-0079 <a name="_sub1" href="#_subfunctions" class="code">function genesSets = getSimpleGeneSets(originalSTR)</a>
-0080 genesSets  = [];
-0081 <span class="comment">%If gene rule is not empty split in all its different isoenzymes</span>
-0082 <span class="keyword">if</span> ~isempty(originalSTR)
-0083     originalSTR = strtrim(originalSTR);
-0084     <span class="comment">%Remove all brackets</span>
-0085     originalSTR = strrep(originalSTR,<span class="string">'('</span>,<span class="string">''</span>);
-0086     originalSTR = strrep(originalSTR,<span class="string">')'</span>,<span class="string">''</span>);
-0087     <span class="comment">%Split all the different genesSets</span>
-0088     genesSets  = transpose(strsplit(originalSTR,<span class="string">' or '</span>));
-0089 <span class="keyword">end</span>
-0090 <span class="keyword">end</span>
-0091 <span class="comment">%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%</span>
-0092 <span class="comment">%Function that gets a cell array of simple genes sets (single genes or</span>
-0093 <span class="comment">%enzyme complexes) associated with the i-th reaction and modifies the</span>
-0094 <span class="comment">%correspondent row in the rxnGeneMat accordingly.</span>
-0095 <a name="_sub2" href="#_subfunctions" class="code">function rxnGeneMat = modifyRxnGeneMat(genesSets,modelGenes,rxnGeneMat,i)</a>
-0096 
-0097 <span class="keyword">if</span> ~isempty(genesSets)
-0098     <span class="keyword">for</span> j=1:length(genesSets)
-0099         simpleSet  = genesSets{j};
-0100         <span class="comment">%        rxnGeneMat = modifyRxnGeneMat(simpleSet,model.genes,rxnGeneMat,i);</span>
-0101         <span class="comment">%Get individual genes</span>
-0102         STR   = strrep(simpleSet,<span class="string">') and ('</span>,<span class="string">' and '</span>);
-0103         genes = strsplit(STR,<span class="string">' '</span>);
-0104         <span class="keyword">for</span> k=1:length(genes)
-0105             <span class="keyword">if</span> ~strcmpi(genes(k),<span class="string">' and '</span>)
-0106                 <span class="comment">%Get gene index</span>
-0107                 genePos = find(strcmpi(modelGenes,genes(k)));
-0108                 <span class="keyword">if</span> ~isempty(genePos)
-0109                     rxnGeneMat(i,genePos) = 1;
-0110                     <span class="comment">%else</span>
-0111                     <span class="comment">%In this case the gene should be added to the</span>
-0112                     <span class="comment">%genes field (and to all of its dependencies)</span>
-0113                 <span class="keyword">end</span>
-0114             <span class="keyword">end</span>
-0115         <span class="keyword">end</span>
-0116     <span class="keyword">end</span>
-0117 <span class="keyword">end</span>
-0118 <span class="keyword">end</span>
-0119 <span class="comment">%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%</span>
-0120 <span class="comment">%Function that gets the model field grRules and returns the indexes of the</span>
-0121 <span class="comment">%rules in which the pattern &quot;) and (&quot; is present.</span>
-0122 <a name="_sub3" href="#_subfunctions" class="code">function indexes2check = findPotentialErrors(grRules,embedded,model)</a>
-0123 indxs_l       = find(~cellfun(@isempty,strfind(grRules,<span class="string">') and ('</span>)));
-0124 indxs_l_L     = find(~cellfun(@isempty,strfind(grRules,<span class="string">') and'</span>)));
-0125 indxs_l_R     = find(~cellfun(@isempty,strfind(grRules,<span class="string">'and ('</span>)));
-0126 indexes2check = vertcat(indxs_l,indxs_l_L,indxs_l_R);
-0127 indexes2check = unique(indexes2check);
-0128 
-0129 <span class="keyword">if</span> ~isempty(indexes2check)
-0130     
-0131     <span class="keyword">if</span> embedded
-0132         EM = <span class="string">'Potentially problematic &quot;) AND (&quot; in the grRules for reaction(s): '</span>;
-0133         <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,model.rxns(indexes2check),true)
-0134     <span class="keyword">else</span>
-0135         STR = <span class="string">'Potentially problematic &quot;) AND (&quot;, &quot;) AND&quot; or &quot;AND (&quot;relat'</span>;
-0136         STR = [STR,<span class="string">'ionships found in\n\n'</span>];
-0137         <span class="keyword">for</span> i=1:length(indexes2check)
-0138             index = indexes2check(i);
-0139             STR = [STR <span class="string">'  - grRule #'</span> model.rxns{index} <span class="string">': '</span> grRules{index} <span class="string">'\n'</span>];
-0140         <span class="keyword">end</span>
-0141         STR = [STR,<span class="string">'\n This kind of relationships should only be present '</span>];
-0142         STR = [STR,<span class="string">'in  reactions catalysed by complexes of isoenzymes e'</span>];
-0143         STR = [STR,<span class="string">'.g.\n\n  - (G1 or G2) and (G3 or G4)\n\n For these c'</span>];
-0144         STR = [STR,<span class="string">'ases modify the grRules manually, writing all the po'</span>];
-0145         STR = [STR,<span class="string">'ssible combinations e.g.\n\n  - (G1 and G3) or (G1 a'</span>];
-0146         STR = [STR,<span class="string">'nd G4) or (G2 and G3) or (G2 and G4)\n\n For other c'</span>];
-0147         STR = [STR,<span class="string">'ases modify the correspondent grRules avoiding:\n\n '</span>];
-0148         STR = [STR,<span class="string">' 1) Overall container brackets, e.g.\n        &quot;(G1 a'</span>];
-0149         STR = [STR,<span class="string">'nd G2)&quot; should be &quot;G1 and G2&quot;\n\n  2) Single unit en'</span>];
-0150         STR = [STR,<span class="string">'zymes enclosed into brackets, e.g.\n        &quot;(G1)&quot; s'</span>];
-0151         STR = [STR,<span class="string">'hould be &quot;G1&quot;\n\n  3) The use of uppercases for logi'</span>];
-0152         STR = [STR,<span class="string">'cal operators, e.g.\n        &quot;G1 OR G2&quot; should be &quot;G'</span>];
-0153         STR = [STR,<span class="string">'1 or G2&quot;\n\n  4) Unbalanced brackets, e.g.\n        '</span>];
-0154         STR = [STR,<span class="string">'&quot;((G1 and G2) or G3&quot; should be &quot;(G1 and G2) or G3&quot;\n'</span>];
-0155         warning(sprintf(STR))
-0156     <span class="keyword">end</span>
-0157 <span class="keyword">end</span>
-0158 <span class="keyword">end</span>
-0159 
-0160 <a name="_sub4" href="#_subfunctions" class="code">function grRules = grRulesPreparation(grRules)</a>
-0161 <span class="comment">%Remove unnecessary blanks</span>
-0162 grRules=strrep(grRules,<span class="string">'  '</span>,<span class="string">' '</span>);
-0163 grRules=strrep(grRules,<span class="string">'( '</span>,<span class="string">'('</span>);
-0164 grRules=strrep(grRules,<span class="string">' )'</span>,<span class="string">')'</span>);
-0165 <span class="comment">% Make sure that AND and OR strings are in lowercase</span>
-0166 grRules=strrep(grRules,<span class="string">' AND '</span>,<span class="string">' and '</span>);
-0167 grRules=strrep(grRules,<span class="string">' OR '</span>,<span class="string">' or '</span>);
-0168 <span class="keyword">end</span></pre></div>
+0076 
+0077 <span class="keyword">end</span>
+0078 <span class="comment">%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%</span>
+0079 <span class="comment">%Function that gets a cell array with all the simple geneSets in a given</span>
+0080 <span class="comment">%grRule string</span>
+0081 <a name="_sub1" href="#_subfunctions" class="code">function genesSets = getSimpleGeneSets(originalSTR)</a>
+0082 genesSets  = [];
+0083 <span class="comment">%If gene rule is not empty split in all its different isoenzymes</span>
+0084 <span class="keyword">if</span> ~isempty(originalSTR)
+0085     originalSTR = strtrim(originalSTR);
+0086     <span class="comment">%Remove all brackets</span>
+0087     originalSTR = strrep(originalSTR,<span class="string">'('</span>,<span class="string">''</span>);
+0088     originalSTR = strrep(originalSTR,<span class="string">')'</span>,<span class="string">''</span>);
+0089     <span class="comment">%Split all the different genesSets</span>
+0090     genesSets  = transpose(strsplit(originalSTR,<span class="string">' or '</span>));
+0091 <span class="keyword">end</span>
+0092 <span class="keyword">end</span>
+0093 <span class="comment">%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%</span>
+0094 <span class="comment">%Function that gets a cell array of simple genes sets (single genes or</span>
+0095 <span class="comment">%enzyme complexes) associated with the i-th reaction and modifies the</span>
+0096 <span class="comment">%correspondent row in the rxnGeneMat accordingly.</span>
+0097 <a name="_sub2" href="#_subfunctions" class="code">function rxnGeneMat = modifyRxnGeneMat(genesSets,modelGenes,rxnGeneMat,i)</a>
+0098 
+0099 <span class="keyword">if</span> ~isempty(genesSets)
+0100     <span class="keyword">for</span> j=1:length(genesSets)
+0101         simpleSet  = genesSets{j};
+0102         <span class="comment">%        rxnGeneMat = modifyRxnGeneMat(simpleSet,model.genes,rxnGeneMat,i);</span>
+0103         <span class="comment">%Get individual genes</span>
+0104         STR   = strrep(simpleSet,<span class="string">') and ('</span>,<span class="string">' and '</span>);
+0105         genes = strsplit(STR,<span class="string">' '</span>);
+0106         <span class="keyword">for</span> k=1:length(genes)
+0107             <span class="keyword">if</span> ~strcmpi(genes(k),<span class="string">' and '</span>)
+0108                 <span class="comment">%Get gene index</span>
+0109                 genePos = find(strcmpi(modelGenes,genes(k)));
+0110                 <span class="keyword">if</span> ~isempty(genePos)
+0111                     rxnGeneMat(i,genePos) = 1;
+0112                     <span class="comment">%else</span>
+0113                     <span class="comment">%In this case the gene should be added to the</span>
+0114                     <span class="comment">%genes field (and to all of its dependencies)</span>
+0115                 <span class="keyword">end</span>
+0116             <span class="keyword">end</span>
+0117         <span class="keyword">end</span>
+0118     <span class="keyword">end</span>
+0119 <span class="keyword">end</span>
+0120 <span class="keyword">end</span>
+0121 <span class="comment">%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%</span>
+0122 <span class="comment">%Function that gets the model field grRules and returns the indexes of the</span>
+0123 <span class="comment">%rules in which the pattern &quot;) and (&quot; is present.</span>
+0124 <a name="_sub3" href="#_subfunctions" class="code">function indexes2check = findPotentialErrors(grRules,embedded,model)</a>
+0125 indxs_l       = find(~cellfun(@isempty,strfind(grRules,<span class="string">') and ('</span>)));
+0126 indxs_l_L     = find(~cellfun(@isempty,strfind(grRules,<span class="string">') and'</span>)));
+0127 indxs_l_R     = find(~cellfun(@isempty,strfind(grRules,<span class="string">'and ('</span>)));
+0128 indexes2check = vertcat(indxs_l,indxs_l_L,indxs_l_R);
+0129 indexes2check = unique(indexes2check);
+0130 
+0131 <span class="keyword">if</span> ~isempty(indexes2check)
+0132     
+0133     <span class="keyword">if</span> embedded
+0134         EM = <span class="string">'Potentially problematic &quot;) AND (&quot; in the grRules for reaction(s): '</span>;
+0135         <a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>(EM,false,model.rxns(indexes2check),true)
+0136     <span class="keyword">else</span>
+0137         STR = <span class="string">'Potentially problematic &quot;) AND (&quot;, &quot;) AND&quot; or &quot;AND (&quot;relat'</span>;
+0138         STR = [STR,<span class="string">'ionships found in\n\n'</span>];
+0139         <span class="keyword">for</span> i=1:length(indexes2check)
+0140             index = indexes2check(i);
+0141             STR = [STR <span class="string">'  - grRule #'</span> model.rxns{index} <span class="string">': '</span> grRules{index} <span class="string">'\n'</span>];
+0142         <span class="keyword">end</span>
+0143         STR = [STR,<span class="string">'\n This kind of relationships should only be present '</span>];
+0144         STR = [STR,<span class="string">'in  reactions catalysed by complexes of isoenzymes e'</span>];
+0145         STR = [STR,<span class="string">'.g.\n\n  - (G1 or G2) and (G3 or G4)\n\n For these c'</span>];
+0146         STR = [STR,<span class="string">'ases modify the grRules manually, writing all the po'</span>];
+0147         STR = [STR,<span class="string">'ssible combinations e.g.\n\n  - (G1 and G3) or (G1 a'</span>];
+0148         STR = [STR,<span class="string">'nd G4) or (G2 and G3) or (G2 and G4)\n\n For other c'</span>];
+0149         STR = [STR,<span class="string">'ases modify the correspondent grRules avoiding:\n\n '</span>];
+0150         STR = [STR,<span class="string">' 1) Overall container brackets, e.g.\n        &quot;(G1 a'</span>];
+0151         STR = [STR,<span class="string">'nd G2)&quot; should be &quot;G1 and G2&quot;\n\n  2) Single unit en'</span>];
+0152         STR = [STR,<span class="string">'zymes enclosed into brackets, e.g.\n        &quot;(G1)&quot; s'</span>];
+0153         STR = [STR,<span class="string">'hould be &quot;G1&quot;\n\n  3) The use of uppercases for logi'</span>];
+0154         STR = [STR,<span class="string">'cal operators, e.g.\n        &quot;G1 OR G2&quot; should be &quot;G'</span>];
+0155         STR = [STR,<span class="string">'1 or G2&quot;\n\n  4) Unbalanced brackets, e.g.\n        '</span>];
+0156         STR = [STR,<span class="string">'&quot;((G1 and G2) or G3&quot; should be &quot;(G1 and G2) or G3&quot;\n'</span>];
+0157         warning(sprintf(STR))
+0158     <span class="keyword">end</span>
+0159 <span class="keyword">end</span>
+0160 <span class="keyword">end</span>
+0161 
+0162 <a name="_sub4" href="#_subfunctions" class="code">function grRules = grRulesPreparation(grRules)</a>
+0163 <span class="comment">%Remove unnecessary blanks</span>
+0164 grRules=strrep(grRules,<span class="string">'  '</span>,<span class="string">' '</span>);
+0165 grRules=strrep(grRules,<span class="string">'( '</span>,<span class="string">'('</span>);
+0166 grRules=strrep(grRules,<span class="string">' )'</span>,<span class="string">')'</span>);
+0167 <span class="comment">% Make sure that AND and OR strings are in lowercase</span>
+0168 grRules=strrep(grRules,<span class="string">' AND '</span>,<span class="string">' and '</span>);
+0169 grRules=strrep(grRules,<span class="string">' OR '</span>,<span class="string">' or '</span>);
+0170 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/io/readYAMLmodel.html
+++ b/doc/io/readYAMLmodel.html
@@ -601,7 +601,7 @@ This function is called by:
 0544    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'rxns'</span>);
 0545 <span class="keyword">end</span>
 0546 <span class="keyword">for</span> i={<span class="string">'c'</span>} <span class="comment">% Zeros</span>
-0547    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},0,<span class="string">'rxns'</span>);
+0547    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},0,<span class="string">'rxns'</span>,true);
 0548 <span class="keyword">end</span>
 0549 <span class="keyword">for</span> i={<span class="string">'rxnConfidenceScores'</span>,<span class="string">'rxnDeltaG'</span>} <span class="comment">% NaNs</span>
 0550    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},NaN,<span class="string">'rxns'</span>);

--- a/io/readYAMLmodel.m
+++ b/io/readYAMLmodel.m
@@ -544,7 +544,7 @@ for i={'rxnNames','grRules','eccodes','rxnNotes','rxnReferences',...
    model = emptyOrFill(model,i{1},{''},'rxns');
 end
 for i={'c'} % Zeros
-   model = emptyOrFill(model,i{1},0,'rxns');
+   model = emptyOrFill(model,i{1},0,'rxns',true);
 end
 for i={'rxnConfidenceScores','rxnDeltaG'} % NaNs
    model = emptyOrFill(model,i{1},NaN,'rxns');


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `readYAMLmodel` should always make model.c-field, even if no objective function is specified.
  - `standardizeGrRules` should throw error if no grRules field is found.
- doc:
  - `addRxnsGenesMets` more detailed error message if reactions cannot be found.
  
**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch
