### PR TITLE
fix: solverTests for soplex

### DIFF
--- a/doc/testing/unit_tests/solverTests.html
+++ b/doc/testing/unit_tests/solverTests.html
@@ -121,81 +121,84 @@ This function is called by:
 0074 <span class="keyword">end</span>
 0075 
 0076 <a name="_sub3" href="#_subfunctions" class="code">function testSoplex(testCase)</a>
-0077 [a,~] = system(<span class="string">'soplex --help'</span>);
-0078 <span class="keyword">if</span> ~(a == 0)
-0079     error(<span class="string">'SoPlex not installed or cannot be found, test skipped'</span>)
-0080 <span class="keyword">end</span>
-0081 sourceDir = fileparts(which(mfilename));
-0082 load([sourceDir,<span class="string">'/test_data/ecoli_textbook.mat'</span>], <span class="string">'model'</span>);
-0083 <span class="keyword">try</span>
-0084     oldSolver=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0085 <span class="keyword">catch</span>
-0086 <span class="keyword">end</span>
-0087 setRavenSolver(<span class="string">'soplex'</span>);
-0088 
-0089 <span class="keyword">try</span>
-0090     <span class="comment">% Try all three types of flux minimization</span>
-0091     evalc(<span class="string">'sol=solveLP(model,3);'</span>);    
-0092     evalc(<span class="string">'sol=solveLP(model,1);'</span>);
-0093     evalc(<span class="string">'sol=solveLP(model,0);'</span>);
-0094 <span class="keyword">catch</span>
-0095     <span class="keyword">try</span>
-0096         setRavenSolver(oldSolver);
-0097     <span class="keyword">catch</span>
-0098         rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0099     <span class="keyword">end</span>
-0100     error(<span class="string">'Solver not working'</span>)
-0101 <span class="keyword">end</span>
-0102 <span class="keyword">try</span>
-0103     setRavenSolver(oldSolver);
-0104 <span class="keyword">catch</span>
-0105     rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0106 <span class="keyword">end</span>
-0107 
-0108 load([sourceDir,<span class="string">'/test_data/solverTestOutput.mat'</span>], <span class="string">'solOutSoplex'</span>);
-0109 <span class="comment">%Check that the actual model is the same as the expected model</span>
-0110 verifyEqual(testCase,sol,solOutSoplex,<span class="string">'AbsTol'</span>,0.1)
-0111 <span class="keyword">end</span>
-0112 
-0113 <a name="_sub4" href="#_subfunctions" class="code">function testCobra(testCase)</a>
-0114 <span class="keyword">if</span> exist(<span class="string">'initCobraToolbox.m'</span>,<span class="string">'file'</span>)~=2
-0115     error(<span class="string">'COBRA Toolbox not installed or cannot be found in MATLAB path, test skipped'</span>)
-0116 <span class="keyword">end</span>
-0117 sourceDir = fileparts(which(mfilename));
-0118 load([sourceDir,<span class="string">'/test_data/ecoli_textbook.mat'</span>], <span class="string">'model'</span>);
-0119 <span class="keyword">try</span>
-0120     oldSolver=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0121 <span class="keyword">catch</span>
-0122 <span class="keyword">end</span>
-0123 <span class="keyword">global</span> CBT_LP_SOLVER
-0124 <span class="keyword">global</span> CBT_MILP_SOLVER
-0125 CBT_LP_SOLVER = <span class="string">'glpk'</span>;
-0126 CBT_MILP_SOLVER = <span class="string">'glpk'</span>;
-0127 setRavenSolver(<span class="string">'cobra'</span>);
-0128 
-0129 <span class="keyword">try</span>
-0130     <span class="comment">% Try all three types of flux minimization</span>
-0131     evalc(<span class="string">'sol=solveLP(model,3);'</span>);    
-0132     evalc(<span class="string">'sol=solveLP(model,1);'</span>);
-0133     evalc(<span class="string">'sol=solveLP(model,0);'</span>);
-0134 <span class="keyword">catch</span>
-0135     <span class="keyword">try</span>
-0136         setRavenSolver(oldSolver);
-0137     <span class="keyword">catch</span>
-0138         rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0139     <span class="keyword">end</span>
-0140     error(<span class="string">'Solver not working'</span>)
-0141 <span class="keyword">end</span>
-0142 <span class="keyword">try</span>
-0143     setRavenSolver(oldSolver);
-0144 <span class="keyword">catch</span>
-0145     rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
-0146 <span class="keyword">end</span>
-0147 
-0148 load([sourceDir,<span class="string">'/test_data/solverTestOutput.mat'</span>], <span class="string">'solOut'</span>);
-0149 <span class="comment">%Check that the actual model is the same as the expected model</span>
-0150 verifyEqual(testCase,sol,solOut,<span class="string">'AbsTol'</span>,0.1)
-0151 <span class="keyword">end</span></pre></div>
+0077 currDir = pwd;
+0078 cd(fullfile(findRAVENroot,<span class="string">'software'</span>,<span class="string">'soplex'</span>))
+0079 [a,~] = system(<span class="string">'soplex --help'</span>);
+0080 cd(currDir)
+0081 <span class="keyword">if</span> ~(a == 0)
+0082     error(<span class="string">'SoPlex not installed or cannot be found, test skipped'</span>)
+0083 <span class="keyword">end</span>
+0084 sourceDir = fileparts(which(mfilename));
+0085 load([sourceDir,<span class="string">'/test_data/ecoli_textbook.mat'</span>], <span class="string">'model'</span>);
+0086 <span class="keyword">try</span>
+0087     oldSolver=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0088 <span class="keyword">catch</span>
+0089 <span class="keyword">end</span>
+0090 setRavenSolver(<span class="string">'soplex'</span>);
+0091 
+0092 <span class="keyword">try</span>
+0093     <span class="comment">% Try all three types of flux minimization</span>
+0094     evalc(<span class="string">'sol=solveLP(model,3);'</span>);    
+0095     evalc(<span class="string">'sol=solveLP(model,1);'</span>);
+0096     evalc(<span class="string">'sol=solveLP(model,0);'</span>);
+0097 <span class="keyword">catch</span>
+0098     <span class="keyword">try</span>
+0099         setRavenSolver(oldSolver);
+0100     <span class="keyword">catch</span>
+0101         rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0102     <span class="keyword">end</span>
+0103     error(<span class="string">'Solver not working'</span>)
+0104 <span class="keyword">end</span>
+0105 <span class="keyword">try</span>
+0106     setRavenSolver(oldSolver);
+0107 <span class="keyword">catch</span>
+0108     rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0109 <span class="keyword">end</span>
+0110 
+0111 load([sourceDir,<span class="string">'/test_data/solverTestOutput.mat'</span>], <span class="string">'solOutSoplex'</span>);
+0112 <span class="comment">%Check that the actual model is the same as the expected model</span>
+0113 verifyEqual(testCase,sol,solOutSoplex,<span class="string">'AbsTol'</span>,0.1)
+0114 <span class="keyword">end</span>
+0115 
+0116 <a name="_sub4" href="#_subfunctions" class="code">function testCobra(testCase)</a>
+0117 <span class="keyword">if</span> exist(<span class="string">'initCobraToolbox.m'</span>,<span class="string">'file'</span>)~=2
+0118     error(<span class="string">'COBRA Toolbox not installed or cannot be found in MATLAB path, test skipped'</span>)
+0119 <span class="keyword">end</span>
+0120 sourceDir = fileparts(which(mfilename));
+0121 load([sourceDir,<span class="string">'/test_data/ecoli_textbook.mat'</span>], <span class="string">'model'</span>);
+0122 <span class="keyword">try</span>
+0123     oldSolver=getpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0124 <span class="keyword">catch</span>
+0125 <span class="keyword">end</span>
+0126 <span class="keyword">global</span> CBT_LP_SOLVER
+0127 <span class="keyword">global</span> CBT_MILP_SOLVER
+0128 CBT_LP_SOLVER = <span class="string">'glpk'</span>;
+0129 CBT_MILP_SOLVER = <span class="string">'glpk'</span>;
+0130 setRavenSolver(<span class="string">'cobra'</span>);
+0131 
+0132 <span class="keyword">try</span>
+0133     <span class="comment">% Try all three types of flux minimization</span>
+0134     evalc(<span class="string">'sol=solveLP(model,3);'</span>);    
+0135     evalc(<span class="string">'sol=solveLP(model,1);'</span>);
+0136     evalc(<span class="string">'sol=solveLP(model,0);'</span>);
+0137 <span class="keyword">catch</span>
+0138     <span class="keyword">try</span>
+0139         setRavenSolver(oldSolver);
+0140     <span class="keyword">catch</span>
+0141         rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0142     <span class="keyword">end</span>
+0143     error(<span class="string">'Solver not working'</span>)
+0144 <span class="keyword">end</span>
+0145 <span class="keyword">try</span>
+0146     setRavenSolver(oldSolver);
+0147 <span class="keyword">catch</span>
+0148     rmpref(<span class="string">'RAVEN'</span>,<span class="string">'solver'</span>);
+0149 <span class="keyword">end</span>
+0150 
+0151 load([sourceDir,<span class="string">'/test_data/solverTestOutput.mat'</span>], <span class="string">'solOut'</span>);
+0152 <span class="comment">%Check that the actual model is the same as the expected model</span>
+0153 verifyEqual(testCase,sol,solOut,<span class="string">'AbsTol'</span>,0.1)
+0154 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/testing/unit_tests/solverTests.m
+++ b/testing/unit_tests/solverTests.m
@@ -74,7 +74,10 @@ verifyEqual(testCase,sol,solOut,'AbsTol',0.1)
 end
 
 function testSoplex(testCase)
+currDir = pwd;
+cd(fullfile(findRAVENroot,'software','soplex'))
 [a,~] = system('soplex --help');
+cd(currDir)
 if ~(a == 0)
     error('SoPlex not installed or cannot be found, test skipped')
 end


### PR DESCRIPTION

### Main improvements in this PR:
- fix:
  - `checkInstallation` (via `solverTests`) will not report soplex as `fail` on Windows when using RAVEN-provided binary (solves #513).

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch
