### PR TITLE
fix: checkInstallation if MATLAB Add-On

### DIFF
--- a/doc/installation/checkInstallation.html
+++ b/doc/installation/checkInstallation.html
@@ -107,140 +107,140 @@ This function is called by:
 0038 [ravenDir,~,~]=fileparts(fileparts(ST(I).file));
 0039 
 0040 installType = 2; <span class="comment">% If neither git nor add-on, then ZIP was downloaded</span>
-0041 <span class="keyword">if</span> isfolder(fullfile(ravenDir,<span class="string">'.git'</span>))
-0042     installType = 0;
-0043 <span class="keyword">elseif</span> any(strcmp(addList.Name,<span class="string">'RAVEN Toolbox'</span>))
-0044     installType = 1;
-0045 <span class="keyword">end</span>
-0046 
-0047 <span class="comment">% Do not print first few lines if only version should be reported</span>
-0048 <span class="keyword">if</span> ~versionOnly
-0049     fprintf(<span class="string">'\n*** THE RAVEN TOOLBOX ***\n\n'</span>);
-0050     <span class="comment">%Print the RAVEN version if it is not the development version</span>
-0051     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Installation type'</span>,40));
-0052     <span class="keyword">switch</span> installType
-0053         <span class="keyword">case</span> 0
-0054             fprintf(<span class="string">'Advanced (via git)\n'</span>);
-0055         <span class="keyword">case</span> 1
-0056             fprintf(<span class="string">'Easy (as MATLAB Add-On)\n'</span>);
-0057         <span class="keyword">case</span> 2
-0058             fprintf(<span class="string">'Medium (as downloaded ZIP file)\n'</span>);
-0059     <span class="keyword">end</span>
-0060     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Installing from location'</span>,40));
-0061     fprintf(<span class="string">'%s\n'</span>,ravenDir)
-0062     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking RAVEN release'</span>,40));
-0063 <span class="keyword">end</span>
-0064                        
-0065 <span class="keyword">if</span> exist(fullfile(ravenDir,<span class="string">'version.txt'</span>), <span class="string">'file'</span>) == 2
-0066     currVer = fgetl(fopen(fullfile(ravenDir,<span class="string">'version.txt'</span>)));
-0067     fclose(<span class="string">'all'</span>);
-0068     <span class="keyword">if</span> ~versionOnly
-0069         fprintf([currVer <span class="string">'\n'</span>]);
-0070         <span class="keyword">try</span>
-0071             newVer=strtrim(webread(<span class="string">'https://raw.githubusercontent.com/SysBioChalmers/RAVEN/main/version.txt'</span>));
-0072             newVerNum=str2double(strsplit(newVer,<span class="string">'.'</span>));
-0073             currVerNum=str2double(strsplit(currVer,<span class="string">'.'</span>));
-0074             <span class="keyword">for</span> i=1:3
-0075                 <span class="keyword">if</span> currVerNum(i)&lt;newVerNum(i)
-0076                     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Latest RAVEN release available'</span>,40))
-0077                     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>([newVer,<span class="string">'\n'</span>])
-0078                     <span class="keyword">switch</span> installType
-0079                         <span class="keyword">case</span> 0
-0080                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     Run git pull in your favourite git client\n'</span>)
-0081                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     to get the latest RAVEN release\n'</span>);
-0082                         <span class="keyword">case</span> 1
-0083                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'     Instructions on how to upgrade'</span>,40))
-0084                             fprintf(<span class="string">'&lt;a href=&quot;https://github.com/SysBioChalmers/RAVEN/wiki/Installation#upgrade-raven-after-easy-installation&quot;&gt;here&lt;/a&gt;\n'</span>);
-0085                         <span class="keyword">case</span> 2
-0086                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'     Instructions on how to upgrade'</span>,40))
-0087                             fprintf(<span class="string">'&lt;a href=&quot;https://github.com/SysBioChalmers/RAVEN/wiki/Installation#upgrade-raven-after-medium-installation&quot;&gt;here&lt;/a&gt;\n'</span>);                            
-0088                     <span class="keyword">end</span>
-0089                     <span class="keyword">break</span>
-0090                 <span class="keyword">elseif</span> i==3
-0091                     fprintf(<span class="string">'   &gt; You are running the latest RAVEN release\n'</span>);
-0092                 <span class="keyword">end</span>
-0093             <span class="keyword">end</span>
-0094         <span class="keyword">catch</span>
-0095             fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Checking for latest RAVEN release'</span>,40))
-0096             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>);
-0097             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     Cannot reach GitHub for release info\n'</span>);
-0098         <span class="keyword">end</span>
-0099     <span class="keyword">end</span>
-0100 <span class="keyword">else</span>
-0101     currVer = <span class="string">'develop'</span>;
-0102     <span class="keyword">if</span> ~versionOnly; fprintf(<span class="string">'DEVELOPMENT\n'</span>); <span class="keyword">end</span>
-0103 <span class="keyword">end</span>
-0104 <span class="keyword">if</span> strcmp(developMode,<span class="string">'versionOnly'</span>)
-0105     <span class="keyword">return</span>;
-0106 <span class="keyword">end</span>
-0107 
-0108 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking MATLAB release'</span>,40))
-0109 fprintf([version(<span class="string">'-release'</span>) <span class="string">'\n'</span>])
-0110 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking system architecture'</span>,40))
-0111 fprintf([computer(<span class="string">'arch'</span>),<span class="string">'\n'</span>])
-0112 
-0113 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Set RAVEN in MATLAB path'</span>,40))
-0114 subpath=regexp(genpath(ravenDir),pathsep,<span class="string">'split'</span>); <span class="comment">%List all subdirectories</span>
-0115 pathsToKeep=cellfun(@(x) ~contains(x,<span class="string">'.git'</span>),subpath) &amp; cellfun(@(x) ~contains(x,<span class="string">'doc'</span>),subpath);
-0116 <span class="keyword">try</span>
-0117     addpath(strjoin(subpath(pathsToKeep),pathsep));
-0118     fprintf(<span class="string">'Pass\n'</span>);
-0119     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Save MATLAB path'</span>,40))
-0120     <span class="keyword">try</span>
-0121         savepath
-0122         fprintf(<span class="string">'Pass\n'</span>)   
-0123     <span class="keyword">catch</span>
-0124         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
-0125         fprintf([<span class="string">'   You might have to rerun checkInstallation again\n'</span><span class="keyword">...</span>
-0126                  <span class="string">'   next time you start up MATLAB\n'</span>])        
-0127     <span class="keyword">end</span>
-0128 <span class="keyword">catch</span>
-0129     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
-0130 <span class="keyword">end</span>
-0131 
-0132 <span class="keyword">if</span> isunix
-0133     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Make binaries executable'</span>,40))
-0134     status = <a href="#_sub3" class="code" title="subfunction status = makeBinaryExecutable(ravenDir)">makeBinaryExecutable</a>(ravenDir);
-0135     <span class="keyword">if</span> status == 0
-0136         fprintf(<span class="string">'Pass\n'</span>)
-0137     <span class="keyword">else</span>
-0138         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
-0139     <span class="keyword">end</span>
-0140 <span class="keyword">end</span>
-0141 
-0142 <span class="comment">%Check if it is possible to parse an Excel file</span>
-0143 fprintf(<span class="string">'\n=== Model import and export ===\n'</span>);
-0144 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Add Java paths for Excel format'</span>,40))
-0145 <span class="keyword">try</span>
-0146     <span class="comment">%Add the required classes to the static Java path if not already added</span>
-0147     addJavaPaths();
-0148     fprintf(<span class="string">'Pass\n'</span>)
-0149 <span class="keyword">catch</span>
-0150     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
-0151 <span class="keyword">end</span>
-0152 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking libSBML version'</span>,40))
-0153 <span class="keyword">try</span>
-0154     evalc(<span class="string">'importModel(fullfile(ravenDir,''tutorial'',''empty.xml''))'</span>);
-0155     <span class="keyword">try</span>
-0156         libSBMLver=OutputSBML_RAVEN; <span class="comment">% Only works in libSBML 5.17.0+</span>
-0157         fprintf([libSBMLver.libSBML_version_string <span class="string">'\n'</span>]);
-0158     <span class="keyword">catch</span>
-0159         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
-0160         fprintf(<span class="string">'   An older libSBML version was found, update to version 5.17.0 or higher for a significant improvement of model import\n'</span>);
-0161     <span class="keyword">end</span>
-0162 <span class="keyword">catch</span>
-0163     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
-0164     fprintf(<span class="string">'   Download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n'</span>);
-0165 <span class="keyword">end</span>
-0166 fprintf(<span class="string">' &gt; Checking model import and export\n'</span>)
-0167 [~,res]=evalc(&quot;runtests(<span class="string">'importExportTests.m'</span>);&quot;);
-0168 
-0169 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Import Excel format'</span>,40))
-0170 <span class="keyword">if</span> res(1).Passed == 1
-0171     fprintf(<span class="string">'Pass\n'</span>)
-0172 <span class="keyword">else</span>
-0173     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
-0174     addList = matlab.addons.installedAddons;
+0041 addList = matlab.addons.installedAddons;
+0042 <span class="keyword">if</span> isfolder(fullfile(ravenDir,<span class="string">'.git'</span>))
+0043     installType = 0;
+0044 <span class="keyword">elseif</span> any(strcmp(addList.Name,<span class="string">'RAVEN Toolbox'</span>))
+0045     installType = 1;
+0046 <span class="keyword">end</span>
+0047 
+0048 <span class="comment">% Do not print first few lines if only version should be reported</span>
+0049 <span class="keyword">if</span> ~versionOnly
+0050     fprintf(<span class="string">'\n*** THE RAVEN TOOLBOX ***\n\n'</span>);
+0051     <span class="comment">%Print the RAVEN version if it is not the development version</span>
+0052     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Installation type'</span>,40));
+0053     <span class="keyword">switch</span> installType
+0054         <span class="keyword">case</span> 0
+0055             fprintf(<span class="string">'Advanced (via git)\n'</span>);
+0056         <span class="keyword">case</span> 1
+0057             fprintf(<span class="string">'Easy (as MATLAB Add-On)\n'</span>);
+0058         <span class="keyword">case</span> 2
+0059             fprintf(<span class="string">'Medium (as downloaded ZIP file)\n'</span>);
+0060     <span class="keyword">end</span>
+0061     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Installing from location'</span>,40));
+0062     fprintf(<span class="string">'%s\n'</span>,ravenDir)
+0063     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking RAVEN release'</span>,40));
+0064 <span class="keyword">end</span>
+0065                        
+0066 <span class="keyword">if</span> exist(fullfile(ravenDir,<span class="string">'version.txt'</span>), <span class="string">'file'</span>) == 2
+0067     currVer = fgetl(fopen(fullfile(ravenDir,<span class="string">'version.txt'</span>)));
+0068     fclose(<span class="string">'all'</span>);
+0069     <span class="keyword">if</span> ~versionOnly
+0070         fprintf([currVer <span class="string">'\n'</span>]);
+0071         <span class="keyword">try</span>
+0072             newVer=strtrim(webread(<span class="string">'https://raw.githubusercontent.com/SysBioChalmers/RAVEN/main/version.txt'</span>));
+0073             newVerNum=str2double(strsplit(newVer,<span class="string">'.'</span>));
+0074             currVerNum=str2double(strsplit(currVer,<span class="string">'.'</span>));
+0075             <span class="keyword">for</span> i=1:3
+0076                 <span class="keyword">if</span> currVerNum(i)&lt;newVerNum(i)
+0077                     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Latest RAVEN release available'</span>,40))
+0078                     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>([newVer,<span class="string">'\n'</span>])
+0079                     <span class="keyword">switch</span> installType
+0080                         <span class="keyword">case</span> 0
+0081                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     Run git pull in your favourite git client\n'</span>)
+0082                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     to get the latest RAVEN release\n'</span>);
+0083                         <span class="keyword">case</span> 1
+0084                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'     Instructions on how to upgrade'</span>,40))
+0085                             fprintf(<span class="string">'&lt;a href=&quot;https://github.com/SysBioChalmers/RAVEN/wiki/Installation#upgrade-raven-after-easy-installation&quot;&gt;here&lt;/a&gt;\n'</span>);
+0086                         <span class="keyword">case</span> 2
+0087                             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'     Instructions on how to upgrade'</span>,40))
+0088                             fprintf(<span class="string">'&lt;a href=&quot;https://github.com/SysBioChalmers/RAVEN/wiki/Installation#upgrade-raven-after-medium-installation&quot;&gt;here&lt;/a&gt;\n'</span>);                            
+0089                     <span class="keyword">end</span>
+0090                     <span class="keyword">break</span>
+0091                 <span class="keyword">elseif</span> i==3
+0092                     fprintf(<span class="string">'   &gt; You are running the latest RAVEN release\n'</span>);
+0093                 <span class="keyword">end</span>
+0094             <span class="keyword">end</span>
+0095         <span class="keyword">catch</span>
+0096             fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Checking for latest RAVEN release'</span>,40))
+0097             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>);
+0098             <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'     Cannot reach GitHub for release info\n'</span>);
+0099         <span class="keyword">end</span>
+0100     <span class="keyword">end</span>
+0101 <span class="keyword">else</span>
+0102     currVer = <span class="string">'develop'</span>;
+0103     <span class="keyword">if</span> ~versionOnly; fprintf(<span class="string">'DEVELOPMENT\n'</span>); <span class="keyword">end</span>
+0104 <span class="keyword">end</span>
+0105 <span class="keyword">if</span> strcmp(developMode,<span class="string">'versionOnly'</span>)
+0106     <span class="keyword">return</span>;
+0107 <span class="keyword">end</span>
+0108 
+0109 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking MATLAB release'</span>,40))
+0110 fprintf([version(<span class="string">'-release'</span>) <span class="string">'\n'</span>])
+0111 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking system architecture'</span>,40))
+0112 fprintf([computer(<span class="string">'arch'</span>),<span class="string">'\n'</span>])
+0113 
+0114 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Set RAVEN in MATLAB path'</span>,40))
+0115 subpath=regexp(genpath(ravenDir),pathsep,<span class="string">'split'</span>); <span class="comment">%List all subdirectories</span>
+0116 pathsToKeep=cellfun(@(x) ~contains(x,<span class="string">'.git'</span>),subpath) &amp; cellfun(@(x) ~contains(x,<span class="string">'doc'</span>),subpath);
+0117 <span class="keyword">try</span>
+0118     addpath(strjoin(subpath(pathsToKeep),pathsep));
+0119     fprintf(<span class="string">'Pass\n'</span>);
+0120     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Save MATLAB path'</span>,40))
+0121     <span class="keyword">try</span>
+0122         savepath
+0123         fprintf(<span class="string">'Pass\n'</span>)   
+0124     <span class="keyword">catch</span>
+0125         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
+0126         fprintf([<span class="string">'   You might have to rerun checkInstallation again\n'</span><span class="keyword">...</span>
+0127                  <span class="string">'   next time you start up MATLAB\n'</span>])        
+0128     <span class="keyword">end</span>
+0129 <span class="keyword">catch</span>
+0130     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
+0131 <span class="keyword">end</span>
+0132 
+0133 <span class="keyword">if</span> isunix
+0134     fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Make binaries executable'</span>,40))
+0135     status = <a href="#_sub3" class="code" title="subfunction status = makeBinaryExecutable(ravenDir)">makeBinaryExecutable</a>(ravenDir);
+0136     <span class="keyword">if</span> status == 0
+0137         fprintf(<span class="string">'Pass\n'</span>)
+0138     <span class="keyword">else</span>
+0139         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
+0140     <span class="keyword">end</span>
+0141 <span class="keyword">end</span>
+0142 
+0143 <span class="comment">%Check if it is possible to parse an Excel file</span>
+0144 fprintf(<span class="string">'\n=== Model import and export ===\n'</span>);
+0145 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Add Java paths for Excel format'</span>,40))
+0146 <span class="keyword">try</span>
+0147     <span class="comment">%Add the required classes to the static Java path if not already added</span>
+0148     addJavaPaths();
+0149     fprintf(<span class="string">'Pass\n'</span>)
+0150 <span class="keyword">catch</span>
+0151     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
+0152 <span class="keyword">end</span>
+0153 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">' &gt; Checking libSBML version'</span>,40))
+0154 <span class="keyword">try</span>
+0155     evalc(<span class="string">'importModel(fullfile(ravenDir,''tutorial'',''empty.xml''))'</span>);
+0156     <span class="keyword">try</span>
+0157         libSBMLver=OutputSBML_RAVEN; <span class="comment">% Only works in libSBML 5.17.0+</span>
+0158         fprintf([libSBMLver.libSBML_version_string <span class="string">'\n'</span>]);
+0159     <span class="keyword">catch</span>
+0160         <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
+0161         fprintf(<span class="string">'   An older libSBML version was found, update to version 5.17.0 or higher for a significant improvement of model import\n'</span>);
+0162     <span class="keyword">end</span>
+0163 <span class="keyword">catch</span>
+0164     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
+0165     fprintf(<span class="string">'   Download libSBML from http://sbml.org/Software/libSBML/Downloading_libSBML and add to MATLAB path\n'</span>);
+0166 <span class="keyword">end</span>
+0167 fprintf(<span class="string">' &gt; Checking model import and export\n'</span>)
+0168 [~,res]=evalc(&quot;runtests(<span class="string">'importExportTests.m'</span>);&quot;);
+0169 
+0170 fprintf(<a href="#_sub2" class="code" title="subfunction str = myStr(InputStr,len)">myStr</a>(<span class="string">'   &gt; Import Excel format'</span>,40))
+0171 <span class="keyword">if</span> res(1).Passed == 1
+0172     fprintf(<span class="string">'Pass\n'</span>)
+0173 <span class="keyword">else</span>
+0174     <a href="#_sub4" class="code" title="subfunction printOrange(stringToPrint)">printOrange</a>(<span class="string">'Fail\n'</span>)
 0175     <span class="keyword">if</span> any(strcmpi(addList.Name,<span class="string">'Text Analytics Toolbox'</span>))
 0176         fprintf([<span class="string">'   Excel import/export is incompatible with MATLAB Text Analytics Toolbox.\n'</span> <span class="keyword">...</span>
 0177                  <span class="string">'   Further instructions =&gt; https://github.com/SysBioChalmers/RAVEN/issues/55#issuecomment-1514369299\n'</span>])

--- a/installation/checkInstallation.m
+++ b/installation/checkInstallation.m
@@ -38,6 +38,7 @@ end
 [ravenDir,~,~]=fileparts(fileparts(ST(I).file));
 
 installType = 2; % If neither git nor add-on, then ZIP was downloaded
+addList = matlab.addons.installedAddons;
 if isfolder(fullfile(ravenDir,'.git'))
     installType = 0;
 elseif any(strcmp(addList.Name,'RAVEN Toolbox'))
@@ -171,7 +172,6 @@ if res(1).Passed == 1
     fprintf('Pass\n')
 else
     printOrange('Fail\n')
-    addList = matlab.addons.installedAddons;
     if any(strcmpi(addList.Name,'Text Analytics Toolbox'))
         fprintf(['   Excel import/export is incompatible with MATLAB Text Analytics Toolbox.\n' ...
                  '   Further instructions => https://github.com/SysBioChalmers/RAVEN/issues/55#issuecomment-1514369299\n'])


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `checkInstallation` finding RAVEN when installed as MATLAB Add-On

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [x] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.
