### PR TITLE
refactor: getAllowedBounds to use progressbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ Temporary Items
 external/kegg/keggModel.mat
 #software
 #doc
+
+# IDE stuff #
+################
+.idea/
+*.iml


### PR DESCRIPTION
### Main improvements in this PR:

Refactor `waitbar` function used in `getAllowedBounds` to `progressbar`. Note that this is the only function that uses waitbar in RAVEN.

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [ ] Selected `develop` as a target branch
