### PR TITLE
fix: extractMiriamallows multiple miriamNames

### DIFF
--- a/doc/struct_conversion/extractMiriam.html
+++ b/doc/struct_conversion/extractMiriam.html
@@ -97,7 +97,7 @@ This function is called by:
 0026 <span class="comment">%</span>
 0027 <span class="comment">%   Usage: miriam=extractMiriam(modelMiriams,miriamName)</span>
 0028 
-0029 <span class="keyword">if</span> nargin&lt;2 || strcmp(miriamNames,<span class="string">'all'</span>)
+0029 <span class="keyword">if</span> nargin&lt;2 || (ischar(miriamNames) &amp;&amp; strcmp(miriamNames,<span class="string">'all'</span>))
 0030     extractAllTypes=true;
 0031 <span class="keyword">else</span>
 0032     extractAllTypes=false;

--- a/struct_conversion/extractMiriam.m
+++ b/struct_conversion/extractMiriam.m
@@ -26,7 +26,7 @@ function [miriams,extractedMiriamNames]=extractMiriam(modelMiriams,miriamNames)
 %
 %   Usage: miriam=extractMiriam(modelMiriams,miriamName)
 
-if nargin<2 || strcmp(miriamNames,'all')
+if nargin<2 || (ischar(miriamNames) && strcmp(miriamNames,'all'))
     extractAllTypes=true;
 else
     extractAllTypes=false;


### PR DESCRIPTION
### Main improvements in this PR:
- Fixes:
  - `extractMiriam` should allow cell array of multiple miriamNames as input.

**I hereby confirm that I have:**
<!-- Note: replace [ ] with [X] to check the box -->
- [x] Selected `develop` as a target branch
