### PR TITLE
fix: getBlast, importModel, replaceMets, ravenCobraWrapper / feat: getIndexes

### DIFF
--- a/core/contractModel.m
+++ b/core/contractModel.m
@@ -25,7 +25,7 @@ function [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,d
 %   NOTE: This code might not work for advanced grRules strings
 %         that involve nested expressions of 'and' and 'or'.
 %
-% Usage: [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse)
+% Usage: [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse,mets)
 
 if nargin<2
     distReverse=true;

--- a/core/getIndexes.m
+++ b/core/getIndexes.m
@@ -2,7 +2,7 @@ function indexes=getIndexes(model, objects, type, returnLogical)
 % getIndexes
 %   Retrieves the indexes for a list of reactions or metabolites
 %
-%   Input:
+% Input:
 %   model           a model structure
 %   objects         either a cell array of IDs, a logical vector with the
 %                   same number of elements as metabolites in the model,
@@ -10,15 +10,21 @@ function indexes=getIndexes(model, objects, type, returnLogical)
 %   type            'rxns', 'mets', or 'genes' depending on what to retrieve
 %                   'metnames' queries metabolite names, while 'metcomps'
 %                   allows to provide specific metabolites and their
-%                   compartments in the format metaboliteName[comp]
+%                   compartments in the format metaboliteName[comp]. If a
+%                   model.ec structure exists (GECKO 3), then also
+%                   'ecenzymes', 'ecrxns' and 'ecgenes' are allowed
 %   returnLogical   Sets whether to return a logical array or an array with
 %                   the indexes (optional, default false)
 %
-%   Output:
+% Output:
 %   indexes         can be a logical array or a double array depending on
 %                   the value of returnLogical
 %
-% 	Usage: indexes=getIndexes(model, objects, type, returnLogical)
+% Note: If 'ecenzymes', 'ecrxns' or 'ecgenes' are used with a GECKO 3
+% model, then the indexes are from the model.ec.enzymes, model.ec.rxns or
+% model.ec.genes fields, respectively.
+% 
+% Usage: indexes=getIndexes(model, objects, type, returnLogical)
 
 if nargin<4
     returnLogical=false;
@@ -30,6 +36,10 @@ end
 type=char(type);
 
 indexes=[];
+
+if startsWith(type,'ec') && ~isfield(model,'ec')
+    error('Type %s cannot be used if no model.ec structure is present.',type)
+end
 
 switch type
     case 'rxns'
@@ -62,12 +72,18 @@ switch type
             indexes=tempIndexes;
         end
         return %None of the remaining function needs to run if metcomps
+    case 'ecrxns'
+        searchIn=model.ec.rxns;
+    case 'ecenzymes'
+        searchIn=model.ec.enzymes;
+    case 'ecgenes'
+        searchIn=model.ec.genes;
     otherwise
-        if contains(objects,{'rxns','mets','metnames','metcomps','genes'})
-            error('The second and third parameter provided to run getIndexes are likely switched. Note that the second parameter is the object to find the index for, while the third parameter is the object type (''rxns'', ''mets'', ''metnames'', ''metcomps'' or ''genes'').')
+        if contains(objects,{'rxns','mets','metnames','metcomps','genes','ecgenes','ecenzymes','ecrxns'})
+            error('The second and third parameter provided to run getIndexes are likely switched. Note that the second parameter is the object to find the index for, while the third parameter is the object type (''rxns'', ''mets'', ''metnames'', ''metcomps'', ''genes'', ''ecgenes'', ''ecenzymes'' or ''ecrxns'').')
         else
-            error('Incorrect value of the ''type'' parameter. Allowed values are ''rxns'', ''mets'', ''metnames'', ''metcomps'' or ''genes''.');
-        end
+            error('Incorrect value of the ''type'' parameter. Allowed values are ''rxns'', ''mets'', ''metnames'', ''metcomps'', ''genes'', ''ecgenes'', ''ecenzymes'' or ''ecrxns''.');
+       end
 end
 
 if iscell(objects)

--- a/core/replaceMets.m
+++ b/core/replaceMets.m
@@ -1,21 +1,28 @@
-function model=replaceMets(model,metabolite,replacement,verbose)
+function [model, removedRxns, idxDuplRxns]=replaceMets(model,metabolite,replacement,verbose)
 % replaceMets
 %   Replaces metabolite names and annotation with replacement metabolite
 %   that is already in the model. If this results in duplicate metabolites,
 %   the replacement metabolite will be kept, while the S matrix is updated
-%   to use the replacement metabolite instead.
+%   to use the replacement metabolite instead. At the end, contractModel is
+%   run to remove any duplicate reactions that might have occured.
 %
-%   model               a model structure
-%   metabolite          string with name of metabolite to be replace
-%   replacement         string with name of replacement metabolite
-%   verbose             logical whether to print the ids of reactions that
-%                       involve the replaced metabolite (optional, default
-%                       false)
+% Input:
+%   model           a model structure
+%   metabolite      string with name of metabolite to be replace
+%   replacement     string with name of replacement metabolite
+%   verbose         logical whether to print the ids of reactions that
+%                   involve the replaced metabolite (optional, default
+%                   false)
+% 
+% Output:
+%   model           model structure with selected metabolites replaced
+%   removedRxns     identifiers of duplicate reactions that were removed
+%   idxDuplRxns     index of removedRxns in original model
 %
-%   This function is useful when the model contains both 'oxygen' and 'o2'
-%   as metabolites.
+% Note: This function is useful when the model contains both 'oxygen' and
+% 'o2' as metabolites. 
 %
-% Usage: model=replaceMets(model,metabolite,replacement,verbose)
+% Usage: [model, removedRxns, idxDuplRxns] = replaceMets(model, metabolite, replacement, verbose)
 
 metabolite=char(metabolite);
 replacement=char(replacement);
@@ -116,5 +123,5 @@ if ~isempty(idxDelete)
 end
 
 % This could now have created duplicate reactions. Contract model.
-model=contractModel(model);
+model=contractModel(model,[],repIdx);
 end

--- a/doc/core/contractModel.html
+++ b/doc/core/contractModel.html
@@ -53,7 +53,7 @@
    NOTE: This code might not work for advanced grRules strings
          that involve nested expressions of 'and' and 'or'.
 
- Usage: [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse)</pre></div>
+ Usage: [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse,mets)</pre></div>
 
 <!-- crossreference -->
 <h2><a name="_cross"></a>CROSS-REFERENCE INFORMATION <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
@@ -62,7 +62,7 @@ This function calls:
 <li><a href="dispEM.html" class="code" title="function dispEM(string,throwErrors,toList,trimWarnings)">dispEM</a>	dispEM</li><li><a href="getIndexes.html" class="code" title="function indexes=getIndexes(model, objects, type, returnLogical)">getIndexes</a>	getIndexes</li><li><a href="removeReactions.html" class="code" title="function reducedModel=removeReactions(model,rxnsToRemove,removeUnusedMets,removeUnusedGenes,removeUnusedComps)">removeReactions</a>	removeReactions</li><li><a href="sortModel.html" class="code" title="function model=sortModel(model,sortReversible,sortMetName,sortReactionOrder)">sortModel</a>	sortModel</li><li><a href="standardizeGrRules.html" class="code" title="function [grRules,rxnGeneMat,indexes2check] = standardizeGrRules(model,embedded)">standardizeGrRules</a>	standardizeGrRules</li></ul>
 This function is called by:
 <ul style="list-style-image:url(../matlabicon.gif)">
-<li><a href="mergeCompartments.html" class="code" title="function [model, deletedRxns, duplicateRxns]=mergeCompartments(model,keepUnconstrained,deleteRxnsWithOneMet,distReverse)">mergeCompartments</a>	mergeCompartments</li><li><a href="replaceMets.html" class="code" title="function model=replaceMets(model,metabolite,replacement,verbose)">replaceMets</a>	replaceMets</li><li><a href="simplifyModel.html" class="code" title="function [reducedModel, deletedReactions, deletedMetabolites]=simplifyModel(model,deleteUnconstrained, deleteDuplicates, deleteZeroInterval, deleteInaccessible, deleteMinMax, groupLinear, constrainReversible, reservedRxns, suppressWarnings)">simplifyModel</a>	simplifyModel</li></ul>
+<li><a href="mergeCompartments.html" class="code" title="function [model, deletedRxns, duplicateRxns]=mergeCompartments(model,keepUnconstrained,deleteRxnsWithOneMet,distReverse)">mergeCompartments</a>	mergeCompartments</li><li><a href="replaceMets.html" class="code" title="function [model, removedRxns, idxDuplRxns]=replaceMets(model,metabolite,replacement,verbose)">replaceMets</a>	replaceMets</li><li><a href="simplifyModel.html" class="code" title="function [reducedModel, deletedReactions, deletedMetabolites]=simplifyModel(model,deleteUnconstrained, deleteDuplicates, deleteZeroInterval, deleteInaccessible, deleteMinMax, groupLinear, constrainReversible, reservedRxns, suppressWarnings)">simplifyModel</a>	simplifyModel</li></ul>
 <!-- crossreference -->
 
 <h2><a name="_subfunctions"></a>SUBFUNCTIONS <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
@@ -97,7 +97,7 @@ This function is called by:
 0025 <span class="comment">%   NOTE: This code might not work for advanced grRules strings</span>
 0026 <span class="comment">%         that involve nested expressions of 'and' and 'or'.</span>
 0027 <span class="comment">%</span>
-0028 <span class="comment">% Usage: [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse)</span>
+0028 <span class="comment">% Usage: [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse,mets)</span>
 0029 
 0030 <span class="keyword">if</span> nargin&lt;2
 0031     distReverse=true;

--- a/doc/core/getIndexes.html
+++ b/doc/core/getIndexes.html
@@ -30,7 +30,7 @@
 <div class="fragment"><pre class="comment"> getIndexes
    Retrieves the indexes for a list of reactions or metabolites
 
-   Input:
+ Input:
    model           a model structure
    objects         either a cell array of IDs, a logical vector with the
                    same number of elements as metabolites in the model,
@@ -38,15 +38,21 @@
    type            'rxns', 'mets', or 'genes' depending on what to retrieve
                    'metnames' queries metabolite names, while 'metcomps'
                    allows to provide specific metabolites and their
-                   compartments in the format metaboliteName[comp]
+                   compartments in the format metaboliteName[comp]. If a
+                   model.ec structure exists (GECKO 3), then also
+                   'ecenzymes', 'ecrxns' and 'ecgenes' are allowed
    returnLogical   Sets whether to return a logical array or an array with
                    the indexes (optional, default false)
 
-   Output:
+ Output:
    indexes         can be a logical array or a double array depending on
                    the value of returnLogical
 
-     Usage: indexes=getIndexes(model, objects, type, returnLogical)</pre></div>
+ Note: If 'ecenzymes', 'ecrxns' or 'ecgenes' are used with a GECKO 3
+ model, then the indexes are from the model.ec.enzymes, model.ec.rxns or
+ model.ec.genes fields, respectively.
+ 
+ Usage: indexes=getIndexes(model, objects, type, returnLogical)</pre></div>
 
 <!-- crossreference -->
 <h2><a name="_cross"></a>CROSS-REFERENCE INFORMATION <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
@@ -65,7 +71,7 @@ This function is called by:
 0002 <span class="comment">% getIndexes</span>
 0003 <span class="comment">%   Retrieves the indexes for a list of reactions or metabolites</span>
 0004 <span class="comment">%</span>
-0005 <span class="comment">%   Input:</span>
+0005 <span class="comment">% Input:</span>
 0006 <span class="comment">%   model           a model structure</span>
 0007 <span class="comment">%   objects         either a cell array of IDs, a logical vector with the</span>
 0008 <span class="comment">%                   same number of elements as metabolites in the model,</span>
@@ -73,99 +79,115 @@ This function is called by:
 0010 <span class="comment">%   type            'rxns', 'mets', or 'genes' depending on what to retrieve</span>
 0011 <span class="comment">%                   'metnames' queries metabolite names, while 'metcomps'</span>
 0012 <span class="comment">%                   allows to provide specific metabolites and their</span>
-0013 <span class="comment">%                   compartments in the format metaboliteName[comp]</span>
-0014 <span class="comment">%   returnLogical   Sets whether to return a logical array or an array with</span>
-0015 <span class="comment">%                   the indexes (optional, default false)</span>
-0016 <span class="comment">%</span>
-0017 <span class="comment">%   Output:</span>
-0018 <span class="comment">%   indexes         can be a logical array or a double array depending on</span>
-0019 <span class="comment">%                   the value of returnLogical</span>
-0020 <span class="comment">%</span>
-0021 <span class="comment">%     Usage: indexes=getIndexes(model, objects, type, returnLogical)</span>
-0022 
-0023 <span class="keyword">if</span> nargin&lt;4
-0024     returnLogical=false;
-0025 <span class="keyword">end</span>
-0026 
-0027 <span class="keyword">if</span> ~islogical(objects) &amp;&amp; ~isnumeric(objects)
-0028     objects=<a href="convertCharArray.html" class="code" title="function inputConverted = convertCharArray(funcInput)">convertCharArray</a>(objects);
-0029 <span class="keyword">end</span>
-0030 type=char(type);
-0031 
-0032 indexes=[];
-0033 
-0034 <span class="keyword">switch</span> type
-0035     <span class="keyword">case</span> <span class="string">'rxns'</span>
-0036         searchIn=model.rxns;
-0037     <span class="keyword">case</span> <span class="string">'mets'</span>
-0038         searchIn=model.mets;
-0039     <span class="keyword">case</span> <span class="string">'genes'</span>
-0040         searchIn=model.genes;
-0041     <span class="keyword">case</span> <span class="string">'metnames'</span>
-0042         searchIn=model.metNames;
-0043     <span class="keyword">case</span> <span class="string">'metcomps'</span>
-0044         <span class="comment">% If provided as metaboliteName[comp], then index search is quite</span>
-0045         <span class="comment">% different from general approach, and therefore coded separately.</span>
-0046         mets=regexprep(objects,<span class="string">'(^.+)\[(.+)\]$'</span>,<span class="string">'$1'</span>);
-0047         comps=regexprep(objects,<span class="string">'(^.+)\[(.+)\]$'</span>,<span class="string">'$2'</span>);
-0048         indexes=zeros(1,numel(objects));
-0049         <span class="keyword">for</span> i=1:numel(objects)
-0050             index=find(strcmp(mets(i),model.metNames));
-0051             index=index(strcmp(comps(i),model.comps(model.metComps(index))));
-0052             <span class="keyword">if</span> ~isempty(index)
-0053                 indexes(i)=index;
-0054             <span class="keyword">else</span>
-0055                 error([<span class="string">'Could not find object '</span> objects{i} <span class="string">' in the model'</span>]);
-0056             <span class="keyword">end</span>
-0057         <span class="keyword">end</span>
-0058         indexes=indexes(:);
-0059         <span class="keyword">if</span> returnLogical==true
-0060             tempIndexes=false(numel(model.mets),1);
-0061             tempIndexes(indexes)=true;
-0062             indexes=tempIndexes;
-0063         <span class="keyword">end</span>
-0064         <span class="keyword">return</span> <span class="comment">%None of the remaining function needs to run if metcomps</span>
-0065     <span class="keyword">otherwise</span>
-0066         <span class="keyword">if</span> contains(objects,{<span class="string">'rxns'</span>,<span class="string">'mets'</span>,<span class="string">'metnames'</span>,<span class="string">'metcomps'</span>,<span class="string">'genes'</span>})
-0067             error(<span class="string">'The second and third parameter provided to run getIndexes are likely switched. Note that the second parameter is the object to find the index for, while the third parameter is the object type (''rxns'', ''mets'', ''metnames'', ''metcomps'' or ''genes'').'</span>)
-0068         <span class="keyword">else</span>
-0069             error(<span class="string">'Incorrect value of the ''type'' parameter. Allowed values are ''rxns'', ''mets'', ''metnames'', ''metcomps'' or ''genes''.'</span>);
-0070         <span class="keyword">end</span>
-0071 <span class="keyword">end</span>
-0072 
-0073 <span class="keyword">if</span> iscell(objects)
-0074     <span class="keyword">for</span> i=1:numel(objects)
-0075         index=find(strcmp(objects(i),searchIn));
-0076         <span class="keyword">if</span> strcmpi(type,<span class="string">'metnames'</span>)
-0077             indexes{i}=index;
-0078         <span class="keyword">elseif</span> ~isempty(index)
-0079             indexes(i)=index;
-0080         <span class="keyword">else</span>
-0081             error([<span class="string">'Could not find object '''</span> objects{i} <span class="string">''' in the model'</span>]);
-0082         <span class="keyword">end</span>
-0083     <span class="keyword">end</span>
-0084 <span class="keyword">else</span>
-0085     <span class="comment">%Now it's either a logical (or 0/1) array or an array with indexes. We</span>
-0086     <span class="comment">%want it to be an array with indexes.</span>
-0087     <span class="keyword">if</span> all(objects)
-0088         <span class="comment">%This gets weird if it's all 1</span>
-0089         indexes=objects;
-0090     <span class="keyword">else</span>
-0091         indexes=find(objects);
-0092     <span class="keyword">end</span>
-0093 <span class="keyword">end</span>
-0094 
-0095 <span class="keyword">if</span> returnLogical==true
-0096     tempIndexes=false(numel(searchIn),1);
-0097     tempIndexes(indexes)=true;
-0098     indexes=tempIndexes;
-0099 <span class="keyword">end</span>
-0100 
-0101 indexes=indexes(:);
-0102 <span class="keyword">if</span> iscell(indexes) &amp;&amp; length(indexes)==1
-0103     indexes=indexes{1};
-0104 <span class="keyword">end</span>
-0105 <span class="keyword">end</span></pre></div>
+0013 <span class="comment">%                   compartments in the format metaboliteName[comp]. If a</span>
+0014 <span class="comment">%                   model.ec structure exists (GECKO 3), then also</span>
+0015 <span class="comment">%                   'ecenzymes', 'ecrxns' and 'ecgenes' are allowed</span>
+0016 <span class="comment">%   returnLogical   Sets whether to return a logical array or an array with</span>
+0017 <span class="comment">%                   the indexes (optional, default false)</span>
+0018 <span class="comment">%</span>
+0019 <span class="comment">% Output:</span>
+0020 <span class="comment">%   indexes         can be a logical array or a double array depending on</span>
+0021 <span class="comment">%                   the value of returnLogical</span>
+0022 <span class="comment">%</span>
+0023 <span class="comment">% Note: If 'ecenzymes', 'ecrxns' or 'ecgenes' are used with a GECKO 3</span>
+0024 <span class="comment">% model, then the indexes are from the model.ec.enzymes, model.ec.rxns or</span>
+0025 <span class="comment">% model.ec.genes fields, respectively.</span>
+0026 <span class="comment">%</span>
+0027 <span class="comment">% Usage: indexes=getIndexes(model, objects, type, returnLogical)</span>
+0028 
+0029 <span class="keyword">if</span> nargin&lt;4
+0030     returnLogical=false;
+0031 <span class="keyword">end</span>
+0032 
+0033 <span class="keyword">if</span> ~islogical(objects) &amp;&amp; ~isnumeric(objects)
+0034     objects=<a href="convertCharArray.html" class="code" title="function inputConverted = convertCharArray(funcInput)">convertCharArray</a>(objects);
+0035 <span class="keyword">end</span>
+0036 type=char(type);
+0037 
+0038 indexes=[];
+0039 
+0040 <span class="keyword">if</span> startsWith(type,<span class="string">'ec'</span>) &amp;&amp; ~isfield(model,<span class="string">'ec'</span>)
+0041     error(<span class="string">'Type %s cannot be used if no model.ec structure is present.'</span>,type)
+0042 <span class="keyword">end</span>
+0043 
+0044 <span class="keyword">switch</span> type
+0045     <span class="keyword">case</span> <span class="string">'rxns'</span>
+0046         searchIn=model.rxns;
+0047     <span class="keyword">case</span> <span class="string">'mets'</span>
+0048         searchIn=model.mets;
+0049     <span class="keyword">case</span> <span class="string">'genes'</span>
+0050         searchIn=model.genes;
+0051     <span class="keyword">case</span> <span class="string">'metnames'</span>
+0052         searchIn=model.metNames;
+0053     <span class="keyword">case</span> <span class="string">'metcomps'</span>
+0054         <span class="comment">% If provided as metaboliteName[comp], then index search is quite</span>
+0055         <span class="comment">% different from general approach, and therefore coded separately.</span>
+0056         mets=regexprep(objects,<span class="string">'(^.+)\[(.+)\]$'</span>,<span class="string">'$1'</span>);
+0057         comps=regexprep(objects,<span class="string">'(^.+)\[(.+)\]$'</span>,<span class="string">'$2'</span>);
+0058         indexes=zeros(1,numel(objects));
+0059         <span class="keyword">for</span> i=1:numel(objects)
+0060             index=find(strcmp(mets(i),model.metNames));
+0061             index=index(strcmp(comps(i),model.comps(model.metComps(index))));
+0062             <span class="keyword">if</span> ~isempty(index)
+0063                 indexes(i)=index;
+0064             <span class="keyword">else</span>
+0065                 error([<span class="string">'Could not find object '</span> objects{i} <span class="string">' in the model'</span>]);
+0066             <span class="keyword">end</span>
+0067         <span class="keyword">end</span>
+0068         indexes=indexes(:);
+0069         <span class="keyword">if</span> returnLogical==true
+0070             tempIndexes=false(numel(model.mets),1);
+0071             tempIndexes(indexes)=true;
+0072             indexes=tempIndexes;
+0073         <span class="keyword">end</span>
+0074         <span class="keyword">return</span> <span class="comment">%None of the remaining function needs to run if metcomps</span>
+0075     <span class="keyword">case</span> <span class="string">'ecrxns'</span>
+0076         searchIn=model.ec.rxns;
+0077     <span class="keyword">case</span> <span class="string">'ecenzymes'</span>
+0078         searchIn=model.ec.enzymes;
+0079     <span class="keyword">case</span> <span class="string">'ecgenes'</span>
+0080         searchIn=model.ec.genes;
+0081     <span class="keyword">otherwise</span>
+0082         <span class="keyword">if</span> contains(objects,{<span class="string">'rxns'</span>,<span class="string">'mets'</span>,<span class="string">'metnames'</span>,<span class="string">'metcomps'</span>,<span class="string">'genes'</span>,<span class="string">'ecgenes'</span>,<span class="string">'ecenzymes'</span>,<span class="string">'ecrxns'</span>})
+0083             error(<span class="string">'The second and third parameter provided to run getIndexes are likely switched. Note that the second parameter is the object to find the index for, while the third parameter is the object type (''rxns'', ''mets'', ''metnames'', ''metcomps'', ''genes'', ''ecgenes'', ''ecenzymes'' or ''ecrxns'').'</span>)
+0084         <span class="keyword">else</span>
+0085             error(<span class="string">'Incorrect value of the ''type'' parameter. Allowed values are ''rxns'', ''mets'', ''metnames'', ''metcomps'', ''genes'', ''ecgenes'', ''ecenzymes'' or ''ecrxns''.'</span>);
+0086        <span class="keyword">end</span>
+0087 <span class="keyword">end</span>
+0088 
+0089 <span class="keyword">if</span> iscell(objects)
+0090     <span class="keyword">for</span> i=1:numel(objects)
+0091         index=find(strcmp(objects(i),searchIn));
+0092         <span class="keyword">if</span> strcmpi(type,<span class="string">'metnames'</span>)
+0093             indexes{i}=index;
+0094         <span class="keyword">elseif</span> ~isempty(index)
+0095             indexes(i)=index;
+0096         <span class="keyword">else</span>
+0097             error([<span class="string">'Could not find object '''</span> objects{i} <span class="string">''' in the model'</span>]);
+0098         <span class="keyword">end</span>
+0099     <span class="keyword">end</span>
+0100 <span class="keyword">else</span>
+0101     <span class="comment">%Now it's either a logical (or 0/1) array or an array with indexes. We</span>
+0102     <span class="comment">%want it to be an array with indexes.</span>
+0103     <span class="keyword">if</span> all(objects)
+0104         <span class="comment">%This gets weird if it's all 1</span>
+0105         indexes=objects;
+0106     <span class="keyword">else</span>
+0107         indexes=find(objects);
+0108     <span class="keyword">end</span>
+0109 <span class="keyword">end</span>
+0110 
+0111 <span class="keyword">if</span> returnLogical==true
+0112     tempIndexes=false(numel(searchIn),1);
+0113     tempIndexes(indexes)=true;
+0114     indexes=tempIndexes;
+0115 <span class="keyword">end</span>
+0116 
+0117 indexes=indexes(:);
+0118 <span class="keyword">if</span> iscell(indexes) &amp;&amp; length(indexes)==1
+0119     indexes=indexes{1};
+0120 <span class="keyword">end</span>
+0121 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/core/replaceMets.html
+++ b/doc/core/replaceMets.html
@@ -24,26 +24,33 @@
 <div class="box"><strong>replaceMets</strong></div>
 
 <h2><a name="_synopsis"></a>SYNOPSIS <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
-<div class="box"><strong>function model=replaceMets(model,metabolite,replacement,verbose) </strong></div>
+<div class="box"><strong>function [model, removedRxns, idxDuplRxns]=replaceMets(model,metabolite,replacement,verbose) </strong></div>
 
 <h2><a name="_description"></a>DESCRIPTION <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
 <div class="fragment"><pre class="comment"> replaceMets
    Replaces metabolite names and annotation with replacement metabolite
    that is already in the model. If this results in duplicate metabolites,
    the replacement metabolite will be kept, while the S matrix is updated
-   to use the replacement metabolite instead.
+   to use the replacement metabolite instead. At the end, contractModel is
+   run to remove any duplicate reactions that might have occured.
 
-   model               a model structure
-   metabolite          string with name of metabolite to be replace
-   replacement         string with name of replacement metabolite
-   verbose             logical whether to print the ids of reactions that
-                       involve the replaced metabolite (optional, default
-                       false)
+ Input:
+   model           a model structure
+   metabolite      string with name of metabolite to be replace
+   replacement     string with name of replacement metabolite
+   verbose         logical whether to print the ids of reactions that
+                   involve the replaced metabolite (optional, default
+                   false)
+ 
+ Output:
+   model           model structure with selected metabolites replaced
+   removedRxns     identifiers of duplicate reactions that were removed
+   idxDuplRxns     index of removedRxns in original model
 
-   This function is useful when the model contains both 'oxygen' and 'o2'
-   as metabolites.
+ Note: This function is useful when the model contains both 'oxygen' and
+ 'o2' as metabolites. 
 
- Usage: model=replaceMets(model,metabolite,replacement,verbose)</pre></div>
+ Usage: [model, removedRxns, idxDuplRxns] = replaceMets(model, metabolite, replacement, verbose)</pre></div>
 
 <!-- crossreference -->
 <h2><a name="_cross"></a>CROSS-REFERENCE INFORMATION <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
@@ -58,126 +65,133 @@ This function is called by:
 
 
 <h2><a name="_source"></a>SOURCE CODE <a href="#_top"><img alt="^" border="0" src="../up.png"></a></h2>
-<div class="fragment"><pre>0001 <a name="_sub0" href="#_subfunctions" class="code">function model=replaceMets(model,metabolite,replacement,verbose)</a>
+<div class="fragment"><pre>0001 <a name="_sub0" href="#_subfunctions" class="code">function [model, removedRxns, idxDuplRxns]=replaceMets(model,metabolite,replacement,verbose)</a>
 0002 <span class="comment">% replaceMets</span>
 0003 <span class="comment">%   Replaces metabolite names and annotation with replacement metabolite</span>
 0004 <span class="comment">%   that is already in the model. If this results in duplicate metabolites,</span>
 0005 <span class="comment">%   the replacement metabolite will be kept, while the S matrix is updated</span>
-0006 <span class="comment">%   to use the replacement metabolite instead.</span>
-0007 <span class="comment">%</span>
-0008 <span class="comment">%   model               a model structure</span>
-0009 <span class="comment">%   metabolite          string with name of metabolite to be replace</span>
-0010 <span class="comment">%   replacement         string with name of replacement metabolite</span>
-0011 <span class="comment">%   verbose             logical whether to print the ids of reactions that</span>
-0012 <span class="comment">%                       involve the replaced metabolite (optional, default</span>
-0013 <span class="comment">%                       false)</span>
-0014 <span class="comment">%</span>
-0015 <span class="comment">%   This function is useful when the model contains both 'oxygen' and 'o2'</span>
-0016 <span class="comment">%   as metabolites.</span>
-0017 <span class="comment">%</span>
-0018 <span class="comment">% Usage: model=replaceMets(model,metabolite,replacement,verbose)</span>
-0019 
-0020 metabolite=char(metabolite);
-0021 replacement=char(replacement);
-0022 
-0023 <span class="keyword">if</span> nargin&lt;4
-0024     verbose=false;
-0025 <span class="keyword">end</span>
+0006 <span class="comment">%   to use the replacement metabolite instead. At the end, contractModel is</span>
+0007 <span class="comment">%   run to remove any duplicate reactions that might have occured.</span>
+0008 <span class="comment">%</span>
+0009 <span class="comment">% Input:</span>
+0010 <span class="comment">%   model           a model structure</span>
+0011 <span class="comment">%   metabolite      string with name of metabolite to be replace</span>
+0012 <span class="comment">%   replacement     string with name of replacement metabolite</span>
+0013 <span class="comment">%   verbose         logical whether to print the ids of reactions that</span>
+0014 <span class="comment">%                   involve the replaced metabolite (optional, default</span>
+0015 <span class="comment">%                   false)</span>
+0016 <span class="comment">%</span>
+0017 <span class="comment">% Output:</span>
+0018 <span class="comment">%   model           model structure with selected metabolites replaced</span>
+0019 <span class="comment">%   removedRxns     identifiers of duplicate reactions that were removed</span>
+0020 <span class="comment">%   idxDuplRxns     index of removedRxns in original model</span>
+0021 <span class="comment">%</span>
+0022 <span class="comment">% Note: This function is useful when the model contains both 'oxygen' and</span>
+0023 <span class="comment">% 'o2' as metabolites.</span>
+0024 <span class="comment">%</span>
+0025 <span class="comment">% Usage: [model, removedRxns, idxDuplRxns] = replaceMets(model, metabolite, replacement, verbose)</span>
 0026 
-0027 <span class="comment">% Find occurence of replacement metabolites. Annotation will be taken from</span>
-0028 <span class="comment">% first metabolite found. Metabolite ID from replacement will be used where</span>
-0029 <span class="comment">% possible.</span>
-0030 repIdx = find(strcmp(replacement,model.metNames));
-0031 <span class="keyword">if</span> isempty(repIdx)
-0032     error(<span class="string">'The replacement metabolite name cannot be found in the model.'</span>);
-0033 <span class="keyword">end</span>
-0034 
-0035 <span class="comment">% Change name and information from metabolite to replacement metabolite</span>
-0036 metIdx = find(strcmp(metabolite,model.metNames));
-0037 <span class="keyword">if</span> isempty(metIdx)
-0038     error(<span class="string">'The to-be-replaced metabolite name cannot be found in the model.'</span>);
-0039 <span class="keyword">end</span>
-0040 <span class="keyword">if</span> verbose==true
-0041     fprintf(<span class="string">'\n\nThe following reactions contain the replaced metabolite as reactant:\n'</span>)
-0042     fprintf(strjoin(model.rxns(find(model.S(metIdx,:))),<span class="string">'\n'</span>))
-0043     fprintf(<span class="string">'\n'</span>)
-0044 <span class="keyword">end</span>
-0045 model.metNames(metIdx) = model.metNames(repIdx(1));
-0046 <span class="keyword">if</span> isfield(model,<span class="string">'metFormulas'</span>)
-0047     model.metFormulas(metIdx) = model.metFormulas(repIdx(1));
-0048 <span class="keyword">end</span>
-0049 <span class="keyword">if</span> isfield(model,<span class="string">'metMiriams'</span>)
-0050     model.metMiriams(metIdx) = model.metMiriams(repIdx(1));
+0027 metabolite=char(metabolite);
+0028 replacement=char(replacement);
+0029 
+0030 <span class="keyword">if</span> nargin&lt;4
+0031     verbose=false;
+0032 <span class="keyword">end</span>
+0033 
+0034 <span class="comment">% Find occurence of replacement metabolites. Annotation will be taken from</span>
+0035 <span class="comment">% first metabolite found. Metabolite ID from replacement will be used where</span>
+0036 <span class="comment">% possible.</span>
+0037 repIdx = find(strcmp(replacement,model.metNames));
+0038 <span class="keyword">if</span> isempty(repIdx)
+0039     error(<span class="string">'The replacement metabolite name cannot be found in the model.'</span>);
+0040 <span class="keyword">end</span>
+0041 
+0042 <span class="comment">% Change name and information from metabolite to replacement metabolite</span>
+0043 metIdx = find(strcmp(metabolite,model.metNames));
+0044 <span class="keyword">if</span> isempty(metIdx)
+0045     error(<span class="string">'The to-be-replaced metabolite name cannot be found in the model.'</span>);
+0046 <span class="keyword">end</span>
+0047 <span class="keyword">if</span> verbose==true
+0048     fprintf(<span class="string">'\n\nThe following reactions contain the replaced metabolite as reactant:\n'</span>)
+0049     fprintf(strjoin(model.rxns(find(model.S(metIdx,:))),<span class="string">'\n'</span>))
+0050     fprintf(<span class="string">'\n'</span>)
 0051 <span class="keyword">end</span>
-0052 <span class="keyword">if</span> isfield(model,<span class="string">'metCharges'</span>)
-0053     model.metCharges(metIdx) = model.metCharges(repIdx(1));
-0054 <span class="keyword">end</span>
-0055 <span class="keyword">if</span> isfield(model,<span class="string">'metDeltaG'</span>)
-0056     model.metDeltaG(metIdx) = model.metDeltaG(repIdx(1));
-0057 <span class="keyword">end</span>
-0058 <span class="keyword">if</span> isfield(model,<span class="string">'inchis'</span>)
-0059     model.inchis(metIdx) = model.inchis(repIdx(1));
-0060 <span class="keyword">end</span>
-0061 <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
-0062     model.metSmiles(metIdx) = model.metSmiles(repIdx(1));
-0063 <span class="keyword">end</span>
-0064 <span class="comment">% Run through replacement metabolites and their compartments. If any of the</span>
-0065 <span class="comment">% to-be-replaced metabolites is already present (checked by</span>
-0066 <span class="comment">% metaboliteName[compartment], then the replacement metabolite is kept and</span>
-0067 <span class="comment">% the to-be-replace metabolite ID deleted.</span>
-0068 
-0069 <span class="comment">% Build list of metaboliteName[compartment]</span>
-0070 metCompsN =cellstr(num2str(model.metComps));
-0071 map = containers.Map(cellstr(num2str(transpose(1:length(model.comps)))),model.comps);
-0072 metCompsN = map.values(metCompsN);
-0073 metCompsN = strcat(lower(model.metNames),<span class="string">'['</span>,metCompsN,<span class="string">']'</span>);
-0074 
-0075 idxDelete=[];
-0076 <span class="keyword">for</span> i = 1:length(repIdx)
-0077     metCompsNidx=find(strcmp(metCompsN(repIdx(i)), metCompsN));
-0078     <span class="keyword">if</span> length(metCompsNidx)&gt;1
-0079         <span class="keyword">for</span> j = 2:length(metCompsNidx)
-0080             model.S(metCompsNidx(1),:) = model.S(metCompsNidx(1),:) + model.S(metCompsNidx(j),:);
-0081             idxDelete=[idxDelete; metCompsNidx(j)]; <span class="comment">% Make list of metabolite IDs to delete</span>
-0082         <span class="keyword">end</span>
-0083     <span class="keyword">end</span>
-0084 <span class="keyword">end</span>
-0085 
-0086 <span class="keyword">if</span> ~isempty(idxDelete)
-0087     model.S(idxDelete,:) =[];
-0088     model.mets(idxDelete) = [];
-0089     model.metNames(idxDelete) = [];
-0090     model.metComps(idxDelete) = [];
-0091     model.b(idxDelete) = [];
-0092     <span class="keyword">if</span> isfield(model,<span class="string">'metFormulas'</span>)
-0093         model.metFormulas(idxDelete) = [];
-0094     <span class="keyword">end</span>
-0095     <span class="keyword">if</span> isfield(model,<span class="string">'unconstrained'</span>)
-0096         model.unconstrained(idxDelete) = [];
-0097     <span class="keyword">end</span>
-0098     <span class="keyword">if</span> isfield(model,<span class="string">'metMiriams'</span>)
-0099         model.metMiriams(idxDelete) = [];
-0100     <span class="keyword">end</span>
-0101     <span class="keyword">if</span> isfield(model,<span class="string">'metCharges'</span>)
-0102         model.metCharges(idxDelete) = [];
-0103     <span class="keyword">end</span>
-0104     <span class="keyword">if</span> isfield(model,<span class="string">'metDeltaG'</span>)
-0105         model.metDeltaG(idxDelete) = [];
-0106     <span class="keyword">end</span>
-0107     <span class="keyword">if</span> isfield(model,<span class="string">'inchis'</span>)
-0108         model.inchis(idxDelete) = [];
-0109     <span class="keyword">end</span>
-0110     <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
-0111         model.metSmiles(idxDelete) = [];
-0112     <span class="keyword">end</span>
-0113     <span class="keyword">if</span> isfield(model,<span class="string">'metFrom'</span>)
-0114         model.metFrom(idxDelete) = [];
-0115     <span class="keyword">end</span>
-0116 <span class="keyword">end</span>
-0117 
-0118 <span class="comment">% This could now have created duplicate reactions. Contract model.</span>
-0119 model=<a href="contractModel.html" class="code" title="function [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse,mets)">contractModel</a>(model);
-0120 <span class="keyword">end</span></pre></div>
+0052 model.metNames(metIdx) = model.metNames(repIdx(1));
+0053 <span class="keyword">if</span> isfield(model,<span class="string">'metFormulas'</span>)
+0054     model.metFormulas(metIdx) = model.metFormulas(repIdx(1));
+0055 <span class="keyword">end</span>
+0056 <span class="keyword">if</span> isfield(model,<span class="string">'metMiriams'</span>)
+0057     model.metMiriams(metIdx) = model.metMiriams(repIdx(1));
+0058 <span class="keyword">end</span>
+0059 <span class="keyword">if</span> isfield(model,<span class="string">'metCharges'</span>)
+0060     model.metCharges(metIdx) = model.metCharges(repIdx(1));
+0061 <span class="keyword">end</span>
+0062 <span class="keyword">if</span> isfield(model,<span class="string">'metDeltaG'</span>)
+0063     model.metDeltaG(metIdx) = model.metDeltaG(repIdx(1));
+0064 <span class="keyword">end</span>
+0065 <span class="keyword">if</span> isfield(model,<span class="string">'inchis'</span>)
+0066     model.inchis(metIdx) = model.inchis(repIdx(1));
+0067 <span class="keyword">end</span>
+0068 <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
+0069     model.metSmiles(metIdx) = model.metSmiles(repIdx(1));
+0070 <span class="keyword">end</span>
+0071 <span class="comment">% Run through replacement metabolites and their compartments. If any of the</span>
+0072 <span class="comment">% to-be-replaced metabolites is already present (checked by</span>
+0073 <span class="comment">% metaboliteName[compartment], then the replacement metabolite is kept and</span>
+0074 <span class="comment">% the to-be-replace metabolite ID deleted.</span>
+0075 
+0076 <span class="comment">% Build list of metaboliteName[compartment]</span>
+0077 metCompsN =cellstr(num2str(model.metComps));
+0078 map = containers.Map(cellstr(num2str(transpose(1:length(model.comps)))),model.comps);
+0079 metCompsN = map.values(metCompsN);
+0080 metCompsN = strcat(lower(model.metNames),<span class="string">'['</span>,metCompsN,<span class="string">']'</span>);
+0081 
+0082 idxDelete=[];
+0083 <span class="keyword">for</span> i = 1:length(repIdx)
+0084     metCompsNidx=find(strcmp(metCompsN(repIdx(i)), metCompsN));
+0085     <span class="keyword">if</span> length(metCompsNidx)&gt;1
+0086         <span class="keyword">for</span> j = 2:length(metCompsNidx)
+0087             model.S(metCompsNidx(1),:) = model.S(metCompsNidx(1),:) + model.S(metCompsNidx(j),:);
+0088             idxDelete=[idxDelete; metCompsNidx(j)]; <span class="comment">% Make list of metabolite IDs to delete</span>
+0089         <span class="keyword">end</span>
+0090     <span class="keyword">end</span>
+0091 <span class="keyword">end</span>
+0092 
+0093 <span class="keyword">if</span> ~isempty(idxDelete)
+0094     model.S(idxDelete,:) =[];
+0095     model.mets(idxDelete) = [];
+0096     model.metNames(idxDelete) = [];
+0097     model.metComps(idxDelete) = [];
+0098     model.b(idxDelete) = [];
+0099     <span class="keyword">if</span> isfield(model,<span class="string">'metFormulas'</span>)
+0100         model.metFormulas(idxDelete) = [];
+0101     <span class="keyword">end</span>
+0102     <span class="keyword">if</span> isfield(model,<span class="string">'unconstrained'</span>)
+0103         model.unconstrained(idxDelete) = [];
+0104     <span class="keyword">end</span>
+0105     <span class="keyword">if</span> isfield(model,<span class="string">'metMiriams'</span>)
+0106         model.metMiriams(idxDelete) = [];
+0107     <span class="keyword">end</span>
+0108     <span class="keyword">if</span> isfield(model,<span class="string">'metCharges'</span>)
+0109         model.metCharges(idxDelete) = [];
+0110     <span class="keyword">end</span>
+0111     <span class="keyword">if</span> isfield(model,<span class="string">'metDeltaG'</span>)
+0112         model.metDeltaG(idxDelete) = [];
+0113     <span class="keyword">end</span>
+0114     <span class="keyword">if</span> isfield(model,<span class="string">'inchis'</span>)
+0115         model.inchis(idxDelete) = [];
+0116     <span class="keyword">end</span>
+0117     <span class="keyword">if</span> isfield(model,<span class="string">'metSmiles'</span>)
+0118         model.metSmiles(idxDelete) = [];
+0119     <span class="keyword">end</span>
+0120     <span class="keyword">if</span> isfield(model,<span class="string">'metFrom'</span>)
+0121         model.metFrom(idxDelete) = [];
+0122     <span class="keyword">end</span>
+0123 <span class="keyword">end</span>
+0124 
+0125 <span class="comment">% This could now have created duplicate reactions. Contract model.</span>
+0126 model=<a href="contractModel.html" class="code" title="function [reducedModel, removedRxns, indexedDuplicateRxns]=contractModel(model,distReverse,mets)">contractModel</a>(model,[],repIdx);
+0127 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/external/getBlast.html
+++ b/doc/external/getBlast.html
@@ -177,7 +177,7 @@ This function is called by:
 0099 
 0100 <span class="comment">%Create a database for the new organism and blast each of the refFastaFiles</span>
 0101 <span class="comment">%against it</span>
-0102 [status, ~]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'makeblastdb'</span> binEnd]) <span class="string">'&quot; -in '</span> fastaFile{1} <span class="string">' -out &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -dbtype prot'</span>]);
+0102 [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'makeblastdb'</span> binEnd]) <span class="string">'&quot; -in &quot;'</span> fastaFile{1} <span class="string">'&quot; -out &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -dbtype prot'</span>]);
 0103 <span class="keyword">if</span> developMode
 0104     blastReport.dbHashes.phr{numel(blastReport.dbHashes.phr)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.phr'</span>));
 0105     blastReport.dbHashes.pot{numel(blastReport.dbHashes.pot)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.pot'</span>));
@@ -185,78 +185,74 @@ This function is called by:
 0107     blastReport.dbHashes.pto{numel(blastReport.dbHashes.pto)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.pto'</span>));
 0108 <span class="keyword">end</span>
 0109 <span class="keyword">if</span> status~=0
-0110     EM=[<span class="string">'makeblastdb did not run successfully, error: '</span>, num2str(status)];
-0111     dispEM(EM,true);
-0112 <span class="keyword">end</span>
-0113 
-0114 <span class="keyword">for</span> i=1:numel(refFastaFiles)
-0115     <span class="keyword">if</span> ~hideVerbose
-0116         fprintf([<span class="string">'BLASTing &quot;'</span> modelIDs{i} <span class="string">'&quot; against &quot;'</span> organismID{1} <span class="string">'&quot;..\n'</span>]);
-0117     <span class="keyword">end</span>
-0118     [status, ~]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'blastp'</span> binEnd]) <span class="string">'&quot; -query '</span> refFastaFiles{i} <span class="string">' -out &quot;'</span> outFile <span class="string">'_'</span> num2str(i) <span class="string">'&quot; -db &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -evalue 10e-5 -outfmt &quot;10 qseqid sseqid evalue pident length bitscore ppos&quot; -num_threads &quot;'</span> cores <span class="string">'&quot;'</span>]);
-0119     <span class="keyword">if</span> developMode
-0120         blastReport.blastTxtOutput{numel(blastReport.blastTxtOutput)+1}=importdata([outFile <span class="string">'_'</span> num2str(i)]);
-0121     <span class="keyword">end</span>
-0122     <span class="keyword">if</span> status~=0
-0123         EM=[<span class="string">'blastp did not run successfully, error: '</span>, num2str(status)];
-0124         dispEM(EM,true);
-0125     <span class="keyword">end</span>
-0126 <span class="keyword">end</span>
-0127 delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
-0128 
-0129 <span class="comment">%Then create a database for each of the reference organisms and blast the</span>
-0130 <span class="comment">%new organism against them</span>
-0131 <span class="keyword">for</span> i=1:numel(refFastaFiles)
-0132     <span class="keyword">if</span> ~hideVerbose
-0133         fprintf([<span class="string">'BLASTing &quot;'</span> organismID{1} <span class="string">'&quot; against &quot;'</span> modelIDs{i} <span class="string">'&quot;..\n'</span>]);
-0134     <span class="keyword">end</span>
-0135     [status, ~]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'makeblastdb'</span> binEnd]) <span class="string">'&quot; -in '</span> refFastaFiles{i} <span class="string">' -out &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -dbtype prot'</span>]);
-0136     <span class="keyword">if</span> status~=0
-0137         EM=[<span class="string">'makeblastdb did not run successfully, error: '</span>, num2str(status)];
-0138         dispEM(EM,true);
-0139     <span class="keyword">end</span>
-0140     [status, ~]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'blastp'</span> binEnd]) <span class="string">'&quot; -query '</span> fastaFile{1} <span class="string">' -out &quot;'</span> outFile <span class="string">'_r'</span> num2str(i) <span class="string">'&quot; -db &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -evalue 10e-5 -outfmt &quot;10 qseqid sseqid evalue pident length bitscore ppos&quot; -num_threads &quot;'</span> cores <span class="string">'&quot;'</span>]);
-0141     <span class="keyword">if</span> developMode
-0142         blastReport.dbHashes.phr{numel(blastReport.dbHashes.phr)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.phr'</span>));
-0143         blastReport.dbHashes.pot{numel(blastReport.dbHashes.pot)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.pot'</span>));
-0144         blastReport.dbHashes.psq{numel(blastReport.dbHashes.psq)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.psq'</span>));
-0145         blastReport.dbHashes.pto{numel(blastReport.dbHashes.pto)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.pto'</span>));
-0146         blastReport.blastTxtOutput{numel(blastReport.blastTxtOutput)+1}=importdata([outFile <span class="string">'_r'</span> num2str(i)]);
-0147     <span class="keyword">end</span>    
-0148     <span class="keyword">if</span> status~=0
-0149         EM=[<span class="string">'blastp did not run successfully, error: '</span>, num2str(status)];
-0150         dispEM(EM,true);
-0151     <span class="keyword">end</span>
-0152     delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
-0153 <span class="keyword">end</span>
-0154 
-0155 <span class="comment">%Done with the BLAST, do the parsing of the text files</span>
-0156 <span class="keyword">for</span> i=1:numel(refFastaFiles)*2
-0157     tempStruct=[];
-0158     <span class="keyword">if</span> i&lt;=numel(refFastaFiles)
-0159         tempStruct.fromId=modelIDs{i};
-0160         tempStruct.toId=organismID{1};
-0161         A=readtable([outFile <span class="string">'_'</span> num2str(i)],<span class="string">'Delimiter'</span>,<span class="string">','</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
-0162     <span class="keyword">else</span>
-0163         tempStruct.fromId=organismID{1};
-0164         tempStruct.toId=modelIDs{i-numel(refFastaFiles)};
-0165         A=readtable([outFile <span class="string">'_r'</span> num2str(i-numel(refFastaFiles))],<span class="string">'Delimiter'</span>,<span class="string">','</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
-0166     <span class="keyword">end</span>
-0167     tempStruct.fromGenes=A{:,1};
-0168     tempStruct.toGenes=A{:,2};
-0169     tempStruct.evalue=table2array(A(:,3));
-0170     tempStruct.identity=table2array(A(:,4));
-0171     tempStruct.aligLen=table2array(A(:,5));
-0172     tempStruct.bitscore=table2array(A(:,6));
-0173     tempStruct.ppos=table2array(A(:,7));
-0174     blastStructure=[blastStructure tempStruct];
-0175 <span class="keyword">end</span>
-0176 
-0177 <span class="comment">%Remove the old tempfiles</span>
-0178 delete([outFile <span class="string">'*'</span>]);
-0179 <span class="comment">%Remove the temp fasta files</span>
-0180 delete(files{:})
-0181 <span class="keyword">end</span></pre></div>
+0110     error(<span class="string">'makeblastdb did not run successfully, error:\n%s'</span>,strip(message))
+0111 <span class="keyword">end</span>
+0112 
+0113 <span class="keyword">for</span> i=1:numel(refFastaFiles)
+0114     <span class="keyword">if</span> ~hideVerbose
+0115         fprintf([<span class="string">'BLASTing &quot;'</span> modelIDs{i} <span class="string">'&quot; against &quot;'</span> organismID{1} <span class="string">'&quot;..\n'</span>]);
+0116     <span class="keyword">end</span>
+0117     [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'blastp'</span> binEnd]) <span class="string">'&quot; -query &quot;'</span> refFastaFiles{i} <span class="string">'&quot; -out &quot;'</span> outFile <span class="string">'_'</span> num2str(i) <span class="string">'&quot; -db &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -evalue 10e-5 -outfmt &quot;10 qseqid sseqid evalue pident length bitscore ppos&quot; -num_threads &quot;'</span> cores <span class="string">'&quot;'</span>]);
+0118     <span class="keyword">if</span> developMode
+0119         blastReport.blastTxtOutput{numel(blastReport.blastTxtOutput)+1}=importdata([outFile <span class="string">'_'</span> num2str(i)]);
+0120     <span class="keyword">end</span>
+0121     <span class="keyword">if</span> status~=0
+0122         error(<span class="string">'blastp did not run successfully, error:\n%s'</span>,strip(message))
+0123     <span class="keyword">end</span>
+0124 <span class="keyword">end</span>
+0125 delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
+0126 
+0127 <span class="comment">%Then create a database for each of the reference organisms and blast the</span>
+0128 <span class="comment">%new organism against them</span>
+0129 <span class="keyword">for</span> i=1:numel(refFastaFiles)
+0130     <span class="keyword">if</span> ~hideVerbose
+0131         fprintf([<span class="string">'BLASTing &quot;'</span> organismID{1} <span class="string">'&quot; against &quot;'</span> modelIDs{i} <span class="string">'&quot;..\n'</span>]);
+0132     <span class="keyword">end</span>
+0133     [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'makeblastdb'</span> binEnd]) <span class="string">'&quot; -in &quot;'</span> refFastaFiles{i} <span class="string">'&quot; -out &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -dbtype prot'</span>]);
+0134     <span class="keyword">if</span> status~=0
+0135         error(<span class="string">'makeblastdb did not run successfully, error:\n%s'</span>,strip(message))
+0136     <span class="keyword">end</span>
+0137     [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'blast+'</span>,[<span class="string">'blastp'</span> binEnd]) <span class="string">'&quot; -query &quot;'</span> fastaFile{1} <span class="string">'&quot; -out &quot;'</span> outFile <span class="string">'_r'</span> num2str(i) <span class="string">'&quot; -db &quot;'</span> fullfile(tmpDB, <span class="string">'tmpDB'</span>) <span class="string">'&quot; -evalue 10e-5 -outfmt &quot;10 qseqid sseqid evalue pident length bitscore ppos&quot; -num_threads &quot;'</span> cores <span class="string">'&quot;'</span>]);
+0138     <span class="keyword">if</span> developMode
+0139         blastReport.dbHashes.phr{numel(blastReport.dbHashes.phr)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.phr'</span>));
+0140         blastReport.dbHashes.pot{numel(blastReport.dbHashes.pot)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.pot'</span>));
+0141         blastReport.dbHashes.psq{numel(blastReport.dbHashes.psq)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.psq'</span>));
+0142         blastReport.dbHashes.pto{numel(blastReport.dbHashes.pto)+1}=getMD5Hash(fullfile(tmpDB, <span class="string">'tmpDB.pto'</span>));
+0143         blastReport.blastTxtOutput{numel(blastReport.blastTxtOutput)+1}=importdata([outFile <span class="string">'_r'</span> num2str(i)]);
+0144     <span class="keyword">end</span>    
+0145     <span class="keyword">if</span> status~=0
+0146         error(<span class="string">'blastp did not run successfully, error:\n%s'</span>,strip(message))
+0147     <span class="keyword">end</span>
+0148     delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
+0149 <span class="keyword">end</span>
+0150 
+0151 <span class="comment">%Done with the BLAST, do the parsing of the text files</span>
+0152 <span class="keyword">for</span> i=1:numel(refFastaFiles)*2
+0153     tempStruct=[];
+0154     <span class="keyword">if</span> i&lt;=numel(refFastaFiles)
+0155         tempStruct.fromId=modelIDs{i};
+0156         tempStruct.toId=organismID{1};
+0157         A=readtable([outFile <span class="string">'_'</span> num2str(i)],<span class="string">'Delimiter'</span>,<span class="string">','</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
+0158     <span class="keyword">else</span>
+0159         tempStruct.fromId=organismID{1};
+0160         tempStruct.toId=modelIDs{i-numel(refFastaFiles)};
+0161         A=readtable([outFile <span class="string">'_r'</span> num2str(i-numel(refFastaFiles))],<span class="string">'Delimiter'</span>,<span class="string">','</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
+0162     <span class="keyword">end</span>
+0163     tempStruct.fromGenes=A{:,1};
+0164     tempStruct.toGenes=A{:,2};
+0165     tempStruct.evalue=table2array(A(:,3));
+0166     tempStruct.identity=table2array(A(:,4));
+0167     tempStruct.aligLen=table2array(A(:,5));
+0168     tempStruct.bitscore=table2array(A(:,6));
+0169     tempStruct.ppos=table2array(A(:,7));
+0170     blastStructure=[blastStructure tempStruct];
+0171 <span class="keyword">end</span>
+0172 
+0173 <span class="comment">%Remove the old tempfiles</span>
+0174 delete([outFile <span class="string">'*'</span>]);
+0175 <span class="comment">%Remove the temp fasta files</span>
+0176 delete(files{:})
+0177 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/external/getDiamond.html
+++ b/doc/external/getDiamond.html
@@ -180,75 +180,71 @@ This function is called by:
 0101     diamondReport.dbHashes{numel(diamondReport.dbHashes)+1} = char(regexp(message,<span class="string">'[a-f0-9]{32}'</span>,<span class="string">'match'</span>));
 0102 <span class="keyword">end</span>
 0103 <span class="keyword">if</span> status~=0
-0104     EM=[<span class="string">'DIAMOND makedb did not run successfully, error: '</span>, num2str(status)];
-0105     dispEM(EM,true);
-0106 <span class="keyword">end</span>
-0107 
-0108 <span class="keyword">for</span> i=1:numel(refFastaFiles)
-0109     <span class="keyword">if</span> ~hideVerbose
-0110         fprintf([<span class="string">'Running DIAMOND blastp with &quot;'</span> modelIDs{i} <span class="string">'&quot; against &quot;'</span> organismID{1} <span class="string">'&quot;..\n'</span>]);
-0111     <span class="keyword">end</span>
-0112     [status, ~]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot; blastp --query &quot;'</span> refFastaFiles{i} <span class="string">'&quot; --out &quot;'</span> outFile <span class="string">'_'</span> num2str(i) <span class="string">'&quot; --db &quot;'</span> fullfile(tmpDB) <span class="string">'&quot; --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads '</span> cores ]);
-0113     <span class="keyword">if</span> developMode
-0114         diamondReport.diamondTxtOutput{numel(diamondReport.diamondTxtOutput)+1}=importdata([outFile <span class="string">'_'</span> num2str(i)]);
-0115     <span class="keyword">end</span>
-0116     <span class="keyword">if</span> status~=0
-0117         EM=[<span class="string">'DIAMOND blastp did not run successfully, error: '</span>, num2str(status)];
-0118         dispEM(EM,true);
-0119     <span class="keyword">end</span>
-0120 <span class="keyword">end</span>
-0121 delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
-0122 
-0123 <span class="comment">%Then create a database for each of the reference organisms and blast the</span>
-0124 <span class="comment">%new organism against them</span>
-0125 <span class="keyword">for</span> i=1:numel(refFastaFiles)
-0126     <span class="keyword">if</span> ~hideVerbose
-0127         fprintf([<span class="string">'Running DIAMOND blastp with &quot;'</span> organismID{1} <span class="string">'&quot; against &quot;'</span> modelIDs{i} <span class="string">'&quot;..\n'</span>]);
-0128     <span class="keyword">end</span>
-0129     [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot; makedb --in &quot;'</span> refFastaFiles{i} <span class="string">'&quot; --db &quot;'</span> fullfile(tmpDB) <span class="string">'&quot;'</span>]);
-0130     <span class="keyword">if</span> status~=0
-0131         EM=[<span class="string">'DIAMOND makedb did not run successfully, error: '</span>, num2str(status)];
-0132         dispEM(EM,true);
-0133     <span class="keyword">end</span>
-0134     [status, ~]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot; blastp --query &quot;'</span> fastaFile{1} <span class="string">'&quot; --out &quot;'</span> outFile <span class="string">'_r'</span> num2str(i) <span class="string">'&quot; --db &quot;'</span> fullfile(tmpDB) <span class="string">'&quot; --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads '</span> cores]);
-0135     <span class="keyword">if</span> developMode
-0136         diamondReport.dbHashes{numel(diamondReport.dbHashes)+1} = char(regexp(message,<span class="string">'[a-f0-9]{32}'</span>,<span class="string">'match'</span>));
-0137         diamondReport.diamondTxtOutput{numel(diamondReport.diamondTxtOutput)+1}=importdata([outFile <span class="string">'_r'</span> num2str(i)]);
+0104     error(<span class="string">'DIAMOND makedb did not run successfully, error:\n%s'</span>,strip(message))
+0105 <span class="keyword">end</span>
+0106 
+0107 <span class="keyword">for</span> i=1:numel(refFastaFiles)
+0108     <span class="keyword">if</span> ~hideVerbose
+0109         fprintf([<span class="string">'Running DIAMOND blastp with &quot;'</span> modelIDs{i} <span class="string">'&quot; against &quot;'</span> organismID{1} <span class="string">'&quot;..\n'</span>]);
+0110     <span class="keyword">end</span>
+0111     [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot; blastp --query &quot;'</span> refFastaFiles{i} <span class="string">'&quot; --out &quot;'</span> outFile <span class="string">'_'</span> num2str(i) <span class="string">'&quot; --db &quot;'</span> fullfile(tmpDB) <span class="string">'&quot; --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads '</span> cores ]);
+0112     <span class="keyword">if</span> developMode
+0113         diamondReport.diamondTxtOutput{numel(diamondReport.diamondTxtOutput)+1}=importdata([outFile <span class="string">'_'</span> num2str(i)]);
+0114     <span class="keyword">end</span>
+0115     <span class="keyword">if</span> status~=0
+0116         error(<span class="string">'DIAMOND blastp did not run successfully, error:\n%s'</span>,strip(message))
+0117     <span class="keyword">end</span>
+0118 <span class="keyword">end</span>
+0119 delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
+0120 
+0121 <span class="comment">%Then create a database for each of the reference organisms and blast the</span>
+0122 <span class="comment">%new organism against them</span>
+0123 <span class="keyword">for</span> i=1:numel(refFastaFiles)
+0124     <span class="keyword">if</span> ~hideVerbose
+0125         fprintf([<span class="string">'Running DIAMOND blastp with &quot;'</span> organismID{1} <span class="string">'&quot; against &quot;'</span> modelIDs{i} <span class="string">'&quot;..\n'</span>]);
+0126     <span class="keyword">end</span>
+0127     [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot; makedb --in &quot;'</span> refFastaFiles{i} <span class="string">'&quot; --db &quot;'</span> fullfile(tmpDB) <span class="string">'&quot;'</span>]);
+0128     <span class="keyword">if</span> status~=0
+0129         error(<span class="string">'DIAMOND makedb did not run successfully, error:\n%s'</span>,strip(message))
+0130     <span class="keyword">end</span>
+0131     [status, message]=system([<span class="string">'&quot;'</span> fullfile(ravenPath,<span class="string">'software'</span>,<span class="string">'diamond'</span>,[<span class="string">'diamond'</span> binEnd]) <span class="string">'&quot; blastp --query &quot;'</span> fastaFile{1} <span class="string">'&quot; --out &quot;'</span> outFile <span class="string">'_r'</span> num2str(i) <span class="string">'&quot; --db &quot;'</span> fullfile(tmpDB) <span class="string">'&quot; --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads '</span> cores]);
+0132     <span class="keyword">if</span> developMode
+0133         diamondReport.dbHashes{numel(diamondReport.dbHashes)+1} = char(regexp(message,<span class="string">'[a-f0-9]{32}'</span>,<span class="string">'match'</span>));
+0134         diamondReport.diamondTxtOutput{numel(diamondReport.diamondTxtOutput)+1}=importdata([outFile <span class="string">'_r'</span> num2str(i)]);
+0135     <span class="keyword">end</span>
+0136     <span class="keyword">if</span> status~=0
+0137         error(<span class="string">'DIAMOND blastp did not run successfully, error:\n%s'</span>,strip(message))
 0138     <span class="keyword">end</span>
-0139     <span class="keyword">if</span> status~=0
-0140         EM=[<span class="string">'DIAMOND blastp did not run successfully, error: '</span>, num2str(status)];
-0141         dispEM(EM,true);
-0142     <span class="keyword">end</span>
-0143     delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
-0144 <span class="keyword">end</span>
-0145 
-0146 <span class="comment">%Done with the DIAMOND blastp, do the parsing of the text files</span>
-0147 <span class="keyword">for</span> i=1:numel(refFastaFiles)*2
-0148     tempStruct=[];
-0149     <span class="keyword">if</span> i&lt;=numel(refFastaFiles)
-0150         tempStruct.fromId=modelIDs{i};
-0151         tempStruct.toId=organismID{1};
-0152         A=readtable([outFile <span class="string">'_'</span> num2str(i)],<span class="string">'Delimiter'</span>,<span class="string">'\t'</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
-0153     <span class="keyword">else</span>
-0154         tempStruct.fromId=organismID{1};
-0155         tempStruct.toId=modelIDs{i-numel(refFastaFiles)};
-0156         A=readtable([outFile <span class="string">'_r'</span> num2str(i-numel(refFastaFiles))],<span class="string">'Delimiter'</span>,<span class="string">'\t'</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
-0157     <span class="keyword">end</span>
-0158     tempStruct.fromGenes=A{:,1};
-0159     tempStruct.toGenes=A{:,2};
-0160     tempStruct.evalue=table2array(A(:,3));
-0161     tempStruct.identity=table2array(A(:,4));
-0162     tempStruct.aligLen=table2array(A(:,5));
-0163     tempStruct.bitscore=table2array(A(:,6));
-0164     tempStruct.ppos=table2array(A(:,7));
-0165     blastStructure=[blastStructure tempStruct];
-0166 <span class="keyword">end</span>
-0167 
-0168 <span class="comment">%Remove the old tempfiles</span>
-0169 delete([outFile <span class="string">'*'</span>]);
-0170 <span class="comment">%Remove the temp fasta files</span>
-0171 delete(files{:})
-0172 <span class="keyword">end</span></pre></div>
+0139     delete([tmpDB filesep <span class="string">'tmpDB*'</span>]);
+0140 <span class="keyword">end</span>
+0141 
+0142 <span class="comment">%Done with the DIAMOND blastp, do the parsing of the text files</span>
+0143 <span class="keyword">for</span> i=1:numel(refFastaFiles)*2
+0144     tempStruct=[];
+0145     <span class="keyword">if</span> i&lt;=numel(refFastaFiles)
+0146         tempStruct.fromId=modelIDs{i};
+0147         tempStruct.toId=organismID{1};
+0148         A=readtable([outFile <span class="string">'_'</span> num2str(i)],<span class="string">'Delimiter'</span>,<span class="string">'\t'</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
+0149     <span class="keyword">else</span>
+0150         tempStruct.fromId=organismID{1};
+0151         tempStruct.toId=modelIDs{i-numel(refFastaFiles)};
+0152         A=readtable([outFile <span class="string">'_r'</span> num2str(i-numel(refFastaFiles))],<span class="string">'Delimiter'</span>,<span class="string">'\t'</span>,<span class="string">'Format'</span>,<span class="string">'%s%s%f%f%f%f%f'</span>);
+0153     <span class="keyword">end</span>
+0154     tempStruct.fromGenes=A{:,1};
+0155     tempStruct.toGenes=A{:,2};
+0156     tempStruct.evalue=table2array(A(:,3));
+0157     tempStruct.identity=table2array(A(:,4));
+0158     tempStruct.aligLen=table2array(A(:,5));
+0159     tempStruct.bitscore=table2array(A(:,6));
+0160     tempStruct.ppos=table2array(A(:,7));
+0161     blastStructure=[blastStructure tempStruct];
+0162 <span class="keyword">end</span>
+0163 
+0164 <span class="comment">%Remove the old tempfiles</span>
+0165 delete([outFile <span class="string">'*'</span>]);
+0166 <span class="comment">%Remove the temp fasta files</span>
+0167 delete(files{:})
+0168 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/io/importModel.html
+++ b/doc/io/importModel.html
@@ -743,586 +743,590 @@ This function is called by:
 0637             subsystems{counter,1}=cellstr(<a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'SUBSYSTEM'</span>));
 0638             subsystems{counter,1}(cellfun(<span class="string">'isempty'</span>,subsystems{counter,1})) = [];
 0639             <span class="keyword">if</span> strfind(modelSBML.reaction(i).notes,<span class="string">'Confidence Level'</span>)
-0640                 rxnconfidencescores(counter)=str2num(<a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'Confidence Level'</span>));
-0641             <span class="keyword">end</span>
-0642             rxnreferences{counter,1}=<a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'AUTHORS'</span>);
-0643             rxnnotes{counter,1}=<a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'NOTES'</span>);
-0644         <span class="keyword">end</span>
-0645     <span class="keyword">end</span>
-0646     
-0647     <span class="comment">%Get SBO terms</span>
-0648     <span class="keyword">if</span> isfield(modelSBML.reaction(i),<span class="string">'sboTerm'</span>) &amp;&amp; ~(modelSBML.reaction(i).sboTerm==-1)
-0649         rxnMiriams{counter} = <a href="#_sub5" class="code" title="subfunction miriam = addSBOtoMiriam(miriam,sboTerm)">addSBOtoMiriam</a>(rxnMiriams{counter}, modelSBML.reaction(i).sboTerm);
-0650     <span class="keyword">end</span>
-0651     
-0652     <span class="comment">%Get ec-codes</span>
-0653     eccode=<span class="string">''</span>;
-0654     <span class="keyword">if</span> ~isempty(modelSBML.reaction(i).annotation)
-0655         <span class="keyword">if</span> strfind(modelSBML.reaction(i).annotation,<span class="string">'urn:miriam:ec-code'</span>)
-0656             eccode=<a href="#_sub3" class="code" title="subfunction fieldContent=parseAnnotation(searchString,startString,midString,fieldName)">parseAnnotation</a>(modelSBML.reaction(i).annotation,<span class="string">'urn:miriam:'</span>,<span class="string">':'</span>,<span class="string">'ec-code'</span>);
-0657         <span class="keyword">elseif</span> strfind(modelSBML.reaction(i).annotation,<span class="string">'http://identifiers.org/ec-code'</span>)
-0658             eccode=<a href="#_sub3" class="code" title="subfunction fieldContent=parseAnnotation(searchString,startString,midString,fieldName)">parseAnnotation</a>(modelSBML.reaction(i).annotation,<span class="string">'http://identifiers.org/'</span>,<span class="string">'/'</span>,<span class="string">'ec-code'</span>);
-0659         <span class="keyword">elseif</span> strfind(modelSBML.reaction(i).annotation,<span class="string">'https://identifiers.org/ec-code'</span>)
-0660             eccode=<a href="#_sub3" class="code" title="subfunction fieldContent=parseAnnotation(searchString,startString,midString,fieldName)">parseAnnotation</a>(modelSBML.reaction(i).annotation,<span class="string">'https://identifiers.org/'</span>,<span class="string">'/'</span>,<span class="string">'ec-code'</span>);
-0661         <span class="keyword">end</span>
-0662     <span class="keyword">elseif</span> isfield(modelSBML.reaction(i),<span class="string">'notes'</span>)
-0663         <span class="keyword">if</span> strfind(modelSBML.reaction(i).notes,<span class="string">'EC Number'</span>)
-0664             eccode=[eccode <a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'EC Number'</span>)];
-0665         <span class="keyword">elseif</span> strfind(modelSBML.reaction(i).notes,<span class="string">'PROTEIN_CLASS'</span>)
-0666             eccode=[eccode <a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'PROTEIN_CLASS'</span>)];
-0667         <span class="keyword">end</span>
-0668     <span class="keyword">end</span>
-0669     eccodes{counter}=eccode;
-0670     
-0671     <span class="comment">%Add all reactants</span>
-0672     <span class="keyword">for</span> j=1:numel(modelSBML.reaction(i).reactant)
-0673         <span class="comment">%Get the index of the metabolite in metaboliteIDs. External</span>
-0674         <span class="comment">%metabolites will be removed at a later stage</span>
-0675         metIndex=find(strcmp(modelSBML.reaction(i).reactant(j).species,metaboliteIDs),1);
-0676         <span class="keyword">if</span> isempty(metIndex)
-0677             EM=[<span class="string">'Could not find metabolite '</span> modelSBML.reaction(i).reactant(j).species <span class="string">' in reaction '</span> reactionIDs{counter}];
-0678             dispEM(EM);
-0679         <span class="keyword">end</span>
-0680         S(metIndex,counter)=S(metIndex,counter)+modelSBML.reaction(i).reactant(j).stoichiometry*-1;
-0681     <span class="keyword">end</span>
-0682     
-0683     <span class="comment">%Add all products</span>
-0684     <span class="keyword">for</span> j=1:numel(modelSBML.reaction(i).product)
-0685         <span class="comment">%Get the index of the metabolite in metaboliteIDs.</span>
-0686         metIndex=find(strcmp(modelSBML.reaction(i).product(j).species,metaboliteIDs),1);
-0687         <span class="keyword">if</span> isempty(metIndex)
-0688             EM=[<span class="string">'Could not find metabolite '</span> modelSBML.reaction(i).product(j).species <span class="string">' in reaction '</span> reactionIDs{counter}];
-0689             dispEM(EM);
-0690         <span class="keyword">end</span>
-0691         S(metIndex,counter)=S(metIndex,counter)+modelSBML.reaction(i).product(j).stoichiometry;
-0692     <span class="keyword">end</span>
-0693 <span class="keyword">end</span>
-0694 
-0695 <span class="comment">%if FBC, objective function is separately defined. Multiple objective</span>
-0696 <span class="comment">%functions can be defined, one is set as active</span>
-0697 <span class="keyword">if</span> isfield(modelSBML, <span class="string">'fbc_activeObjective'</span>)
-0698     obj=modelSBML.fbc_activeObjective;
-0699     <span class="keyword">for</span> i=1:numel(modelSBML.fbc_objective)
-0700         <span class="keyword">if</span> strcmp(obj,modelSBML.fbc_objective(i).fbc_id)
-0701             <span class="keyword">if</span> ~isempty(modelSBML.fbc_objective(i).fbc_fluxObjective)
-0702                 rxn=modelSBML.fbc_objective(i).fbc_fluxObjective.fbc_reaction;
-0703                 rxn=regexprep(rxn,<span class="string">'^R_'</span>,<span class="string">''</span>);
-0704                 idx=find(ismember(reactionIDs,rxn));
-0705                 reactionObjective(idx)=modelSBML.fbc_objective(i).fbc_fluxObjective.fbc_coefficient;
-0706             <span class="keyword">end</span>
-0707         <span class="keyword">end</span>
-0708     <span class="keyword">end</span>
-0709 <span class="keyword">end</span>
-0710 
-0711 <span class="comment">%subSystems can be stored as groups instead of in annotations</span>
-0712 <span class="keyword">if</span> isfield(modelSBML,<span class="string">'groups_group'</span>)
-0713     <span class="keyword">for</span> i=1:numel(modelSBML.groups_group)
-0714         groupreactions={modelSBML.groups_group(i).groups_member(:).groups_idRef};
-0715         groupreactions=regexprep(groupreactions,<span class="string">'^R_'</span>,<span class="string">''</span>);
-0716         [~, idx] = ismember(groupreactions, reactionIDs);
-0717         <span class="keyword">if</span> any(idx)
-0718             <span class="keyword">for</span> j=1:numel(idx)
-0719                 <span class="keyword">if</span> isempty(subsystems{idx(j)}) <span class="comment">% First subsystem</span>
-0720                     subsystems{idx(j)} = {modelSBML.groups_group(i).groups_name};
-0721                 <span class="keyword">else</span> <span class="comment">% Consecutive subsystems: concatenate</span>
-0722                     subsystems{idx(j)} = horzcat(subsystems{idx(j)}, modelSBML.groups_group(i).groups_name);
-0723                 <span class="keyword">end</span>
-0724             <span class="keyword">end</span>
-0725         <span class="keyword">end</span>
-0726     <span class="keyword">end</span>
-0727 <span class="keyword">end</span>
-0728 
-0729 <span class="comment">%Shrink the structures if complex-forming reactions had to be skipped</span>
-0730 reactionNames=reactionNames(1:counter);
-0731 reactionIDs=reactionIDs(1:counter);
-0732 subsystems=subsystems(1:counter);
-0733 eccodes=eccodes(1:counter);
-0734 rxnconfidencescores=rxnconfidencescores(1:counter);
-0735 rxnreferences=rxnreferences(1:counter);
-0736 rxnnotes=rxnnotes(1:counter);
-0737 grRules=grRules(1:counter);
-0738 rxnMiriams=rxnMiriams(1:counter);
-0739 reactionReversibility=reactionReversibility(1:counter);
-0740 reactionUB=reactionUB(1:counter);
-0741 reactionLB=reactionLB(1:counter);
-0742 reactionObjective=reactionObjective(1:counter);
-0743 S=S(:,1:counter);
-0744 
-0745 model.name=modelSBML.name;
-0746 model.id=regexprep(modelSBML.id,<span class="string">'^M_'</span>,<span class="string">''</span>); <span class="comment">% COBRA adds M_ prefix</span>
-0747 model.rxns=reactionIDs;
-0748 model.mets=metaboliteIDs;
-0749 model.S=sparse(S);
-0750 model.lb=reactionLB;
-0751 model.ub=reactionUB;
-0752 model.rev=reactionReversibility;
-0753 model.c=reactionObjective;
-0754 model.b=zeros(numel(metaboliteIDs),1);
-0755 model.comps=compartmentIDs;
-0756 model.compNames=compartmentNames;
-0757 model.rxnConfidenceScores=rxnconfidencescores;
-0758 model.rxnReferences=rxnreferences;
-0759 model.rxnNotes=rxnnotes;
-0760 
-0761 <span class="comment">%Load annotation if available. If there are several authors, only the first</span>
-0762 <span class="comment">%author credentials are imported</span>
-0763 <span class="keyword">if</span> isfield(modelSBML,<span class="string">'annotation'</span>)
-0764     endString=<span class="string">'&lt;/'</span>;
-0765     I=strfind(modelSBML.annotation,endString);
-0766     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:Family&gt;'</span>);
-0767     <span class="keyword">if</span> any(J)
-0768         model.annotation.familyName=modelSBML.annotation(J(1)+14:I(find(I&gt;J(1),1))-1);
-0769     <span class="keyword">end</span>
-0770     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:Given&gt;'</span>);
+0640                 confScore = <a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'Confidence Level'</span>);
+0641                 <span class="keyword">if</span> isempty(confScore)
+0642                     confScore = 0;
+0643                 <span class="keyword">end</span>
+0644                 rxnconfidencescores(counter)=str2double(confScore);
+0645             <span class="keyword">end</span>
+0646             rxnreferences{counter,1}=<a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'AUTHORS'</span>);
+0647             rxnnotes{counter,1}=<a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'NOTES'</span>);
+0648         <span class="keyword">end</span>
+0649     <span class="keyword">end</span>
+0650     
+0651     <span class="comment">%Get SBO terms</span>
+0652     <span class="keyword">if</span> isfield(modelSBML.reaction(i),<span class="string">'sboTerm'</span>) &amp;&amp; ~(modelSBML.reaction(i).sboTerm==-1)
+0653         rxnMiriams{counter} = <a href="#_sub5" class="code" title="subfunction miriam = addSBOtoMiriam(miriam,sboTerm)">addSBOtoMiriam</a>(rxnMiriams{counter}, modelSBML.reaction(i).sboTerm);
+0654     <span class="keyword">end</span>
+0655     
+0656     <span class="comment">%Get ec-codes</span>
+0657     eccode=<span class="string">''</span>;
+0658     <span class="keyword">if</span> ~isempty(modelSBML.reaction(i).annotation)
+0659         <span class="keyword">if</span> strfind(modelSBML.reaction(i).annotation,<span class="string">'urn:miriam:ec-code'</span>)
+0660             eccode=<a href="#_sub3" class="code" title="subfunction fieldContent=parseAnnotation(searchString,startString,midString,fieldName)">parseAnnotation</a>(modelSBML.reaction(i).annotation,<span class="string">'urn:miriam:'</span>,<span class="string">':'</span>,<span class="string">'ec-code'</span>);
+0661         <span class="keyword">elseif</span> strfind(modelSBML.reaction(i).annotation,<span class="string">'http://identifiers.org/ec-code'</span>)
+0662             eccode=<a href="#_sub3" class="code" title="subfunction fieldContent=parseAnnotation(searchString,startString,midString,fieldName)">parseAnnotation</a>(modelSBML.reaction(i).annotation,<span class="string">'http://identifiers.org/'</span>,<span class="string">'/'</span>,<span class="string">'ec-code'</span>);
+0663         <span class="keyword">elseif</span> strfind(modelSBML.reaction(i).annotation,<span class="string">'https://identifiers.org/ec-code'</span>)
+0664             eccode=<a href="#_sub3" class="code" title="subfunction fieldContent=parseAnnotation(searchString,startString,midString,fieldName)">parseAnnotation</a>(modelSBML.reaction(i).annotation,<span class="string">'https://identifiers.org/'</span>,<span class="string">'/'</span>,<span class="string">'ec-code'</span>);
+0665         <span class="keyword">end</span>
+0666     <span class="keyword">elseif</span> isfield(modelSBML.reaction(i),<span class="string">'notes'</span>)
+0667         <span class="keyword">if</span> strfind(modelSBML.reaction(i).notes,<span class="string">'EC Number'</span>)
+0668             eccode=[eccode <a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'EC Number'</span>)];
+0669         <span class="keyword">elseif</span> strfind(modelSBML.reaction(i).notes,<span class="string">'PROTEIN_CLASS'</span>)
+0670             eccode=[eccode <a href="#_sub2" class="code" title="subfunction fieldContent=parseNote(searchString,fieldName)">parseNote</a>(modelSBML.reaction(i).notes,<span class="string">'PROTEIN_CLASS'</span>)];
+0671         <span class="keyword">end</span>
+0672     <span class="keyword">end</span>
+0673     eccodes{counter}=eccode;
+0674     
+0675     <span class="comment">%Add all reactants</span>
+0676     <span class="keyword">for</span> j=1:numel(modelSBML.reaction(i).reactant)
+0677         <span class="comment">%Get the index of the metabolite in metaboliteIDs. External</span>
+0678         <span class="comment">%metabolites will be removed at a later stage</span>
+0679         metIndex=find(strcmp(modelSBML.reaction(i).reactant(j).species,metaboliteIDs),1);
+0680         <span class="keyword">if</span> isempty(metIndex)
+0681             EM=[<span class="string">'Could not find metabolite '</span> modelSBML.reaction(i).reactant(j).species <span class="string">' in reaction '</span> reactionIDs{counter}];
+0682             dispEM(EM);
+0683         <span class="keyword">end</span>
+0684         S(metIndex,counter)=S(metIndex,counter)+modelSBML.reaction(i).reactant(j).stoichiometry*-1;
+0685     <span class="keyword">end</span>
+0686     
+0687     <span class="comment">%Add all products</span>
+0688     <span class="keyword">for</span> j=1:numel(modelSBML.reaction(i).product)
+0689         <span class="comment">%Get the index of the metabolite in metaboliteIDs.</span>
+0690         metIndex=find(strcmp(modelSBML.reaction(i).product(j).species,metaboliteIDs),1);
+0691         <span class="keyword">if</span> isempty(metIndex)
+0692             EM=[<span class="string">'Could not find metabolite '</span> modelSBML.reaction(i).product(j).species <span class="string">' in reaction '</span> reactionIDs{counter}];
+0693             dispEM(EM);
+0694         <span class="keyword">end</span>
+0695         S(metIndex,counter)=S(metIndex,counter)+modelSBML.reaction(i).product(j).stoichiometry;
+0696     <span class="keyword">end</span>
+0697 <span class="keyword">end</span>
+0698 
+0699 <span class="comment">%if FBC, objective function is separately defined. Multiple objective</span>
+0700 <span class="comment">%functions can be defined, one is set as active</span>
+0701 <span class="keyword">if</span> isfield(modelSBML, <span class="string">'fbc_activeObjective'</span>)
+0702     obj=modelSBML.fbc_activeObjective;
+0703     <span class="keyword">for</span> i=1:numel(modelSBML.fbc_objective)
+0704         <span class="keyword">if</span> strcmp(obj,modelSBML.fbc_objective(i).fbc_id)
+0705             <span class="keyword">if</span> ~isempty(modelSBML.fbc_objective(i).fbc_fluxObjective)
+0706                 rxn=modelSBML.fbc_objective(i).fbc_fluxObjective.fbc_reaction;
+0707                 rxn=regexprep(rxn,<span class="string">'^R_'</span>,<span class="string">''</span>);
+0708                 idx=find(ismember(reactionIDs,rxn));
+0709                 reactionObjective(idx)=modelSBML.fbc_objective(i).fbc_fluxObjective.fbc_coefficient;
+0710             <span class="keyword">end</span>
+0711         <span class="keyword">end</span>
+0712     <span class="keyword">end</span>
+0713 <span class="keyword">end</span>
+0714 
+0715 <span class="comment">%subSystems can be stored as groups instead of in annotations</span>
+0716 <span class="keyword">if</span> isfield(modelSBML,<span class="string">'groups_group'</span>)
+0717     <span class="keyword">for</span> i=1:numel(modelSBML.groups_group)
+0718         groupreactions={modelSBML.groups_group(i).groups_member(:).groups_idRef};
+0719         groupreactions=regexprep(groupreactions,<span class="string">'^R_'</span>,<span class="string">''</span>);
+0720         [~, idx] = ismember(groupreactions, reactionIDs);
+0721         <span class="keyword">if</span> any(idx)
+0722             <span class="keyword">for</span> j=1:numel(idx)
+0723                 <span class="keyword">if</span> isempty(subsystems{idx(j)}) <span class="comment">% First subsystem</span>
+0724                     subsystems{idx(j)} = {modelSBML.groups_group(i).groups_name};
+0725                 <span class="keyword">else</span> <span class="comment">% Consecutive subsystems: concatenate</span>
+0726                     subsystems{idx(j)} = horzcat(subsystems{idx(j)}, modelSBML.groups_group(i).groups_name);
+0727                 <span class="keyword">end</span>
+0728             <span class="keyword">end</span>
+0729         <span class="keyword">end</span>
+0730     <span class="keyword">end</span>
+0731 <span class="keyword">end</span>
+0732 
+0733 <span class="comment">%Shrink the structures if complex-forming reactions had to be skipped</span>
+0734 reactionNames=reactionNames(1:counter);
+0735 reactionIDs=reactionIDs(1:counter);
+0736 subsystems=subsystems(1:counter);
+0737 eccodes=eccodes(1:counter);
+0738 rxnconfidencescores=rxnconfidencescores(1:counter);
+0739 rxnreferences=rxnreferences(1:counter);
+0740 rxnnotes=rxnnotes(1:counter);
+0741 grRules=grRules(1:counter);
+0742 rxnMiriams=rxnMiriams(1:counter);
+0743 reactionReversibility=reactionReversibility(1:counter);
+0744 reactionUB=reactionUB(1:counter);
+0745 reactionLB=reactionLB(1:counter);
+0746 reactionObjective=reactionObjective(1:counter);
+0747 S=S(:,1:counter);
+0748 
+0749 model.name=modelSBML.name;
+0750 model.id=regexprep(modelSBML.id,<span class="string">'^M_'</span>,<span class="string">''</span>); <span class="comment">% COBRA adds M_ prefix</span>
+0751 model.rxns=reactionIDs;
+0752 model.mets=metaboliteIDs;
+0753 model.S=sparse(S);
+0754 model.lb=reactionLB;
+0755 model.ub=reactionUB;
+0756 model.rev=reactionReversibility;
+0757 model.c=reactionObjective;
+0758 model.b=zeros(numel(metaboliteIDs),1);
+0759 model.comps=compartmentIDs;
+0760 model.compNames=compartmentNames;
+0761 model.rxnConfidenceScores=rxnconfidencescores;
+0762 model.rxnReferences=rxnreferences;
+0763 model.rxnNotes=rxnnotes;
+0764 
+0765 <span class="comment">%Load annotation if available. If there are several authors, only the first</span>
+0766 <span class="comment">%author credentials are imported</span>
+0767 <span class="keyword">if</span> isfield(modelSBML,<span class="string">'annotation'</span>)
+0768     endString=<span class="string">'&lt;/'</span>;
+0769     I=strfind(modelSBML.annotation,endString);
+0770     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:Family&gt;'</span>);
 0771     <span class="keyword">if</span> any(J)
-0772         model.annotation.givenName=modelSBML.annotation(J(1)+13:I(find(I&gt;J(1),1))-1);
+0772         model.annotation.familyName=modelSBML.annotation(J(1)+14:I(find(I&gt;J(1),1))-1);
 0773     <span class="keyword">end</span>
-0774     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:EMAIL&gt;'</span>);
+0774     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:Given&gt;'</span>);
 0775     <span class="keyword">if</span> any(J)
-0776         model.annotation.email=modelSBML.annotation(J(1)+13:I(find(I&gt;J(1),1))-1);
+0776         model.annotation.givenName=modelSBML.annotation(J(1)+13:I(find(I&gt;J(1),1))-1);
 0777     <span class="keyword">end</span>
-0778     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:Orgname&gt;'</span>);
+0778     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:EMAIL&gt;'</span>);
 0779     <span class="keyword">if</span> any(J)
-0780         model.annotation.organization=modelSBML.annotation(J(1)+15:I(find(I&gt;J(1),1))-1);
+0780         model.annotation.email=modelSBML.annotation(J(1)+13:I(find(I&gt;J(1),1))-1);
 0781     <span class="keyword">end</span>
-0782     endString=<span class="string">'&quot;/&gt;'</span>;
-0783     I=strfind(modelSBML.annotation,endString);
-0784     <span class="keyword">if</span> strfind(modelSBML.annotation,<span class="string">'&quot;urn:miriam:'</span>)
-0785         J=strfind(modelSBML.annotation,<span class="string">'&quot;urn:miriam:'</span>);
-0786         <span class="keyword">if</span> any(J)
-0787             model.annotation.taxonomy=modelSBML.annotation(J+12:I(find(I&gt;J,1))-1);
-0788         <span class="keyword">end</span>
-0789     <span class="keyword">else</span>
-0790         J=strfind(modelSBML.annotation,<span class="string">'&quot;http://identifiers.org/'</span>);
-0791         <span class="keyword">if</span> any(J)
-0792             model.annotation.taxonomy=modelSBML.annotation(J+24:I(find(I&gt;J,1))-1);
-0793         <span class="keyword">else</span>
-0794             J=strfind(modelSBML.annotation,<span class="string">'&quot;https://identifiers.org/'</span>);
-0795             <span class="keyword">if</span> any(J)
-0796                 model.annotation.taxonomy=modelSBML.annotation(J+25:I(find(I&gt;J,1))-1);
-0797             <span class="keyword">end</span>
-0798         <span class="keyword">end</span>
-0799     <span class="keyword">end</span>
-0800 <span class="keyword">end</span>
-0801 <span class="keyword">if</span> isfield(modelSBML,<span class="string">'notes'</span>)
-0802     startString=strfind(modelSBML.notes,<span class="string">'xhtml&quot;&gt;'</span>);
-0803     endString=strfind(modelSBML.notes,<span class="string">'&lt;/body&gt;'</span>);
-0804     <span class="keyword">if</span> any(startString) &amp;&amp; any(endString)
-0805         model.annotation.note=modelSBML.notes(startString+7:endString-1);
-0806         model.annotation.note=regexprep(model.annotation.note,<span class="string">'&lt;p&gt;|&lt;/p&gt;'</span>,<span class="string">''</span>);
-0807         model.annotation.note=strtrim(model.annotation.note);
-0808         <span class="keyword">if</span> regexp(model.annotation.note,<span class="string">'This file was generated using the exportModel function in RAVEN Toolbox \d\.\d and OutputSBML in libSBML'</span>)
-0809             model.annotation=rmfield(model.annotation,<span class="string">'note'</span>); <span class="comment">% Default note added when running exportModel</span>
-0810         <span class="keyword">end</span>
-0811     <span class="keyword">end</span>
-0812 <span class="keyword">end</span>
-0813 
-0814 <span class="keyword">if</span> any(~cellfun(@isempty,compartmentOutside))
-0815     model.compOutside=compartmentOutside;
+0782     J=strfind(modelSBML.annotation,<span class="string">'&lt;vCard:Orgname&gt;'</span>);
+0783     <span class="keyword">if</span> any(J)
+0784         model.annotation.organization=modelSBML.annotation(J(1)+15:I(find(I&gt;J(1),1))-1);
+0785     <span class="keyword">end</span>
+0786     endString=<span class="string">'&quot;/&gt;'</span>;
+0787     I=strfind(modelSBML.annotation,endString);
+0788     <span class="keyword">if</span> strfind(modelSBML.annotation,<span class="string">'&quot;urn:miriam:'</span>)
+0789         J=strfind(modelSBML.annotation,<span class="string">'&quot;urn:miriam:'</span>);
+0790         <span class="keyword">if</span> any(J)
+0791             model.annotation.taxonomy=modelSBML.annotation(J+12:I(find(I&gt;J,1))-1);
+0792         <span class="keyword">end</span>
+0793     <span class="keyword">else</span>
+0794         J=strfind(modelSBML.annotation,<span class="string">'&quot;http://identifiers.org/'</span>);
+0795         <span class="keyword">if</span> any(J)
+0796             model.annotation.taxonomy=modelSBML.annotation(J+24:I(find(I&gt;J,1))-1);
+0797         <span class="keyword">else</span>
+0798             J=strfind(modelSBML.annotation,<span class="string">'&quot;https://identifiers.org/'</span>);
+0799             <span class="keyword">if</span> any(J)
+0800                 model.annotation.taxonomy=modelSBML.annotation(J+25:I(find(I&gt;J,1))-1);
+0801             <span class="keyword">end</span>
+0802         <span class="keyword">end</span>
+0803     <span class="keyword">end</span>
+0804 <span class="keyword">end</span>
+0805 <span class="keyword">if</span> isfield(modelSBML,<span class="string">'notes'</span>)
+0806     startString=strfind(modelSBML.notes,<span class="string">'xhtml&quot;&gt;'</span>);
+0807     endString=strfind(modelSBML.notes,<span class="string">'&lt;/body&gt;'</span>);
+0808     <span class="keyword">if</span> any(startString) &amp;&amp; any(endString)
+0809         model.annotation.note=modelSBML.notes(startString+7:endString-1);
+0810         model.annotation.note=regexprep(model.annotation.note,<span class="string">'&lt;p&gt;|&lt;/p&gt;'</span>,<span class="string">''</span>);
+0811         model.annotation.note=strtrim(model.annotation.note);
+0812         <span class="keyword">if</span> regexp(model.annotation.note,<span class="string">'This file was generated using the exportModel function in RAVEN Toolbox \d\.\d and OutputSBML in libSBML'</span>)
+0813             model.annotation=rmfield(model.annotation,<span class="string">'note'</span>); <span class="comment">% Default note added when running exportModel</span>
+0814         <span class="keyword">end</span>
+0815     <span class="keyword">end</span>
 0816 <span class="keyword">end</span>
 0817 
-0818 model.rxnNames=reactionNames;
-0819 model.metNames=metaboliteNames;
-0820 
-0821 <span class="comment">%Match the compartments for metabolites</span>
-0822 [~, J]=ismember(metaboliteCompartments,model.comps);
-0823 model.metComps=J;
+0818 <span class="keyword">if</span> any(~cellfun(@isempty,compartmentOutside))
+0819     model.compOutside=compartmentOutside;
+0820 <span class="keyword">end</span>
+0821 
+0822 model.rxnNames=reactionNames;
+0823 model.metNames=metaboliteNames;
 0824 
-0825 <span class="comment">%If any genes have been loaded (only for the new format)</span>
-0826 <span class="keyword">if</span> ~isempty(geneNames)
-0827     <span class="comment">%In some rare cases geneNames may not necessarily be used in grRules.</span>
-0828     <span class="comment">%That is true for Yeast 7.6. It's therefore important to change gene</span>
-0829     <span class="comment">%systematic names to geneIDs in sophisticated way. Gene systematic</span>
-0830     <span class="comment">%names are not unique, since exactly the same name may be in different</span>
-0831     <span class="comment">%compartments</span>
-0832     <span class="keyword">if</span> all(cellfun(@isempty,strfind(grRules,geneNames{1})))
-0833         geneShortNames=geneNames;
-0834         <span class="comment">%geneShortNames contain compartments as well, so these are removed</span>
-0835         geneShortNames=regexprep(geneShortNames,<span class="string">' \[.+$'</span>,<span class="string">''</span>);
-0836         <span class="comment">%grRules obtained from modifier fields contain geneNames. These are</span>
-0837         <span class="comment">%changed into geneIDs. grRulesFromModifier is a good way to have</span>
-0838         <span class="comment">%geneIDs and rxns association when it's important to resolve</span>
-0839         <span class="comment">%systematic name ambiguities</span>
-0840         grRulesFromModifier=regexprep(regexprep(grRulesFromModifier,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),regexprep(geneNames,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),geneIDs);
-0841         grRules=regexprep(regexprep(grRules,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),regexprep(geneNames,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),geneIDs);
-0842         
-0843         <span class="comment">%Yeast 7.6 contains several metabolites, which were used in gene</span>
-0844         <span class="comment">%associations. For that reason, the list of species ID is created</span>
-0845         <span class="comment">%and we then check whether any of them have kegg.genes annotation</span>
-0846         <span class="comment">%thereby obtaining systematic gene names</span>
-0847         geneShortNames=vertcat(geneShortNames,metaboliteNames);
-0848         geneIDs=vertcat(geneIDs,metaboliteIDs);
-0849         geneSystNames=extractMiriam(vertcat(geneMiriams,metaboliteMiriams),<span class="string">'kegg.genes'</span>);
-0850         geneCompartments=vertcat(geneCompartments,metaboliteCompartments);
-0851         geneMiriams=vertcat(geneMiriams,metaboliteMiriams);
-0852         
-0853         <span class="comment">%Now we retain information for only these entries, which have</span>
-0854         <span class="comment">%kegg.genes annotation</span>
-0855         geneShortNames=geneShortNames(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
-0856         geneIDs=geneIDs(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
-0857         geneSystNames=geneSystNames(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
-0858         geneCompartments=geneCompartments(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
-0859         geneMiriams=geneMiriams(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
-0860         <span class="comment">%Now we reorder geneIDs and geneSystNames by geneSystNames string</span>
-0861         <span class="comment">%length</span>
-0862         geneNames=geneIDs;<span class="comment">%Backuping geneIDs, since we need unsorted order for later</span>
-0863         [~, Indx] = sort(cellfun(<span class="string">'size'</span>, geneSystNames, 2), <span class="string">'descend'</span>);
-0864         geneIDs = geneIDs(Indx);
-0865         geneSystNames = geneSystNames(Indx);
-0866         <span class="keyword">for</span> i=1:numel(geneSystNames)
-0867             <span class="keyword">for</span> j=1:numel(grRules)
-0868                 <span class="keyword">if</span> strfind(grRules{j},geneSystNames{i})
-0869                     <span class="keyword">if</span> ~isempty(grRules{j})
-0870                         <span class="keyword">if</span> sum(ismember(geneSystNames,geneSystNames{i}))==1
-0871                             grRules{j}=regexprep(grRules{j},geneSystNames{i},geneIDs{i});
-0872                         <span class="keyword">elseif</span> sum(ismember(geneSystNames,geneSystNames{i}))&gt;1
-0873                             counter=0;
-0874                             ovrlpIDs=geneIDs(ismember(geneSystNames,geneSystNames{i}));
-0875                             <span class="keyword">for</span> k=1:numel(ovrlpIDs)
-0876                                 <span class="keyword">if</span> strfind(grRulesFromModifier{j},ovrlpIDs{k})
-0877                                     counter=counter+1;
-0878                                     grRules{j}=regexprep(grRules{j},geneSystNames{i},ovrlpIDs{k});
-0879                                 <span class="keyword">end</span>
-0880                                 <span class="keyword">if</span> counter&gt;1
-0881                                     EM=[<span class="string">'Gene association is ambiguous for reaction '</span> modelSBML.reaction(j).id];
-0882                                     dispEM(EM);
+0825 <span class="comment">%Match the compartments for metabolites</span>
+0826 [~, J]=ismember(metaboliteCompartments,model.comps);
+0827 model.metComps=J;
+0828 
+0829 <span class="comment">%If any genes have been loaded (only for the new format)</span>
+0830 <span class="keyword">if</span> ~isempty(geneNames)
+0831     <span class="comment">%In some rare cases geneNames may not necessarily be used in grRules.</span>
+0832     <span class="comment">%That is true for Yeast 7.6. It's therefore important to change gene</span>
+0833     <span class="comment">%systematic names to geneIDs in sophisticated way. Gene systematic</span>
+0834     <span class="comment">%names are not unique, since exactly the same name may be in different</span>
+0835     <span class="comment">%compartments</span>
+0836     <span class="keyword">if</span> all(cellfun(@isempty,strfind(grRules,geneNames{1})))
+0837         geneShortNames=geneNames;
+0838         <span class="comment">%geneShortNames contain compartments as well, so these are removed</span>
+0839         geneShortNames=regexprep(geneShortNames,<span class="string">' \[.+$'</span>,<span class="string">''</span>);
+0840         <span class="comment">%grRules obtained from modifier fields contain geneNames. These are</span>
+0841         <span class="comment">%changed into geneIDs. grRulesFromModifier is a good way to have</span>
+0842         <span class="comment">%geneIDs and rxns association when it's important to resolve</span>
+0843         <span class="comment">%systematic name ambiguities</span>
+0844         grRulesFromModifier=regexprep(regexprep(grRulesFromModifier,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),regexprep(geneNames,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),geneIDs);
+0845         grRules=regexprep(regexprep(grRules,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),regexprep(geneNames,<span class="string">'\[|\]'</span>,<span class="string">'_'</span>),geneIDs);
+0846         
+0847         <span class="comment">%Yeast 7.6 contains several metabolites, which were used in gene</span>
+0848         <span class="comment">%associations. For that reason, the list of species ID is created</span>
+0849         <span class="comment">%and we then check whether any of them have kegg.genes annotation</span>
+0850         <span class="comment">%thereby obtaining systematic gene names</span>
+0851         geneShortNames=vertcat(geneShortNames,metaboliteNames);
+0852         geneIDs=vertcat(geneIDs,metaboliteIDs);
+0853         geneSystNames=extractMiriam(vertcat(geneMiriams,metaboliteMiriams),<span class="string">'kegg.genes'</span>);
+0854         geneCompartments=vertcat(geneCompartments,metaboliteCompartments);
+0855         geneMiriams=vertcat(geneMiriams,metaboliteMiriams);
+0856         
+0857         <span class="comment">%Now we retain information for only these entries, which have</span>
+0858         <span class="comment">%kegg.genes annotation</span>
+0859         geneShortNames=geneShortNames(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
+0860         geneIDs=geneIDs(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
+0861         geneSystNames=geneSystNames(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
+0862         geneCompartments=geneCompartments(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
+0863         geneMiriams=geneMiriams(~cellfun(<span class="string">'isempty'</span>,geneSystNames));
+0864         <span class="comment">%Now we reorder geneIDs and geneSystNames by geneSystNames string</span>
+0865         <span class="comment">%length</span>
+0866         geneNames=geneIDs;<span class="comment">%Backuping geneIDs, since we need unsorted order for later</span>
+0867         [~, Indx] = sort(cellfun(<span class="string">'size'</span>, geneSystNames, 2), <span class="string">'descend'</span>);
+0868         geneIDs = geneIDs(Indx);
+0869         geneSystNames = geneSystNames(Indx);
+0870         <span class="keyword">for</span> i=1:numel(geneSystNames)
+0871             <span class="keyword">for</span> j=1:numel(grRules)
+0872                 <span class="keyword">if</span> strfind(grRules{j},geneSystNames{i})
+0873                     <span class="keyword">if</span> ~isempty(grRules{j})
+0874                         <span class="keyword">if</span> sum(ismember(geneSystNames,geneSystNames{i}))==1
+0875                             grRules{j}=regexprep(grRules{j},geneSystNames{i},geneIDs{i});
+0876                         <span class="keyword">elseif</span> sum(ismember(geneSystNames,geneSystNames{i}))&gt;1
+0877                             counter=0;
+0878                             ovrlpIDs=geneIDs(ismember(geneSystNames,geneSystNames{i}));
+0879                             <span class="keyword">for</span> k=1:numel(ovrlpIDs)
+0880                                 <span class="keyword">if</span> strfind(grRulesFromModifier{j},ovrlpIDs{k})
+0881                                     counter=counter+1;
+0882                                     grRules{j}=regexprep(grRules{j},geneSystNames{i},ovrlpIDs{k});
 0883                                 <span class="keyword">end</span>
-0884                             <span class="keyword">end</span>
-0885                         <span class="keyword">end</span>
-0886                     <span class="keyword">end</span>
-0887                 <span class="keyword">end</span>
-0888             <span class="keyword">end</span>
-0889         <span class="keyword">end</span>
-0890     <span class="keyword">end</span>
-0891     model.genes=geneNames;
-0892     model.grRules=grRules;
-0893     [grRules,rxnGeneMat] = standardizeGrRules(model,true);
-0894     model.grRules = grRules;
-0895     model.rxnGeneMat = rxnGeneMat;
-0896     
-0897     <span class="comment">%Match the compartments for genes</span>
-0898     [~, J]=ismember(geneCompartments,model.comps);
-0899     model.geneComps=J;
-0900 <span class="keyword">else</span>
-0901     <span class="keyword">if</span> ~all(cellfun(@isempty,grRules))
-0902         <span class="comment">%If fbc_geneProduct exists, follow the specified gene order, such</span>
-0903         <span class="comment">%that matching geneShortNames in function below will work</span>
-0904         <span class="keyword">if</span> isfield(modelSBML,<span class="string">'fbc_geneProduct'</span>)
-0905             genes={modelSBML.fbc_geneProduct.fbc_id};
-0906             
-0907             <span class="comment">%Get gene Miriams if they were not retrieved above (this occurs</span>
-0908             <span class="comment">%when genes are stored as fbc_geneProduct instead of species)</span>
-0909             <span class="keyword">if</span> isempty(geneMiriams)
-0910                 geneMiriams = cell(numel(genes),1);
-0911                 <span class="keyword">if</span> isfield(modelSBML.fbc_geneProduct,<span class="string">'sboTerm'</span>) &amp;&amp; numel(unique([modelSBML.fbc_geneProduct.sboTerm])) == 1
-0912                     <span class="comment">%If all the SBO terms are identical, don't add them to geneMiriams</span>
-0913                     modelSBML.fbc_geneProduct = rmfield(modelSBML.fbc_geneProduct,<span class="string">'sboTerm'</span>);
-0914                 <span class="keyword">end</span>
-0915                 <span class="keyword">for</span> i = 1:numel(genes)
-0916                     geneMiriams{i}=<a href="#_sub4" class="code" title="subfunction miriamStruct=parseMiriam(searchString)">parseMiriam</a>(modelSBML.fbc_geneProduct(i).annotation);
-0917                     <span class="keyword">if</span> isfield(modelSBML.fbc_geneProduct(i),<span class="string">'sboTerm'</span>) &amp;&amp; ~(modelSBML.fbc_geneProduct(i).sboTerm==-1)
-0918                         geneMiriams{i} = <a href="#_sub5" class="code" title="subfunction miriam = addSBOtoMiriam(miriam,sboTerm)">addSBOtoMiriam</a>(geneMiriams{i},modelSBML.fbc_geneProduct(i).sboTerm);
-0919                     <span class="keyword">end</span>
-0920                 <span class="keyword">end</span>
-0921             <span class="keyword">end</span>
-0922         <span class="keyword">else</span>
-0923             genes=<a href="#_sub1" class="code" title="subfunction matchGenes=getGeneList(grRules)">getGeneList</a>(grRules);
-0924         <span class="keyword">end</span>
-0925         <span class="keyword">if</span> strcmpi(genes{1}(1:2),<span class="string">'G_'</span>)
-0926             genes=regexprep(genes,<span class="string">'^G_'</span>,<span class="string">''</span>);
-0927             grRules=regexprep(grRules,<span class="string">'^G_'</span>,<span class="string">''</span>);
-0928             grRules=regexprep(grRules,<span class="string">'\(G_'</span>,<span class="string">'('</span>);
-0929             grRules=regexprep(grRules,<span class="string">' G_'</span>,<span class="string">' '</span>);
-0930         <span class="keyword">end</span>
-0931         model.genes=genes;
-0932         model.grRules=grRules;
-0933         [grRules,rxnGeneMat] = standardizeGrRules(model,true);
-0934         model.grRules = grRules;
-0935         model.rxnGeneMat = rxnGeneMat;
-0936     <span class="keyword">end</span>
-0937 <span class="keyword">end</span>
-0938 
-0939 <span class="keyword">if</span> all(cellfun(@isempty,geneShortNames))
-0940     <span class="keyword">if</span> isfield(modelSBML,<span class="string">'fbc_geneProduct'</span>)
-0941         <span class="keyword">for</span> i=1:numel(genes)
-0942             <span class="keyword">if</span> ~isempty(modelSBML.fbc_geneProduct(i).fbc_label)
-0943                 geneShortNames{i,1}=modelSBML.fbc_geneProduct(i).fbc_label;
-0944             <span class="keyword">elseif</span> ~isempty(modelSBML.fbc_geneProduct(i).fbc_name)
-0945                 geneShortNames{i,1}=modelSBML.fbc_geneProduct(i).fbc_name;
-0946             <span class="keyword">else</span>
-0947                 geneShortNames{i,1}=<span class="string">''</span>;
-0948             <span class="keyword">end</span>
-0949         <span class="keyword">end</span>
-0950     <span class="keyword">end</span>
-0951 <span class="keyword">end</span>
-0952 
-0953 <span class="comment">%If any InChIs have been loaded</span>
-0954 <span class="keyword">if</span> any(~cellfun(@isempty,metaboliteInChI))
-0955     model.inchis=metaboliteInChI;
-0956 <span class="keyword">end</span>
-0957 
-0958 <span class="comment">%If any formulas have been loaded</span>
-0959 <span class="keyword">if</span> any(~cellfun(@isempty,metaboliteFormula))
-0960     model.metFormulas=metaboliteFormula;
-0961 <span class="keyword">end</span>
-0962 
-0963 <span class="comment">%If any charges have been loaded</span>
-0964 <span class="keyword">if</span> ~isempty(metaboliteCharges)
-0965     model.metCharges=metaboliteCharges;
-0966 <span class="keyword">end</span>
-0967 
-0968 <span class="comment">%If any gene short names have been loaded</span>
-0969 <span class="keyword">if</span> any(~cellfun(@isempty,geneShortNames))
-0970     model.geneShortNames=geneShortNames;
-0971 <span class="keyword">end</span>
-0972 
-0973 <span class="comment">%If any Miriam strings for compartments have been loaded</span>
-0974 <span class="keyword">if</span> any(~cellfun(@isempty,compartmentMiriams))
-0975     model.compMiriams=compartmentMiriams;
-0976 <span class="keyword">end</span>
-0977 
-0978 <span class="comment">%If any Miriam strings for metabolites have been loaded</span>
-0979 <span class="keyword">if</span> any(~cellfun(@isempty,metaboliteMiriams))
-0980     model.metMiriams=metaboliteMiriams;
-0981 <span class="keyword">end</span>
-0982 
-0983 <span class="comment">%If any subsystems have been loaded</span>
-0984 <span class="keyword">if</span> any(~cellfun(@isempty,subsystems))
-0985     model.subSystems=subsystems;
-0986 <span class="keyword">end</span>
-0987 <span class="keyword">if</span> any(rxnComps)
-0988     <span class="keyword">if</span> all(rxnComps)
-0989         model.rxnComps=rxnComps;
-0990     <span class="keyword">else</span>
-0991         <span class="keyword">if</span> supressWarnings==false
-0992             EM=<span class="string">'The compartments for the following reactions could not be matched. Ignoring reaction compartment information'</span>;
-0993             dispEM(EM,false,model.rxns(rxnComps==0));
-0994         <span class="keyword">end</span>
-0995     <span class="keyword">end</span>
-0996 <span class="keyword">end</span>
-0997 
-0998 <span class="comment">%If any ec-codes have been loaded</span>
-0999 <span class="keyword">if</span> any(~cellfun(@isempty,eccodes))
-1000     model.eccodes=eccodes;
-1001 <span class="keyword">end</span>
-1002 
-1003 <span class="comment">%If any Miriam strings for reactions have been loaded</span>
-1004 <span class="keyword">if</span> any(~cellfun(@isempty,rxnMiriams))
-1005     model.rxnMiriams=rxnMiriams;
-1006 <span class="keyword">end</span>
-1007 
-1008 <span class="comment">%If any Miriam strings for genes have been loaded</span>
-1009 <span class="keyword">if</span> any(~cellfun(@isempty,geneMiriams))
-1010     model.geneMiriams=geneMiriams;
-1011 <span class="keyword">end</span>
-1012 
-1013 model.unconstrained=metaboliteUnconstrained;
-1014 
-1015 <span class="comment">%Convert SBML IDs back into their original strings. Here we are using part</span>
-1016 <span class="comment">%from convertSBMLID, originating from the COBRA Toolbox</span>
-1017 model.rxns=regexprep(model.rxns,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
-1018 model.mets=regexprep(model.mets,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
-1019 model.comps=regexprep(model.comps,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
-1020 model.grRules=regexprep(model.grRules,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
-1021 model.genes=regexprep(model.genes,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
-1022 model.id=regexprep(model.id,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
-1023 
-1024 <span class="comment">%Remove unused fields</span>
-1025 <span class="keyword">if</span> isempty(model.annotation)
-1026     model=rmfield(model,<span class="string">'annotation'</span>);
-1027 <span class="keyword">end</span>
-1028 <span class="keyword">if</span> isempty(model.compOutside)
-1029     model=rmfield(model,<span class="string">'compOutside'</span>);
-1030 <span class="keyword">end</span>
-1031 <span class="keyword">if</span> isempty(model.compMiriams)
-1032     model=rmfield(model,<span class="string">'compMiriams'</span>);
-1033 <span class="keyword">end</span>
-1034 <span class="keyword">if</span> isempty(model.rxnComps)
-1035     model=rmfield(model,<span class="string">'rxnComps'</span>);
-1036 <span class="keyword">end</span>
-1037 <span class="keyword">if</span> isempty(model.grRules)
-1038     model=rmfield(model,<span class="string">'grRules'</span>);
-1039 <span class="keyword">end</span>
-1040 <span class="keyword">if</span> isempty(model.rxnGeneMat)
-1041     model=rmfield(model,<span class="string">'rxnGeneMat'</span>);
-1042 <span class="keyword">end</span>
-1043 <span class="keyword">if</span> isempty(model.subSystems)
-1044     model=rmfield(model,<span class="string">'subSystems'</span>);
-1045 <span class="keyword">else</span>
-1046     model.subSystems(cellfun(@isempty,subsystems))={{<span class="string">''</span>}};
-1047 <span class="keyword">end</span>
-1048 <span class="keyword">if</span> isempty(model.eccodes)
-1049     model=rmfield(model,<span class="string">'eccodes'</span>);
-1050 <span class="keyword">end</span>
-1051 <span class="keyword">if</span> isempty(model.rxnMiriams)
-1052     model=rmfield(model,<span class="string">'rxnMiriams'</span>);
-1053 <span class="keyword">end</span>
-1054 <span class="keyword">if</span> cellfun(@isempty,model.rxnNotes)
-1055     model=rmfield(model,<span class="string">'rxnNotes'</span>);
-1056 <span class="keyword">end</span>
-1057 <span class="keyword">if</span> cellfun(@isempty,model.rxnReferences)
-1058     model=rmfield(model,<span class="string">'rxnReferences'</span>);
-1059 <span class="keyword">end</span>
-1060 <span class="keyword">if</span> isempty(model.rxnConfidenceScores) || all(isnan(model.rxnConfidenceScores))
-1061     model=rmfield(model,<span class="string">'rxnConfidenceScores'</span>);
-1062 <span class="keyword">end</span>
-1063 <span class="keyword">if</span> isempty(model.genes)
-1064     model=rmfield(model,<span class="string">'genes'</span>);
-1065 <span class="keyword">elseif</span> isrow(model.genes)
-1066     model.genes=transpose(model.genes);
-1067 <span class="keyword">end</span>
-1068 <span class="keyword">if</span> isempty(model.geneComps)
-1069     model=rmfield(model,<span class="string">'geneComps'</span>);
-1070 <span class="keyword">end</span>
-1071 <span class="keyword">if</span> isempty(model.geneMiriams)
-1072     model=rmfield(model,<span class="string">'geneMiriams'</span>);
-1073 <span class="keyword">end</span>
-1074 <span class="keyword">if</span> isempty(model.geneShortNames)
-1075     model=rmfield(model,<span class="string">'geneShortNames'</span>);
-1076 <span class="keyword">end</span>
-1077 <span class="keyword">if</span> isempty(model.inchis)
-1078     model=rmfield(model,<span class="string">'inchis'</span>);
-1079 <span class="keyword">end</span>
-1080 <span class="keyword">if</span> isempty(model.metFormulas)
-1081     model=rmfield(model,<span class="string">'metFormulas'</span>);
-1082 <span class="keyword">end</span>
-1083 <span class="keyword">if</span> isempty(model.metMiriams)
-1084     model=rmfield(model,<span class="string">'metMiriams'</span>);
-1085 <span class="keyword">end</span>
-1086 <span class="keyword">if</span> ~any(model.metCharges)
-1087     model=rmfield(model,<span class="string">'metCharges'</span>);
-1088 <span class="keyword">end</span>
-1089 
-1090 <span class="comment">%This just removes the grRules if no genes have been loaded</span>
-1091 <span class="keyword">if</span> ~isfield(model,<span class="string">'genes'</span>) &amp;&amp; isfield(model,<span class="string">'grRules'</span>)
-1092     model=rmfield(model,<span class="string">'grRules'</span>);
-1093 <span class="keyword">end</span>
-1094 
-1095 <span class="comment">%Print warnings about bad structure</span>
-1096 <span class="keyword">if</span> supressWarnings==false
-1097     checkModelStruct(model,false);
-1098 <span class="keyword">end</span>
-1099 
-1100 <span class="keyword">if</span> removeExcMets==true
-1101     model=simplifyModel(model);
+0884                                 <span class="keyword">if</span> counter&gt;1
+0885                                     EM=[<span class="string">'Gene association is ambiguous for reaction '</span> modelSBML.reaction(j).id];
+0886                                     dispEM(EM);
+0887                                 <span class="keyword">end</span>
+0888                             <span class="keyword">end</span>
+0889                         <span class="keyword">end</span>
+0890                     <span class="keyword">end</span>
+0891                 <span class="keyword">end</span>
+0892             <span class="keyword">end</span>
+0893         <span class="keyword">end</span>
+0894     <span class="keyword">end</span>
+0895     model.genes=geneNames;
+0896     model.grRules=grRules;
+0897     [grRules,rxnGeneMat] = standardizeGrRules(model,true);
+0898     model.grRules = grRules;
+0899     model.rxnGeneMat = rxnGeneMat;
+0900     
+0901     <span class="comment">%Match the compartments for genes</span>
+0902     [~, J]=ismember(geneCompartments,model.comps);
+0903     model.geneComps=J;
+0904 <span class="keyword">else</span>
+0905     <span class="keyword">if</span> ~all(cellfun(@isempty,grRules))
+0906         <span class="comment">%If fbc_geneProduct exists, follow the specified gene order, such</span>
+0907         <span class="comment">%that matching geneShortNames in function below will work</span>
+0908         <span class="keyword">if</span> isfield(modelSBML,<span class="string">'fbc_geneProduct'</span>)
+0909             genes={modelSBML.fbc_geneProduct.fbc_id};
+0910             
+0911             <span class="comment">%Get gene Miriams if they were not retrieved above (this occurs</span>
+0912             <span class="comment">%when genes are stored as fbc_geneProduct instead of species)</span>
+0913             <span class="keyword">if</span> isempty(geneMiriams)
+0914                 geneMiriams = cell(numel(genes),1);
+0915                 <span class="keyword">if</span> isfield(modelSBML.fbc_geneProduct,<span class="string">'sboTerm'</span>) &amp;&amp; numel(unique([modelSBML.fbc_geneProduct.sboTerm])) == 1
+0916                     <span class="comment">%If all the SBO terms are identical, don't add them to geneMiriams</span>
+0917                     modelSBML.fbc_geneProduct = rmfield(modelSBML.fbc_geneProduct,<span class="string">'sboTerm'</span>);
+0918                 <span class="keyword">end</span>
+0919                 <span class="keyword">for</span> i = 1:numel(genes)
+0920                     geneMiriams{i}=<a href="#_sub4" class="code" title="subfunction miriamStruct=parseMiriam(searchString)">parseMiriam</a>(modelSBML.fbc_geneProduct(i).annotation);
+0921                     <span class="keyword">if</span> isfield(modelSBML.fbc_geneProduct(i),<span class="string">'sboTerm'</span>) &amp;&amp; ~(modelSBML.fbc_geneProduct(i).sboTerm==-1)
+0922                         geneMiriams{i} = <a href="#_sub5" class="code" title="subfunction miriam = addSBOtoMiriam(miriam,sboTerm)">addSBOtoMiriam</a>(geneMiriams{i},modelSBML.fbc_geneProduct(i).sboTerm);
+0923                     <span class="keyword">end</span>
+0924                 <span class="keyword">end</span>
+0925             <span class="keyword">end</span>
+0926         <span class="keyword">else</span>
+0927             genes=<a href="#_sub1" class="code" title="subfunction matchGenes=getGeneList(grRules)">getGeneList</a>(grRules);
+0928         <span class="keyword">end</span>
+0929         <span class="keyword">if</span> strcmpi(genes{1}(1:2),<span class="string">'G_'</span>)
+0930             genes=regexprep(genes,<span class="string">'^G_'</span>,<span class="string">''</span>);
+0931             grRules=regexprep(grRules,<span class="string">'^G_'</span>,<span class="string">''</span>);
+0932             grRules=regexprep(grRules,<span class="string">'\(G_'</span>,<span class="string">'('</span>);
+0933             grRules=regexprep(grRules,<span class="string">' G_'</span>,<span class="string">' '</span>);
+0934         <span class="keyword">end</span>
+0935         model.genes=genes;
+0936         model.grRules=grRules;
+0937         [grRules,rxnGeneMat] = standardizeGrRules(model,true);
+0938         model.grRules = grRules;
+0939         model.rxnGeneMat = rxnGeneMat;
+0940     <span class="keyword">end</span>
+0941 <span class="keyword">end</span>
+0942 
+0943 <span class="keyword">if</span> all(cellfun(@isempty,geneShortNames))
+0944     <span class="keyword">if</span> isfield(modelSBML,<span class="string">'fbc_geneProduct'</span>)
+0945         <span class="keyword">for</span> i=1:numel(genes)
+0946             <span class="keyword">if</span> ~isempty(modelSBML.fbc_geneProduct(i).fbc_label)
+0947                 geneShortNames{i,1}=modelSBML.fbc_geneProduct(i).fbc_label;
+0948             <span class="keyword">elseif</span> ~isempty(modelSBML.fbc_geneProduct(i).fbc_name)
+0949                 geneShortNames{i,1}=modelSBML.fbc_geneProduct(i).fbc_name;
+0950             <span class="keyword">else</span>
+0951                 geneShortNames{i,1}=<span class="string">''</span>;
+0952             <span class="keyword">end</span>
+0953         <span class="keyword">end</span>
+0954     <span class="keyword">end</span>
+0955 <span class="keyword">end</span>
+0956 
+0957 <span class="comment">%If any InChIs have been loaded</span>
+0958 <span class="keyword">if</span> any(~cellfun(@isempty,metaboliteInChI))
+0959     model.inchis=metaboliteInChI;
+0960 <span class="keyword">end</span>
+0961 
+0962 <span class="comment">%If any formulas have been loaded</span>
+0963 <span class="keyword">if</span> any(~cellfun(@isempty,metaboliteFormula))
+0964     model.metFormulas=metaboliteFormula;
+0965 <span class="keyword">end</span>
+0966 
+0967 <span class="comment">%If any charges have been loaded</span>
+0968 <span class="keyword">if</span> ~isempty(metaboliteCharges)
+0969     model.metCharges=metaboliteCharges;
+0970 <span class="keyword">end</span>
+0971 
+0972 <span class="comment">%If any gene short names have been loaded</span>
+0973 <span class="keyword">if</span> any(~cellfun(@isempty,geneShortNames))
+0974     model.geneShortNames=geneShortNames;
+0975 <span class="keyword">end</span>
+0976 
+0977 <span class="comment">%If any Miriam strings for compartments have been loaded</span>
+0978 <span class="keyword">if</span> any(~cellfun(@isempty,compartmentMiriams))
+0979     model.compMiriams=compartmentMiriams;
+0980 <span class="keyword">end</span>
+0981 
+0982 <span class="comment">%If any Miriam strings for metabolites have been loaded</span>
+0983 <span class="keyword">if</span> any(~cellfun(@isempty,metaboliteMiriams))
+0984     model.metMiriams=metaboliteMiriams;
+0985 <span class="keyword">end</span>
+0986 
+0987 <span class="comment">%If any subsystems have been loaded</span>
+0988 <span class="keyword">if</span> any(~cellfun(@isempty,subsystems))
+0989     model.subSystems=subsystems;
+0990 <span class="keyword">end</span>
+0991 <span class="keyword">if</span> any(rxnComps)
+0992     <span class="keyword">if</span> all(rxnComps)
+0993         model.rxnComps=rxnComps;
+0994     <span class="keyword">else</span>
+0995         <span class="keyword">if</span> supressWarnings==false
+0996             EM=<span class="string">'The compartments for the following reactions could not be matched. Ignoring reaction compartment information'</span>;
+0997             dispEM(EM,false,model.rxns(rxnComps==0));
+0998         <span class="keyword">end</span>
+0999     <span class="keyword">end</span>
+1000 <span class="keyword">end</span>
+1001 
+1002 <span class="comment">%If any ec-codes have been loaded</span>
+1003 <span class="keyword">if</span> any(~cellfun(@isempty,eccodes))
+1004     model.eccodes=eccodes;
+1005 <span class="keyword">end</span>
+1006 
+1007 <span class="comment">%If any Miriam strings for reactions have been loaded</span>
+1008 <span class="keyword">if</span> any(~cellfun(@isempty,rxnMiriams))
+1009     model.rxnMiriams=rxnMiriams;
+1010 <span class="keyword">end</span>
+1011 
+1012 <span class="comment">%If any Miriam strings for genes have been loaded</span>
+1013 <span class="keyword">if</span> any(~cellfun(@isempty,geneMiriams))
+1014     model.geneMiriams=geneMiriams;
+1015 <span class="keyword">end</span>
+1016 
+1017 model.unconstrained=metaboliteUnconstrained;
+1018 
+1019 <span class="comment">%Convert SBML IDs back into their original strings. Here we are using part</span>
+1020 <span class="comment">%from convertSBMLID, originating from the COBRA Toolbox</span>
+1021 model.rxns=regexprep(model.rxns,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
+1022 model.mets=regexprep(model.mets,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
+1023 model.comps=regexprep(model.comps,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
+1024 model.grRules=regexprep(model.grRules,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
+1025 model.genes=regexprep(model.genes,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
+1026 model.id=regexprep(model.id,<span class="string">'__([0-9]+)__'</span>,<span class="string">'${char(str2num($1))}'</span>);
+1027 
+1028 <span class="comment">%Remove unused fields</span>
+1029 <span class="keyword">if</span> isempty(model.annotation)
+1030     model=rmfield(model,<span class="string">'annotation'</span>);
+1031 <span class="keyword">end</span>
+1032 <span class="keyword">if</span> isempty(model.compOutside)
+1033     model=rmfield(model,<span class="string">'compOutside'</span>);
+1034 <span class="keyword">end</span>
+1035 <span class="keyword">if</span> isempty(model.compMiriams)
+1036     model=rmfield(model,<span class="string">'compMiriams'</span>);
+1037 <span class="keyword">end</span>
+1038 <span class="keyword">if</span> isempty(model.rxnComps)
+1039     model=rmfield(model,<span class="string">'rxnComps'</span>);
+1040 <span class="keyword">end</span>
+1041 <span class="keyword">if</span> isempty(model.grRules)
+1042     model=rmfield(model,<span class="string">'grRules'</span>);
+1043 <span class="keyword">end</span>
+1044 <span class="keyword">if</span> isempty(model.rxnGeneMat)
+1045     model=rmfield(model,<span class="string">'rxnGeneMat'</span>);
+1046 <span class="keyword">end</span>
+1047 <span class="keyword">if</span> isempty(model.subSystems)
+1048     model=rmfield(model,<span class="string">'subSystems'</span>);
+1049 <span class="keyword">else</span>
+1050     model.subSystems(cellfun(@isempty,subsystems))={{<span class="string">''</span>}};
+1051 <span class="keyword">end</span>
+1052 <span class="keyword">if</span> isempty(model.eccodes)
+1053     model=rmfield(model,<span class="string">'eccodes'</span>);
+1054 <span class="keyword">end</span>
+1055 <span class="keyword">if</span> isempty(model.rxnMiriams)
+1056     model=rmfield(model,<span class="string">'rxnMiriams'</span>);
+1057 <span class="keyword">end</span>
+1058 <span class="keyword">if</span> cellfun(@isempty,model.rxnNotes)
+1059     model=rmfield(model,<span class="string">'rxnNotes'</span>);
+1060 <span class="keyword">end</span>
+1061 <span class="keyword">if</span> cellfun(@isempty,model.rxnReferences)
+1062     model=rmfield(model,<span class="string">'rxnReferences'</span>);
+1063 <span class="keyword">end</span>
+1064 <span class="keyword">if</span> isempty(model.rxnConfidenceScores) || all(isnan(model.rxnConfidenceScores))
+1065     model=rmfield(model,<span class="string">'rxnConfidenceScores'</span>);
+1066 <span class="keyword">end</span>
+1067 <span class="keyword">if</span> isempty(model.genes)
+1068     model=rmfield(model,<span class="string">'genes'</span>);
+1069 <span class="keyword">elseif</span> isrow(model.genes)
+1070     model.genes=transpose(model.genes);
+1071 <span class="keyword">end</span>
+1072 <span class="keyword">if</span> isempty(model.geneComps)
+1073     model=rmfield(model,<span class="string">'geneComps'</span>);
+1074 <span class="keyword">end</span>
+1075 <span class="keyword">if</span> isempty(model.geneMiriams)
+1076     model=rmfield(model,<span class="string">'geneMiriams'</span>);
+1077 <span class="keyword">end</span>
+1078 <span class="keyword">if</span> isempty(model.geneShortNames)
+1079     model=rmfield(model,<span class="string">'geneShortNames'</span>);
+1080 <span class="keyword">end</span>
+1081 <span class="keyword">if</span> isempty(model.inchis)
+1082     model=rmfield(model,<span class="string">'inchis'</span>);
+1083 <span class="keyword">end</span>
+1084 <span class="keyword">if</span> isempty(model.metFormulas)
+1085     model=rmfield(model,<span class="string">'metFormulas'</span>);
+1086 <span class="keyword">end</span>
+1087 <span class="keyword">if</span> isempty(model.metMiriams)
+1088     model=rmfield(model,<span class="string">'metMiriams'</span>);
+1089 <span class="keyword">end</span>
+1090 <span class="keyword">if</span> ~any(model.metCharges)
+1091     model=rmfield(model,<span class="string">'metCharges'</span>);
+1092 <span class="keyword">end</span>
+1093 
+1094 <span class="comment">%This just removes the grRules if no genes have been loaded</span>
+1095 <span class="keyword">if</span> ~isfield(model,<span class="string">'genes'</span>) &amp;&amp; isfield(model,<span class="string">'grRules'</span>)
+1096     model=rmfield(model,<span class="string">'grRules'</span>);
+1097 <span class="keyword">end</span>
+1098 
+1099 <span class="comment">%Print warnings about bad structure</span>
+1100 <span class="keyword">if</span> supressWarnings==false
+1101     checkModelStruct(model,false);
 1102 <span class="keyword">end</span>
-1103 <span class="keyword">end</span>
-1104 
-1105 <a name="_sub1" href="#_subfunctions" class="code">function matchGenes=getGeneList(grRules)</a>
-1106 <span class="comment">%Constructs the list of unique genes from grRules</span>
-1107 
-1108 <span class="comment">%Assumes that everything that isn't a paranthesis, &quot; AND &quot; or &quot; or &quot; is a</span>
-1109 <span class="comment">%gene name</span>
-1110 genes=strrep(grRules,<span class="string">'('</span>,<span class="string">''</span>);
-1111 genes=strrep(genes,<span class="string">')'</span>,<span class="string">''</span>);
-1112 genes=strrep(genes,<span class="string">' or '</span>,<span class="string">' '</span>);
-1113 genes=strrep(genes,<span class="string">' and '</span>,<span class="string">' '</span>);
-1114 genes=strrep(genes,<span class="string">' OR '</span>,<span class="string">' '</span>);
-1115 genes=strrep(genes,<span class="string">' AND '</span>,<span class="string">' '</span>);
-1116 genes=regexp(genes,<span class="string">' '</span>,<span class="string">'split'</span>);
-1117 
-1118 allNames={};
-1119 <span class="keyword">for</span> i=1:numel(genes)
-1120     allNames=[allNames genes{i}];
-1121 <span class="keyword">end</span>
-1122 matchGenes=unique(allNames)';
-1123 
-1124 <span class="comment">%Remove the empty element if present</span>
-1125 <span class="keyword">if</span> isempty(matchGenes{1})
-1126     matchGenes(1)=[];
-1127 <span class="keyword">end</span>
-1128 <span class="keyword">end</span>
-1129 
-1130 <a name="_sub2" href="#_subfunctions" class="code">function fieldContent=parseNote(searchString,fieldName)</a>
-1131 <span class="comment">%The function obtains the particular information from 'notes' field, using</span>
-1132 <span class="comment">%fieldName as the dummy string</span>
+1103 
+1104 <span class="keyword">if</span> removeExcMets==true
+1105     model=simplifyModel(model);
+1106 <span class="keyword">end</span>
+1107 <span class="keyword">end</span>
+1108 
+1109 <a name="_sub1" href="#_subfunctions" class="code">function matchGenes=getGeneList(grRules)</a>
+1110 <span class="comment">%Constructs the list of unique genes from grRules</span>
+1111 
+1112 <span class="comment">%Assumes that everything that isn't a paranthesis, &quot; AND &quot; or &quot; or &quot; is a</span>
+1113 <span class="comment">%gene name</span>
+1114 genes=strrep(grRules,<span class="string">'('</span>,<span class="string">''</span>);
+1115 genes=strrep(genes,<span class="string">')'</span>,<span class="string">''</span>);
+1116 genes=strrep(genes,<span class="string">' or '</span>,<span class="string">' '</span>);
+1117 genes=strrep(genes,<span class="string">' and '</span>,<span class="string">' '</span>);
+1118 genes=strrep(genes,<span class="string">' OR '</span>,<span class="string">' '</span>);
+1119 genes=strrep(genes,<span class="string">' AND '</span>,<span class="string">' '</span>);
+1120 genes=regexp(genes,<span class="string">' '</span>,<span class="string">'split'</span>);
+1121 
+1122 allNames={};
+1123 <span class="keyword">for</span> i=1:numel(genes)
+1124     allNames=[allNames genes{i}];
+1125 <span class="keyword">end</span>
+1126 matchGenes=unique(allNames)';
+1127 
+1128 <span class="comment">%Remove the empty element if present</span>
+1129 <span class="keyword">if</span> isempty(matchGenes{1})
+1130     matchGenes(1)=[];
+1131 <span class="keyword">end</span>
+1132 <span class="keyword">end</span>
 1133 
-1134 fieldContent=<span class="string">''</span>;
-1135 
-1136 <span class="keyword">if</span> strfind(searchString,fieldName)
-1137     [~,targetString] = regexp(searchString,[<span class="string">'&lt;p&gt;'</span> fieldName <span class="string">'.*?&lt;/p&gt;'</span>],<span class="string">'tokens'</span>,<span class="string">'match'</span>);
-1138     targetString=regexprep(targetString,<span class="string">'&lt;p&gt;|&lt;/p&gt;'</span>,<span class="string">''</span>);
-1139     targetString=regexprep(targetString,[fieldName, <span class="string">':'</span>],<span class="string">''</span>);
-1140     <span class="keyword">for</span> i=1:numel(targetString)
-1141         fieldContent=[fieldContent <span class="string">';'</span> strtrim(targetString{1,i})];
-1142     <span class="keyword">end</span>
-1143     fieldContent=regexprep(fieldContent,<span class="string">'^;|;$'</span>,<span class="string">''</span>);
-1144 <span class="keyword">else</span>
-1145     fieldContent=<span class="string">''</span>;
-1146 <span class="keyword">end</span>
-1147 <span class="keyword">end</span>
-1148 
-1149 <a name="_sub3" href="#_subfunctions" class="code">function fieldContent=parseAnnotation(searchString,startString,midString,fieldName)</a>
-1150 
-1151 fieldContent=<span class="string">''</span>;
+1134 <a name="_sub2" href="#_subfunctions" class="code">function fieldContent=parseNote(searchString,fieldName)</a>
+1135 <span class="comment">%The function obtains the particular information from 'notes' field, using</span>
+1136 <span class="comment">%fieldName as the dummy string</span>
+1137 
+1138 fieldContent=<span class="string">''</span>;
+1139 
+1140 <span class="keyword">if</span> strfind(searchString,fieldName)
+1141     [~,targetString] = regexp(searchString,[<span class="string">'&lt;p&gt;'</span> fieldName <span class="string">'.*?&lt;/p&gt;'</span>],<span class="string">'tokens'</span>,<span class="string">'match'</span>);
+1142     targetString=regexprep(targetString,<span class="string">'&lt;p&gt;|&lt;/p&gt;'</span>,<span class="string">''</span>);
+1143     targetString=regexprep(targetString,[fieldName, <span class="string">':'</span>],<span class="string">''</span>);
+1144     <span class="keyword">for</span> i=1:numel(targetString)
+1145         fieldContent=[fieldContent <span class="string">';'</span> strtrim(targetString{1,i})];
+1146     <span class="keyword">end</span>
+1147     fieldContent=regexprep(fieldContent,<span class="string">'^;|;$'</span>,<span class="string">''</span>);
+1148 <span class="keyword">else</span>
+1149     fieldContent=<span class="string">''</span>;
+1150 <span class="keyword">end</span>
+1151 <span class="keyword">end</span>
 1152 
-1153 <span class="comment">%Removing whitespace characters from the ending strings, which may occur in</span>
-1154 <span class="comment">%several cases</span>
-1155 searchString=regexprep(searchString,<span class="string">'&quot; /&gt;'</span>,<span class="string">'&quot;/&gt;'</span>);
-1156 [~,targetString] = regexp(searchString,[<span class="string">'&lt;rdf:li rdf:resource=&quot;'</span> startString fieldName midString <span class="string">'.*?&quot;/&gt;'</span>],<span class="string">'tokens'</span>,<span class="string">'match'</span>);
-1157 targetString=regexprep(targetString,<span class="string">'&lt;rdf:li rdf:resource=&quot;|&quot;/&gt;'</span>,<span class="string">''</span>);
-1158 targetString=regexprep(targetString,startString,<span class="string">''</span>);
-1159 targetString=regexprep(targetString,[fieldName midString],<span class="string">''</span>);
-1160 
-1161 <span class="keyword">for</span> i=1:numel(targetString)
-1162     fieldContent=[fieldContent <span class="string">';'</span> strtrim(targetString{1,i})];
-1163 <span class="keyword">end</span>
+1153 <a name="_sub3" href="#_subfunctions" class="code">function fieldContent=parseAnnotation(searchString,startString,midString,fieldName)</a>
+1154 
+1155 fieldContent=<span class="string">''</span>;
+1156 
+1157 <span class="comment">%Removing whitespace characters from the ending strings, which may occur in</span>
+1158 <span class="comment">%several cases</span>
+1159 searchString=regexprep(searchString,<span class="string">'&quot; /&gt;'</span>,<span class="string">'&quot;/&gt;'</span>);
+1160 [~,targetString] = regexp(searchString,[<span class="string">'&lt;rdf:li rdf:resource=&quot;'</span> startString fieldName midString <span class="string">'.*?&quot;/&gt;'</span>],<span class="string">'tokens'</span>,<span class="string">'match'</span>);
+1161 targetString=regexprep(targetString,<span class="string">'&lt;rdf:li rdf:resource=&quot;|&quot;/&gt;'</span>,<span class="string">''</span>);
+1162 targetString=regexprep(targetString,startString,<span class="string">''</span>);
+1163 targetString=regexprep(targetString,[fieldName midString],<span class="string">''</span>);
 1164 
-1165 fieldContent=regexprep(fieldContent,<span class="string">'^;|;$'</span>,<span class="string">''</span>);
-1166 <span class="keyword">end</span>
-1167 
-1168 <a name="_sub4" href="#_subfunctions" class="code">function miriamStruct=parseMiriam(searchString)</a>
-1169 <span class="comment">%Generates miriam structure from annotation field</span>
-1170 
-1171 <span class="comment">%Finding whether miriams are written in the old or the new way</span>
-1172 <span class="keyword">if</span> strfind(searchString,<span class="string">'urn:miriam:'</span>)
-1173     startString=<span class="string">'urn:miriam:'</span>;
-1174     midString=<span class="string">':'</span>;
-1175 <span class="keyword">elseif</span> strfind(searchString,<span class="string">'http://identifiers.org/'</span>)
-1176     startString=<span class="string">'http://identifiers.org/'</span>;
-1177     midString=<span class="string">'/'</span>;
-1178 <span class="keyword">elseif</span> strfind(searchString,<span class="string">'https://identifiers.org/'</span>)
-1179     startString=<span class="string">'https://identifiers.org/'</span>;
-1180     midString=<span class="string">'/'</span>;
-1181 <span class="keyword">else</span>
-1182     miriamStruct=[];
-1183     <span class="keyword">return</span>;
-1184 <span class="keyword">end</span>
-1185 
-1186 miriamStruct=[];
-1187 
-1188 searchString=regexprep(searchString,<span class="string">'&quot; /&gt;'</span>,<span class="string">'&quot;/&gt;'</span>);
-1189 [~,targetString] = regexp(searchString,<span class="string">'&lt;rdf:li rdf:resource=&quot;.*?&quot;/&gt;'</span>,<span class="string">'tokens'</span>,<span class="string">'match'</span>);
-1190 targetString=regexprep(targetString,<span class="string">'&lt;rdf:li rdf:resource=&quot;|&quot;/&gt;'</span>,<span class="string">''</span>);
-1191 targetString=regexprep(targetString,startString,<span class="string">''</span>);
-1192 targetString=regexprep(targetString,midString,<span class="string">'/'</span>,<span class="string">'once'</span>);
-1193 
-1194 counter=0;
-1195 <span class="keyword">for</span> i=1:numel(targetString)
-1196     <span class="keyword">if</span> isempty(regexp(targetString{1,i},<span class="string">'inchi|ec-code'</span>, <span class="string">'once'</span>))
-1197         counter=counter+1;
-1198         miriamStruct.name{counter,1} = regexprep(targetString{1,i},<span class="string">'/.+'</span>,<span class="string">''</span>,<span class="string">'once'</span>);
-1199         miriamStruct.value{counter,1} = regexprep(targetString{1,i},[miriamStruct.name{counter,1} <span class="string">'/'</span>],<span class="string">''</span>,<span class="string">'once'</span>);
-1200         miriamStruct.name{counter,1} = regexprep(miriamStruct.name{counter,1},<span class="string">'^obo\.'</span>,<span class="string">''</span>);
-1201     <span class="keyword">end</span>
-1202 <span class="keyword">end</span>
-1203 <span class="keyword">end</span>
-1204 
-1205 <a name="_sub5" href="#_subfunctions" class="code">function miriam = addSBOtoMiriam(miriam,sboTerm)</a>
-1206 <span class="comment">%Appends SBO term to miriam structure</span>
-1207 
-1208 sboTerm = {[<span class="string">'SBO:'</span> sprintf(<span class="string">'%07u'</span>,sboTerm)]};  <span class="comment">% convert to proper format</span>
-1209 <span class="keyword">if</span> isempty(miriam)
-1210     miriam.name = {<span class="string">'sbo'</span>};
-1211     miriam.value = sboTerm;
-1212 <span class="keyword">elseif</span> any(strcmp(<span class="string">'sbo'</span>,miriam.name))
-1213     currSbo = strcmp(<span class="string">'sbo'</span>,miriam.name);
-1214     miriam.value(currSbo) = sboTerm;
-1215 <span class="keyword">else</span>
-1216     miriam.name(end+1) = {<span class="string">'sbo'</span>};
-1217     miriam.value(end+1) = sboTerm;
-1218 <span class="keyword">end</span>
-1219 <span class="keyword">end</span></pre></div>
+1165 <span class="keyword">for</span> i=1:numel(targetString)
+1166     fieldContent=[fieldContent <span class="string">';'</span> strtrim(targetString{1,i})];
+1167 <span class="keyword">end</span>
+1168 
+1169 fieldContent=regexprep(fieldContent,<span class="string">'^;|;$'</span>,<span class="string">''</span>);
+1170 <span class="keyword">end</span>
+1171 
+1172 <a name="_sub4" href="#_subfunctions" class="code">function miriamStruct=parseMiriam(searchString)</a>
+1173 <span class="comment">%Generates miriam structure from annotation field</span>
+1174 
+1175 <span class="comment">%Finding whether miriams are written in the old or the new way</span>
+1176 <span class="keyword">if</span> strfind(searchString,<span class="string">'urn:miriam:'</span>)
+1177     startString=<span class="string">'urn:miriam:'</span>;
+1178     midString=<span class="string">':'</span>;
+1179 <span class="keyword">elseif</span> strfind(searchString,<span class="string">'http://identifiers.org/'</span>)
+1180     startString=<span class="string">'http://identifiers.org/'</span>;
+1181     midString=<span class="string">'/'</span>;
+1182 <span class="keyword">elseif</span> strfind(searchString,<span class="string">'https://identifiers.org/'</span>)
+1183     startString=<span class="string">'https://identifiers.org/'</span>;
+1184     midString=<span class="string">'/'</span>;
+1185 <span class="keyword">else</span>
+1186     miriamStruct=[];
+1187     <span class="keyword">return</span>;
+1188 <span class="keyword">end</span>
+1189 
+1190 miriamStruct=[];
+1191 
+1192 searchString=regexprep(searchString,<span class="string">'&quot; /&gt;'</span>,<span class="string">'&quot;/&gt;'</span>);
+1193 [~,targetString] = regexp(searchString,<span class="string">'&lt;rdf:li rdf:resource=&quot;.*?&quot;/&gt;'</span>,<span class="string">'tokens'</span>,<span class="string">'match'</span>);
+1194 targetString=regexprep(targetString,<span class="string">'&lt;rdf:li rdf:resource=&quot;|&quot;/&gt;'</span>,<span class="string">''</span>);
+1195 targetString=regexprep(targetString,startString,<span class="string">''</span>);
+1196 targetString=regexprep(targetString,midString,<span class="string">'/'</span>,<span class="string">'once'</span>);
+1197 
+1198 counter=0;
+1199 <span class="keyword">for</span> i=1:numel(targetString)
+1200     <span class="keyword">if</span> isempty(regexp(targetString{1,i},<span class="string">'inchi|ec-code'</span>, <span class="string">'once'</span>))
+1201         counter=counter+1;
+1202         miriamStruct.name{counter,1} = regexprep(targetString{1,i},<span class="string">'/.+'</span>,<span class="string">''</span>,<span class="string">'once'</span>);
+1203         miriamStruct.value{counter,1} = regexprep(targetString{1,i},[miriamStruct.name{counter,1} <span class="string">'/'</span>],<span class="string">''</span>,<span class="string">'once'</span>);
+1204         miriamStruct.name{counter,1} = regexprep(miriamStruct.name{counter,1},<span class="string">'^obo\.'</span>,<span class="string">''</span>);
+1205     <span class="keyword">end</span>
+1206 <span class="keyword">end</span>
+1207 <span class="keyword">end</span>
+1208 
+1209 <a name="_sub5" href="#_subfunctions" class="code">function miriam = addSBOtoMiriam(miriam,sboTerm)</a>
+1210 <span class="comment">%Appends SBO term to miriam structure</span>
+1211 
+1212 sboTerm = {[<span class="string">'SBO:'</span> sprintf(<span class="string">'%07u'</span>,sboTerm)]};  <span class="comment">% convert to proper format</span>
+1213 <span class="keyword">if</span> isempty(miriam)
+1214     miriam.name = {<span class="string">'sbo'</span>};
+1215     miriam.value = sboTerm;
+1216 <span class="keyword">elseif</span> any(strcmp(<span class="string">'sbo'</span>,miriam.name))
+1217     currSbo = strcmp(<span class="string">'sbo'</span>,miriam.name);
+1218     miriam.value(currSbo) = sboTerm;
+1219 <span class="keyword">else</span>
+1220     miriam.name(end+1) = {<span class="string">'sbo'</span>};
+1221     miriam.value(end+1) = sboTerm;
+1222 <span class="keyword">end</span>
+1223 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/io/readYAMLmodel.html
+++ b/doc/io/readYAMLmodel.html
@@ -100,637 +100,639 @@ This function is called by:
 0043 <span class="keyword">end</span>
 0044 <span class="comment">% If entry is broken of multiple lines, concatenate. Assumes at least 6</span>
 0045 <span class="comment">% leading spaces to avoid metaData to be concatenated.</span>
-0046 newLine=regexp(line_raw,<span class="string">'^ {6,}([\w\(\)].*)'</span>,<span class="string">'tokens'</span>);
-0047 brokenLine=find(~cellfun(@isempty,newLine));
+0046 newLine=regexp(line_raw,<span class="string">'^ {6,}([\w\(\)].*)'</span>,<span class="string">'tokenExtents'</span>);
+0047 brokenLine=find(~cellfun(<span class="string">'isempty'</span>,newLine));
 0048 <span class="keyword">for</span> i=1:numel(brokenLine)
-0049     line_raw{brokenLine(i)-1} = strjoin({line_raw{brokenLine(i)-1},char(newLine{brokenLine(i)}{1})},<span class="string">' '</span>);
-0050 <span class="keyword">end</span>
-0051 line_raw(brokenLine)=[];
-0052 
-0053 line_key = regexprep(line_raw,<span class="string">'^ *-? ([^:]+)(:).*'</span>,<span class="string">'$1'</span>);
-0054 line_key = regexprep(line_key,<span class="string">'(.*!!omap)|(---)|( {4,}.*)'</span>,<span class="string">''</span>);
-0055 
-0056 line_value = regexprep(line_raw, <span class="string">'.*:$'</span>,<span class="string">''</span>);
-0057 line_value = regexprep(line_value, <span class="string">'[^&quot;:]+: &quot;?(.+)&quot;?$'</span>,<span class="string">'$1'</span>);
-0058 line_value = regexprep(line_value, <span class="string">'(&quot;)|(^ {4,}- )'</span>,<span class="string">''</span>);
-0059 
-0060 modelFields =   {<span class="string">'id'</span>,char();<span class="keyword">...</span>
-0061                <span class="string">'name'</span>,char();<span class="keyword">...</span>
-0062         <span class="string">'description'</span>,char();<span class="keyword">...</span>
-0063             <span class="string">'version'</span>,char();<span class="keyword">...</span>
-0064                <span class="string">'date'</span>,char();<span class="keyword">...</span>
-0065          <span class="string">'annotation'</span>,struct();<span class="keyword">...</span>
-0066                <span class="string">'rxns'</span>,{};<span class="keyword">...</span>
-0067            <span class="string">'rxnNames'</span>,{};<span class="keyword">...</span>
-0068                <span class="string">'mets'</span>,{};<span class="keyword">...</span>
-0069            <span class="string">'metNames'</span>,{};<span class="keyword">...</span>
-0070                   <span class="string">'S'</span>,sparse([]);<span class="keyword">...</span>
-0071                  <span class="string">'lb'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0072                  <span class="string">'ub'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0073                 <span class="string">'rev'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0074                   <span class="string">'c'</span>,[];<span class="keyword">...</span>
-0075                   <span class="string">'b'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0076               <span class="string">'genes'</span>,cell(0,0);<span class="keyword">...</span>
-0077             <span class="string">'grRules'</span>,cell(0,0);<span class="keyword">...</span>
-0078          <span class="string">'rxnGeneMat'</span>,sparse([]);<span class="keyword">...</span>
-0079            <span class="string">'rxnComps'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0080          <span class="string">'subSystems'</span>,cell(0,0);<span class="keyword">...</span>
-0081             <span class="string">'eccodes'</span>,cell(0,0);<span class="keyword">...</span>
-0082          <span class="string">'rxnMiriams'</span>,cell(0,0);<span class="keyword">...</span>
-0083           <span class="string">'rxnDeltaG'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0084            <span class="string">'rxnNotes'</span>,cell(0,0);<span class="keyword">...</span>
-0085       <span class="string">'rxnReferences'</span>,cell(0,0);<span class="keyword">...</span>
-0086 <span class="string">'rxnConfidenceScores'</span>,cell(0,0);<span class="keyword">...</span>
-0087            <span class="string">'metComps'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0088              <span class="string">'inchis'</span>,cell(0,0);<span class="keyword">...</span>
-0089           <span class="string">'metSmiles'</span>,cell(0,0);<span class="keyword">...</span>
-0090         <span class="string">'metFormulas'</span>,cell(0,0);<span class="keyword">...</span>
-0091          <span class="string">'metMiriams'</span>,cell(0,0);<span class="keyword">...</span>
-0092           <span class="string">'metDeltaG'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0093          <span class="string">'metCharges'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0094            <span class="string">'metNotes'</span>,cell(0,0);<span class="keyword">...</span>
-0095               <span class="string">'comps'</span>,cell(0,0);<span class="keyword">...</span>
-0096           <span class="string">'compNames'</span>,cell(0,0);<span class="keyword">...</span>
-0097         <span class="string">'compOutside'</span>,cell(0,0);<span class="keyword">...</span>
-0098           <span class="string">'geneComps'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0099         <span class="string">'geneMiriams'</span>,cell(0,0);<span class="keyword">...</span>
-0100      <span class="string">'geneShortNames'</span>,cell(0,0);<span class="keyword">...</span>
-0101       <span class="string">'unconstrained'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
-0102             <span class="string">'metFrom'</span>,cell(0,0);<span class="keyword">...</span>
-0103             <span class="string">'rxnFrom'</span>,cell(0,0)};
-0104 <span class="keyword">for</span> i=1:size(modelFields,1)
-0105     model.(modelFields{i,1})=modelFields{i,2};
-0106 <span class="keyword">end</span>
-0107 
-0108 <span class="comment">% If GECKO model</span>
-0109 <span class="keyword">if</span> any(contains(line_key,<span class="string">'geckoLight'</span>))
-0110     isGECKO=true;
-0111     ecFields = {<span class="string">'geckoLight'</span>, false;<span class="keyword">...</span>
-0112                       <span class="string">'rxns'</span>, {};<span class="keyword">...</span>
-0113                       <span class="string">'kcat'</span>, {};<span class="keyword">...</span>
-0114                     <span class="string">'source'</span>, cell(0,0);<span class="keyword">...</span>
-0115                      <span class="string">'notes'</span>, cell(0,0);<span class="keyword">...</span>
-0116                    <span class="string">'eccodes'</span>, cell(0,0);<span class="keyword">...</span>
-0117                      <span class="string">'genes'</span>, cell(0,0);<span class="keyword">...</span>
-0118                    <span class="string">'enzymes'</span>, cell(0,0);<span class="keyword">...</span>
-0119                         <span class="string">'mw'</span>, cell(0,0);<span class="keyword">...</span>
-0120                   <span class="string">'sequence'</span>, cell(0,0);<span class="keyword">...</span>
-0121                      <span class="string">'concs'</span>, cell(0,0);<span class="keyword">...</span>
-0122                  <span class="string">'rxnEnzMat'</span>, []};
-0123     <span class="keyword">for</span> i=1:size(ecFields,1)
-0124         model.ec.(ecFields{i,1})=ecFields{i,2};
-0125     <span class="keyword">end</span>
-0126     ecGecko=cell(25000,2);      ecGeckoNo=1;
-0127     enzStoich=cell(100000,3);   enzStoichNo=1;
-0128 <span class="keyword">else</span>
-0129     isGECKO=false;
-0130 <span class="keyword">end</span>
-0131 
-0132 section = 0;
-0133 metMiriams=cell(100000,3);   metMirNo=1;
-0134 rxnMiriams=cell(100000,3);   rxnMirNo=1;
-0135 geneMiriams=cell(100000,3);  genMirNo=1;
-0136 subSystems=cell(100000,2);   subSysNo=1;
-0137 eccodes=cell(100000,2);      ecCodeNo=1;
-0138 equations=cell(100000,3);   equatiNo=1;
-0139 
-0140 <span class="keyword">for</span> i=1:numel(line_key)
-0141     tline_raw = line_raw{i};
-0142     tline_key = line_key{i};
-0143     tline_value = line_value{i};
-0144     <span class="comment">% import different sections</span>
-0145     <span class="keyword">switch</span> tline_raw
-0146         <span class="keyword">case</span> <span class="string">'- metaData:'</span>
-0147             section = 1;
-0148             <span class="keyword">if</span> verbose
-0149                 fprintf(<span class="string">'\t%d\n'</span>, section);
-0150             <span class="keyword">end</span>
-0151             <span class="keyword">continue</span> <span class="comment">% Go to next line</span>
-0152         <span class="keyword">case</span> <span class="string">'- metabolites:'</span>
-0153             section = 2;
-0154             <span class="keyword">if</span> verbose
-0155                 fprintf(<span class="string">'\t%d\n'</span>, section);
-0156             <span class="keyword">end</span>
-0157             pos=0;
-0158             <span class="keyword">continue</span>
-0159         <span class="keyword">case</span> <span class="string">'- reactions:'</span>
-0160             section = 3;
-0161             <span class="keyword">if</span> verbose
-0162                 fprintf(<span class="string">'\t%d\n'</span>, section);
-0163             <span class="keyword">end</span>
-0164             pos=0;
-0165             <span class="keyword">continue</span>
-0166         <span class="keyword">case</span> <span class="string">'- genes:'</span>
-0167             section = 4;
-0168             <span class="keyword">if</span> verbose
-0169                 fprintf(<span class="string">'\t%d\n'</span>, section);
-0170             <span class="keyword">end</span>
-0171             pos=0;
-0172             <span class="keyword">continue</span>
-0173         <span class="keyword">case</span> <span class="string">'- compartments: !!omap'</span>
-0174             section = 5;
-0175             <span class="keyword">if</span> verbose
-0176                 fprintf(<span class="string">'\t%d\n'</span>, section);
-0177             <span class="keyword">end</span>
-0178             pos=0;
-0179             <span class="keyword">continue</span>
-0180         <span class="keyword">case</span> <span class="string">'- ec-rxns:'</span>
-0181             section = 6;
-0182             <span class="keyword">if</span> verbose
-0183                 fprintf(<span class="string">'\t%d\n'</span>, section);
-0184             <span class="keyword">end</span>
-0185             pos=0;
-0186             <span class="keyword">continue</span>
-0187         <span class="keyword">case</span> <span class="string">'- ec-enzymes:'</span>
-0188             section = 7;
-0189             <span class="keyword">if</span> verbose
-0190                 fprintf(<span class="string">'\t%d\n'</span>, section);
-0191             <span class="keyword">end</span>
-0192             pos=0;
-0193             <span class="keyword">continue</span>
-0194     <span class="keyword">end</span>
-0195 
-0196     <span class="comment">% skip over empty keys</span>
-0197     <span class="keyword">if</span> isempty(tline_raw) || (isempty(tline_key) &amp;&amp; contains(tline_raw,<span class="string">'!!omap'</span>))
-0198         <span class="keyword">continue</span>;
-0199     <span class="keyword">end</span>
-0200     
-0201     <span class="comment">% import metaData</span>
-0202     <span class="keyword">if</span> section == 1
-0203         <span class="keyword">switch</span> tline_key
-0204             <span class="keyword">case</span> {<span class="string">'short_name'</span>,<span class="string">'id'</span>} <span class="comment">%short_name used by human-GEM</span>
-0205                 model.id = tline_value;
-0206             <span class="keyword">case</span> <span class="string">'name'</span>
-0207                 model.name = tline_value;                
-0208             <span class="keyword">case</span> <span class="string">'full_name'</span> <span class="comment">%used by human-GEM</span>
-0209                 model.description = tline_value;
-0210             <span class="keyword">case</span> <span class="string">'version'</span>
-0211                 model.version = tline_value;
-0212             <span class="keyword">case</span> <span class="string">'date'</span>
-0213                 model.date = tline_value;                
-0214             <span class="keyword">case</span> <span class="string">'taxonomy'</span>
-0215                 model.annotation.taxonomy = tline_value;
-0216             <span class="keyword">case</span> {<span class="string">'description'</span>,<span class="string">'note'</span>} <span class="comment">%description used by human-GEM</span>
-0217                 model.annotation.note = tline_value;
-0218             <span class="keyword">case</span> <span class="string">'github'</span>
-0219                 model.annotation.sourceUrl = tline_value;
-0220             <span class="keyword">case</span> <span class="string">'givenName'</span>
-0221                 model.annotation.givenName = tline_value;
-0222             <span class="keyword">case</span> <span class="string">'familyName'</span>
-0223                 model.annotation.familyName = tline_value;
-0224             <span class="keyword">case</span> <span class="string">'authors'</span>
-0225                 model.annotation.authorList = tline_value;
-0226             <span class="keyword">case</span> <span class="string">'email'</span>
-0227                 model.annotation.email = tline_value;
-0228             <span class="keyword">case</span> <span class="string">'organization'</span>
-0229                 model.annotation.organization = tline_value;
-0230             <span class="keyword">case</span> <span class="string">'geckoLight'</span>
-0231                 <span class="keyword">if</span> strcmp(tline_value,<span class="string">'true'</span>)
-0232                     model.ec.geckoLight = true;
-0233                 <span class="keyword">end</span>
-0234         <span class="keyword">end</span>; <span class="keyword">continue</span>
-0235     <span class="keyword">end</span>
-0236 
-0237     <span class="comment">% import metabolites:</span>
-0238     <span class="keyword">if</span> section == 2
-0239         <span class="keyword">switch</span> tline_key
-0240             <span class="keyword">case</span> <span class="string">'id'</span>
-0241                 pos = pos + 1;
-0242                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'mets'</span>, tline_value,pos);
-0243                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0244             <span class="keyword">case</span> <span class="string">'name'</span>
-0245                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metNames'</span>, tline_value, pos);
-0246                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0247             <span class="keyword">case</span> <span class="string">'compartment'</span>
-0248                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metComps'</span>, tline_value, pos);
-0249                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0250             <span class="keyword">case</span> <span class="string">'formula'</span>
-0251                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metFormulas'</span>, tline_value, pos);
-0252                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0253             <span class="keyword">case</span> <span class="string">'charge'</span>
-0254                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metCharges'</span>, tline_value, pos);
-0255                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0256             <span class="keyword">case</span> <span class="string">'notes'</span>
-0257                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metNotes'</span>, tline_value, pos);
-0258                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0259             <span class="keyword">case</span> <span class="string">'inchis'</span>
-0260                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'inchis'</span>, tline_value, pos);
-0261                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0262             <span class="keyword">case</span> <span class="string">'smiles'</span>
-0263                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metSmiles'</span>, tline_value, pos);
-0264                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;    
-0265             <span class="keyword">case</span> <span class="string">'deltaG'</span>
-0266                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metDeltaG'</span>, tline_value, pos);
-0267                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;                                
-0268             <span class="keyword">case</span> <span class="string">'metFrom'</span>
-0269                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metFrom'</span>, tline_value, pos);
-0270                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0271             <span class="keyword">case</span> <span class="string">'annotation'</span>
-0272                 readList = <span class="string">'annotation'</span>;
-0273             <span class="keyword">otherwise</span>
-0274                 <span class="keyword">switch</span> readList
-0275                     <span class="keyword">case</span> <span class="string">'annotation'</span>
-0276                         [metMiriams, miriamKey] = <a href="#_sub3" class="code" title="subfunction [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)">gatherAnnotation</a>(pos,metMiriams,tline_key,tline_value,miriamKey,metMirNo);
-0277                         metMirNo = metMirNo + 1;
-0278                     <span class="keyword">otherwise</span>
-0279                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
-0280                 <span class="keyword">end</span>
-0281         <span class="keyword">end</span>; <span class="keyword">continue</span>
-0282     <span class="keyword">end</span>
-0283 
-0284     <span class="comment">% import reactions:</span>
-0285     <span class="keyword">if</span> section == 3
-0286         <span class="keyword">switch</span> tline_key
-0287             <span class="keyword">case</span> <span class="string">'id'</span>
-0288                 pos = pos + 1;
-0289                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxns'</span>, tline_value,pos);
-0290                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0291             <span class="keyword">case</span> <span class="string">'name'</span>
-0292                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnNames'</span>, tline_value, pos);
-0293                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0294             <span class="keyword">case</span> <span class="string">'lower_bound'</span>
-0295                 model.lb(pos,1) = {tline_value};
-0296                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0297             <span class="keyword">case</span> <span class="string">'upper_bound'</span>
-0298                 model.ub(pos,1) = {tline_value};
-0299                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0300             <span class="keyword">case</span> <span class="string">'rev'</span>
-0301                 model.rev(pos,1) = {tline_value};
-0302                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0303             <span class="keyword">case</span> <span class="string">'gene_reaction_rule'</span>
-0304                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'grRules'</span>, tline_value, pos);
-0305                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0306             <span class="keyword">case</span> <span class="string">'rxnNotes'</span>
-0307                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnNotes'</span>, tline_value, pos);
-0308                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0309             <span class="keyword">case</span> <span class="string">'rxnFrom'</span>
-0310                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnFrom'</span>, tline_value, pos);
-0311                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0312             <span class="keyword">case</span> <span class="string">'deltaG'</span>
-0313                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnDeltaG'</span>, tline_value, pos);
-0314                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;                
-0315             <span class="keyword">case</span> <span class="string">'objective_coefficient'</span>
-0316                 model.c(pos,1) = 1;
-0317                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0318             <span class="keyword">case</span> <span class="string">'references'</span>
-0319                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnReferences'</span>, tline_value, pos);
-0320                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0321             <span class="keyword">case</span> <span class="string">'confidence_score'</span>
-0322                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnConfidenceScores'</span>, tline_value, pos);
-0323                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
-0324             <span class="keyword">case</span> <span class="string">'eccodes'</span>
-0325                 <span class="keyword">if</span> isempty(tline_value)
-0326                     readList = <span class="string">'eccodes'</span>;
-0327                 <span class="keyword">else</span>
-0328                     eccodes(ecCodeNo,1:2)={pos,tline_value};
-0329                     ecCodeNo=ecCodeNo+1;
-0330                 <span class="keyword">end</span>
-0331             <span class="keyword">case</span> <span class="string">'subsystem'</span>
-0332                 <span class="keyword">if</span> isempty(tline_value)
-0333                     readList = <span class="string">'subsystem'</span>;
-0334                 <span class="keyword">else</span>
-0335                     subSystems(subSysNo,1:2)={pos,tline_value};
-0336                     subSysNo=subSysNo+1;
-0337                 <span class="keyword">end</span>
-0338             <span class="keyword">case</span> <span class="string">'metabolites'</span>
-0339                 readList = <span class="string">'equation'</span>;
-0340             <span class="keyword">case</span> <span class="string">'annotation'</span>
-0341                 readList = <span class="string">'annotation'</span>;
-0342                 
-0343             <span class="keyword">otherwise</span>
-0344                 <span class="keyword">switch</span> readList
-0345                     <span class="keyword">case</span> <span class="string">'eccodes'</span>
-0346                         eccodes(ecCodeNo,1:2)={pos,regexprep(tline_value,<span class="string">'^ +- &quot;?(.*)&quot;?$'</span>,<span class="string">'$1'</span>)};
-0347                         ecCodeNo=ecCodeNo+1;
-0348                     <span class="keyword">case</span> <span class="string">'subsystem'</span>
-0349                         subSystems(subSysNo,1:2)={pos,regexprep(tline_value,<span class="string">'^ +- &quot;?(.*)&quot;?$'</span>,<span class="string">'$1'</span>)};
-0350                         subSysNo=subSysNo+1;
-0351                     <span class="keyword">case</span> <span class="string">'annotation'</span>
-0352                         [rxnMiriams, miriamKey,rxnMirNo] = <a href="#_sub3" class="code" title="subfunction [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)">gatherAnnotation</a>(pos,rxnMiriams,tline_key,tline_value,miriamKey,rxnMirNo);
-0353                         rxnMirNo=rxnMirNo+1;
-0354                     <span class="keyword">case</span> <span class="string">'equation'</span>
-0355                         coeff = sscanf(tline_value,<span class="string">'%f'</span>);
-0356                         equations(equatiNo,1:3)={pos,tline_key,coeff};
-0357                         equatiNo=equatiNo+1;
-0358                     <span class="keyword">otherwise</span>
-0359                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
-0360                 <span class="keyword">end</span>                
-0361         <span class="keyword">end</span>; <span class="keyword">continue</span>
-0362     <span class="keyword">end</span>
-0363 
-0364     <span class="comment">% import genes:</span>
-0365     <span class="keyword">if</span> section == 4
-0366         <span class="keyword">switch</span> tline_key
-0367             <span class="keyword">case</span> <span class="string">'id'</span>
-0368                 pos = pos + 1;
-0369                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'genes'</span>, tline_value, pos);
-0370                 readList = <span class="string">''</span>;
-0371                 miriamKey = <span class="string">''</span>;
-0372             <span class="keyword">case</span> <span class="string">'name'</span>
-0373                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'geneShortNames'</span>, tline_value, pos);
-0374             <span class="keyword">case</span> <span class="string">'annotation'</span>
-0375                 readList = <span class="string">'annotation'</span>;
-0376             <span class="keyword">otherwise</span>
-0377                 <span class="keyword">switch</span> readList
-0378                     <span class="keyword">case</span> <span class="string">'annotation'</span>
-0379                         [geneMiriams, miriamKey] = <a href="#_sub3" class="code" title="subfunction [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)">gatherAnnotation</a>(pos,geneMiriams,tline_key,tline_value,miriamKey,genMirNo);
-0380                         genMirNo = genMirNo + 1;
-0381                     <span class="keyword">otherwise</span>
-0382                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
-0383                 <span class="keyword">end</span>
-0384         <span class="keyword">end</span>; <span class="keyword">continue</span>
-0385     <span class="keyword">end</span>
-0386 
-0387     <span class="comment">% import compartments:</span>
-0388     <span class="keyword">if</span> section == 5
-0389         model.comps(end+1,1) = {tline_key};
-0390         model.compNames(end+1,1) = {tline_value};
-0391     <span class="keyword">end</span>
-0392 
-0393     <span class="comment">% import ec reaction info</span>
-0394     <span class="keyword">if</span> section == 6
-0395         <span class="keyword">switch</span> tline_key
-0396             <span class="keyword">case</span> <span class="string">'id'</span>
-0397                 pos = pos + 1;
-0398                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'rxns'</span>, tline_value, pos);
-0399                 readList=<span class="string">''</span>;
-0400             <span class="keyword">case</span> <span class="string">'kcat'</span>
-0401                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'kcat'</span>, tline_value, pos);
-0402                 readList=<span class="string">''</span>;
-0403             <span class="keyword">case</span> <span class="string">'source'</span>
-0404                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'source'</span>, tline_value, pos);
-0405                 readList=<span class="string">''</span>;
-0406             <span class="keyword">case</span> <span class="string">'notes'</span>
-0407                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'notes'</span>, tline_value, pos);
-0408                 readList=<span class="string">''</span>;
-0409             <span class="keyword">case</span> <span class="string">'eccodes'</span>
-0410                 <span class="keyword">if</span> isempty(tline_value)
-0411                     readList = <span class="string">'eccodes'</span>;
-0412                 <span class="keyword">else</span>
-0413                     ecGecko(ecGeckoNo,1:2)={pos,tline_value};
-0414                     ecGeckoNo=ecGeckoNo+1;
-0415                 <span class="keyword">end</span>
-0416             <span class="keyword">case</span> <span class="string">'enzymes'</span>
-0417                 readList = <span class="string">'enzStoich'</span>;
-0418             <span class="keyword">otherwise</span>
-0419                 <span class="keyword">switch</span> readList
-0420                     <span class="keyword">case</span> <span class="string">'eccodes'</span>
-0421                         ecGecko(ecGeckoNo,1:2)={pos,regexprep(tline_value,<span class="string">'^ +- &quot;?(.*)&quot;?$'</span>,<span class="string">'$1'</span>)};
-0422                         ecGeckoNo=ecGeckoNo+1;
-0423                     <span class="keyword">case</span> <span class="string">'enzStoich'</span>
-0424                         coeff = sscanf(tline_value,<span class="string">'%f'</span>);
-0425                         enzStoich(enzStoichNo,1:3)={pos,tline_key,coeff};
-0426                         enzStoichNo=enzStoichNo+1;
-0427                     <span class="keyword">otherwise</span>
-0428                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
-0429                 <span class="keyword">end</span>
-0430         <span class="keyword">end</span>; <span class="keyword">continue</span>
-0431     <span class="keyword">end</span>
-0432 
-0433     <span class="comment">% import ec enzyme info</span>
-0434     <span class="keyword">if</span> section == 7
-0435         <span class="keyword">switch</span> tline_key
-0436             <span class="keyword">case</span> <span class="string">'genes'</span>
-0437                 pos = pos + 1;
-0438                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'genes'</span>, tline_value, pos);
-0439             <span class="keyword">case</span> <span class="string">'enzymes'</span>
-0440                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'enzymes'</span>, tline_value, pos);
-0441             <span class="keyword">case</span> <span class="string">'mw'</span>
-0442                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'mw'</span>, tline_value, pos);
-0443             <span class="keyword">case</span> <span class="string">'sequence'</span>
-0444                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'sequence'</span>, tline_value, pos);
-0445             <span class="keyword">case</span> <span class="string">'concs'</span>
-0446                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'concs'</span>, tline_value, pos);
-0447             <span class="keyword">otherwise</span>
-0448                 error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
-0449         <span class="keyword">end</span>; <span class="keyword">continue</span>
-0450     <span class="keyword">end</span>
-0451 <span class="keyword">end</span>
-0452 
-0453 <span class="comment">%Parse annotations</span>
-0454 <span class="keyword">if</span> ~isempty(metMiriams)
-0455     locs = cell2mat(metMiriams(:,1));
-0456     <span class="keyword">for</span> i=unique(locs)'
-0457         model.metMiriams{i,1}.name=metMiriams(locs==i,2);
-0458         model.metMiriams{i,1}.value=metMiriams(locs==i,3);
-0459     <span class="keyword">end</span>
-0460 <span class="keyword">end</span>
-0461 <span class="keyword">if</span> ~isempty(rxnMiriams)
-0462     locs = cell2mat(rxnMiriams(:,1));
-0463     <span class="keyword">for</span> i=unique(locs)'
-0464         model.rxnMiriams{i,1}.name=rxnMiriams(locs==i,2);
-0465         model.rxnMiriams{i,1}.value=rxnMiriams(locs==i,3);
-0466     <span class="keyword">end</span>
-0467 <span class="keyword">end</span>
-0468 <span class="keyword">if</span> ~isempty(geneMiriams)
-0469     locs = cell2mat(geneMiriams(:,1));
-0470     <span class="keyword">for</span> i=unique(locs)'
-0471         model.geneMiriams{i,1}.name=geneMiriams(locs==i,2);
-0472         model.geneMiriams{i,1}.value=geneMiriams(locs==i,3);
-0473     <span class="keyword">end</span>
-0474 <span class="keyword">end</span>
-0475 
-0476 <span class="comment">%Parse subSystems</span>
-0477 <span class="keyword">if</span> ~isempty(subSystems)
-0478     locs = cell2mat(subSystems(:,1));
-0479     <span class="keyword">for</span> i=unique(locs)'
-0480         model.subSystems{i,1}=subSystems(locs==i,2);
-0481     <span class="keyword">end</span>
-0482 <span class="keyword">end</span>
-0483 
-0484 <span class="comment">%Parse ec-codes</span>
-0485 <span class="keyword">if</span> ~isempty(eccodes)
-0486     locs = cell2mat(eccodes(:,1));
-0487     <span class="keyword">for</span> i=unique(locs)'
-0488         eccodesCat=strjoin(eccodes(locs==i,2),<span class="string">';'</span>);
-0489         model.eccodes{i,1}=eccodesCat;
-0490     <span class="keyword">end</span>
-0491     emptyEc=cellfun(@isempty,model.eccodes);
-0492     model.eccodes(emptyEc)={<span class="string">''</span>};
-0493 <span class="keyword">end</span>
-0494 
-0495 <span class="comment">% follow-up data processing</span>
-0496 <span class="keyword">if</span> verbose
-0497     fprintf(<span class="string">'\nimporting completed\nfollow-up processing...'</span>);
-0498 <span class="keyword">end</span>
-0499 [~, model.metComps] = ismember(model.metComps, model.comps);
-0500 [~, model.geneComps] = ismember(model.geneComps, model.comps);
-0501 [~, model.rxnComps] = ismember(model.rxnComps, model.comps);
-0502 
-0503 <span class="comment">% Fill S-matrix</span>
-0504 rxnIdx = cellfun(@isempty, equations(:,1));
-0505 equations(rxnIdx,:) = <span class="string">''</span>;
-0506 rxnIdx = cell2mat(equations(:,1));
-0507 [~,metIdx] = ismember(equations(:,2),model.mets);
-0508 coeffs = cell2mat(equations(:,3));
-0509 model.S=sparse(max(metIdx),max(rxnIdx));
-0510 linearIndices = sub2ind([max(metIdx), max(rxnIdx)],metIdx,rxnIdx);
-0511 model.S(linearIndices) = coeffs;
-0512 
-0513 <span class="comment">% Convert strings to numeric</span>
-0514 model.metCharges = str2double(model.metCharges);
-0515 model.lb = str2double(model.lb);
-0516 model.ub = str2double(model.ub);
-0517 model.rxnConfidenceScores = str2double(model.rxnConfidenceScores);
-0518 model.b = zeros(length(model.mets),1);
-0519 model.metDeltaG = str2double(model.metDeltaG);
-0520 model.rxnDeltaG = str2double(model.rxnDeltaG);
-0521 
-0522 <span class="comment">% Fill some other fields</span>
-0523 model.annotation.defaultLB = min(model.lb);
-0524 model.annotation.defaultUB = max(model.ub);
-0525 <span class="keyword">if</span> numel(model.lb)&lt;numel(model.rxns) <span class="comment">%No LB reported = min</span>
-0526     model.lb(end+1:numel(model.rxns)-numel(model.lb),1) = double(model.annotation.defaultLB);
-0527 <span class="keyword">end</span>
-0528 <span class="keyword">if</span> numel(model.ub)&lt;numel(model.rxns) <span class="comment">%No UB reported = max</span>
-0529     model.ub(end+1:numel(model.rxns)-numel(model.ub),1) = double(model.annotation.defaultUB);
-0530 <span class="keyword">end</span>
-0531 <span class="keyword">if</span> ~all(cellfun(@isempty,model.rev))
-0532     model.rev = str2double(model.rev);
-0533 <span class="keyword">else</span>
-0534     model.rev = [];
-0535 <span class="keyword">end</span>
-0536 <span class="keyword">if</span> numel(model.rev)&lt;numel(model.rxns) <span class="comment">%No rev reported, assume from LB and UB</span>
-0537     model.rev(end+1:numel(model.rxns)-numel(model.rev),1) = double(model.lb&lt;0 &amp; model.ub&gt;0);
-0538 <span class="keyword">end</span>
-0539 
-0540 <span class="comment">% Remove empty fields, otherwise fill to correct length</span>
-0541 <span class="comment">% Reactions</span>
-0542 <span class="keyword">for</span> i={<span class="string">'rxnNames'</span>,<span class="string">'grRules'</span>,<span class="string">'eccodes'</span>,<span class="string">'rxnNotes'</span>,<span class="string">'rxnReferences'</span>,<span class="keyword">...</span>
-0543        <span class="string">'rxnFrom'</span>,<span class="string">'subSystems'</span>,<span class="string">'rxnMiriams'</span>} <span class="comment">% Empty strings</span>
-0544    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'rxns'</span>);
-0545 <span class="keyword">end</span>
-0546 <span class="keyword">for</span> i={<span class="string">'c'</span>} <span class="comment">% Zeros</span>
-0547    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},0,<span class="string">'rxns'</span>,true);
-0548 <span class="keyword">end</span>
-0549 <span class="keyword">for</span> i={<span class="string">'rxnConfidenceScores'</span>,<span class="string">'rxnDeltaG'</span>} <span class="comment">% NaNs</span>
-0550    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},NaN,<span class="string">'rxns'</span>);
-0551 <span class="keyword">end</span>
-0552 <span class="keyword">for</span> i={<span class="string">'rxnComps'</span>} <span class="comment">% Ones, assume first compartment</span>
-0553    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},1,<span class="string">'rxns'</span>);
-0554 <span class="keyword">end</span>
-0555 <span class="comment">% Metabolites</span>
-0556 <span class="keyword">for</span> i={<span class="string">'metNames'</span>,<span class="string">'inchis'</span>,<span class="string">'metFormulas'</span>,<span class="string">'metMiriams'</span>,<span class="string">'metFrom'</span>,<span class="string">'metSmiles'</span>,<span class="string">'metNotes'</span>} <span class="comment">% Empty strings</span>
-0557    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'mets'</span>);
-0558 <span class="keyword">end</span>
-0559 <span class="keyword">for</span> i={<span class="string">'metCharges'</span>,<span class="string">'unconstrained'</span>} <span class="comment">% Zeros</span>
-0560    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},0,<span class="string">'mets'</span>);
-0561 <span class="keyword">end</span>
-0562 <span class="keyword">for</span> i={<span class="string">'metDeltaG'</span>} <span class="comment">% % NaNs</span>
-0563     model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},NaN,<span class="string">'mets'</span>);
-0564  <span class="keyword">end</span>
-0565 <span class="keyword">for</span> i={<span class="string">'metComps'</span>} <span class="comment">% Ones, assume first compartment</span>
-0566    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},1,<span class="string">'mets'</span>);
-0567 <span class="keyword">end</span>
-0568 <span class="comment">% Genes</span>
-0569 <span class="keyword">for</span> i={<span class="string">'geneMiriams'</span>,<span class="string">'geneShortNames'</span>} <span class="comment">% Empty strings</span>
-0570    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'genes'</span>);
-0571 <span class="keyword">end</span>
-0572 <span class="keyword">for</span> i={<span class="string">'geneComps'</span>} <span class="comment">% Ones, assume first compartment</span>
-0573    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},1,<span class="string">'genes'</span>);
-0574 <span class="keyword">end</span>
-0575 <span class="comment">% Comps</span>
-0576 <span class="keyword">for</span> i={<span class="string">'compNames'</span>} <span class="comment">% Empty strings</span>
-0577    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'comps'</span>);
-0578 <span class="keyword">end</span>
-0579 <span class="keyword">for</span> i={<span class="string">'compOutside'</span>} <span class="comment">% First comp</span>
-0580    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},model.comps{1},<span class="string">'comps'</span>);
-0581 <span class="keyword">end</span>
-0582 <span class="comment">% Single fields are kept, even if empty</span>
-0583 <span class="comment">% for i={'description','name','version','date','annotation'}</span>
-0584 <span class="comment">%     if isempty(model.(i{1}))</span>
-0585 <span class="comment">%         model = rmfield(model,i{1});</span>
-0586 <span class="comment">%     end</span>
-0587 <span class="comment">% end</span>
-0588 
-0589 <span class="comment">% Make rxnGeneMat fields and map to the existing model.genes field</span>
-0590 [genes, rxnGeneMat] = getGenesFromGrRules(model.grRules);
-0591 model.rxnGeneMat = sparse(numel(model.rxns),numel(model.genes));
-0592 [~,geneOrder] = ismember(genes,model.genes);
-0593 <span class="keyword">if</span> any(geneOrder == 0)
-0594     error([<span class="string">'The grRules includes the following gene(s), that are not in '</span><span class="keyword">...</span>
-0595            <span class="string">'the list of model genes: '</span>, genes{~geneOrder}])
-0596 <span class="keyword">end</span>
-0597 model.rxnGeneMat(:,geneOrder) = rxnGeneMat;
-0598 
-0599 <span class="comment">% Finalize GECKO model</span>
-0600 <span class="keyword">if</span> isGECKO
-0601     <span class="comment">% Fill in empty fields and empty entries</span>
-0602     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'source'</span>,<span class="string">'notes'</span>,<span class="string">'eccodes'</span>} <span class="comment">% Even keep empty</span>
-0603         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'rxns'</span>,true);
-0604     <span class="keyword">end</span>
-0605     <span class="keyword">for</span> i={<span class="string">'enzymes'</span>,<span class="string">'mw'</span>,<span class="string">'sequence'</span>}
-0606         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'genes'</span>,true);
-0607     <span class="keyword">end</span>
-0608     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'concs'</span>,{<span class="string">'NaN'</span>},<span class="string">'genes'</span>,true);
-0609     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'kcat'</span>,{<span class="string">'0'</span>},<span class="string">'genes'</span>,true);
-0610     <span class="comment">% Change string to double</span>
-0611     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'mw'</span>,<span class="string">'concs'</span>}
-0612         <span class="keyword">if</span> isfield(model.ec,i{1})
-0613             model.ec.(i{1}) = str2double(model.ec.(i{1}));
-0614         <span class="keyword">end</span>
-0615     <span class="keyword">end</span>
-0616     <span class="comment">% Fill rxnEnzMat</span>
-0617     rxnIdx              = cellfun(@isempty, enzStoich(:,1));
-0618     enzStoich(rxnIdx,:) = <span class="string">''</span>;
-0619     rxnIdx              = cell2mat(enzStoich(:,1));
-0620     [~,enzIdx]          = ismember(enzStoich(:,2),model.ec.enzymes);
-0621     coeffs              = cell2mat(enzStoich(:,3));
-0622     model.ec.rxnEnzMat  = zeros(max(rxnIdx), max(enzIdx));
-0623     linearIndices       = sub2ind([max(rxnIdx), max(enzIdx)], rxnIdx, enzIdx);
-0624     model.ec.rxnEnzMat(linearIndices) = coeffs;
-0625     <span class="comment">%Parse ec-codes</span>
-0626     <span class="keyword">if</span> ~isempty(ecGecko)
-0627         locs = cell2mat(ecGecko(:,1));
-0628         <span class="keyword">for</span> i=unique(locs)'
-0629             ecGeckoCat=strjoin(ecGecko(locs==i,2),<span class="string">';'</span>);
-0630             model.ec.eccodes{i,1}=ecGeckoCat;
-0631         <span class="keyword">end</span>
-0632         emptyEc=cellfun(@isempty,model.ec.eccodes);
-0633         model.ec.eccodes(emptyEc)={<span class="string">''</span>};
-0634     <span class="keyword">end</span>
-0635 <span class="keyword">end</span>
-0636 
-0637 <span class="keyword">if</span> verbose
-0638     fprintf(<span class="string">' Done!\n'</span>);
-0639 <span class="keyword">end</span>
-0640 <span class="keyword">end</span>
-0641 
-0642 <a name="_sub1" href="#_subfunctions" class="code">function model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)</a>
-0643 <span class="keyword">if</span> nargin&lt;5
-0644     keepEmpty=false;
-0645 <span class="keyword">end</span>
-0646 <span class="keyword">if</span> isnumeric(emptyEntry)
-0647     emptyCells=isempty(model.(field));
-0648 <span class="keyword">else</span>
-0649     emptyCells=cellfun(@isempty,model.(field));
-0650 <span class="keyword">end</span>
-0651 <span class="keyword">if</span> all(emptyCells) &amp;&amp; ~keepEmpty
-0652     model = rmfield(model, field);
-0653 <span class="keyword">elseif</span> numel(model.(field))&lt;numel(model.(type))
-0654     model.(field)(end+1:numel(model.(type)),1)=emptyEntry;
-0655 <span class="keyword">end</span>
-0656 <span class="keyword">end</span>
-0657 
-0658 <a name="_sub2" href="#_subfunctions" class="code">function model = readFieldValue(model, fieldName, value, pos)</a>
-0659 <span class="keyword">if</span> numel(model.(fieldName))&lt;pos-1
-0660     model.(fieldName)(end+1:pos,1) = {<span class="string">''</span>};
-0661 <span class="keyword">end</span>
-0662 model.(fieldName)(pos,1) = {value};
+0049     extraLine = char(line_raw(brokenLine(i)));
+0050     extraLine = extraLine(newLine{brokenLine(i)}{1}(1):end);
+0051     line_raw{brokenLine(i)-1} = strjoin({line_raw{brokenLine(i)-1},extraLine},<span class="string">' '</span>);
+0052 <span class="keyword">end</span>
+0053 line_raw(brokenLine)=[];
+0054 
+0055 line_key = regexprep(line_raw,<span class="string">'^ *-? ([^:]+)(:).*'</span>,<span class="string">'$1'</span>);
+0056 line_key = regexprep(line_key,<span class="string">'(.*!!omap)|(---)|( {4,}.*)'</span>,<span class="string">''</span>);
+0057 
+0058 line_value = regexprep(line_raw, <span class="string">'.*:$'</span>,<span class="string">''</span>);
+0059 line_value = regexprep(line_value, <span class="string">'[^&quot;:]+: &quot;?(.+)&quot;?$'</span>,<span class="string">'$1'</span>);
+0060 line_value = regexprep(line_value, <span class="string">'(&quot;)|(^ {4,}- )'</span>,<span class="string">''</span>);
+0061 
+0062 modelFields =   {<span class="string">'id'</span>,char();<span class="keyword">...</span>
+0063                <span class="string">'name'</span>,char();<span class="keyword">...</span>
+0064         <span class="string">'description'</span>,char();<span class="keyword">...</span>
+0065             <span class="string">'version'</span>,char();<span class="keyword">...</span>
+0066                <span class="string">'date'</span>,char();<span class="keyword">...</span>
+0067          <span class="string">'annotation'</span>,struct();<span class="keyword">...</span>
+0068                <span class="string">'rxns'</span>,{};<span class="keyword">...</span>
+0069            <span class="string">'rxnNames'</span>,{};<span class="keyword">...</span>
+0070                <span class="string">'mets'</span>,{};<span class="keyword">...</span>
+0071            <span class="string">'metNames'</span>,{};<span class="keyword">...</span>
+0072                   <span class="string">'S'</span>,sparse([]);<span class="keyword">...</span>
+0073                  <span class="string">'lb'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0074                  <span class="string">'ub'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0075                 <span class="string">'rev'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0076                   <span class="string">'c'</span>,[];<span class="keyword">...</span>
+0077                   <span class="string">'b'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0078               <span class="string">'genes'</span>,cell(0,0);<span class="keyword">...</span>
+0079             <span class="string">'grRules'</span>,cell(0,0);<span class="keyword">...</span>
+0080          <span class="string">'rxnGeneMat'</span>,sparse([]);<span class="keyword">...</span>
+0081            <span class="string">'rxnComps'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0082          <span class="string">'subSystems'</span>,cell(0,0);<span class="keyword">...</span>
+0083             <span class="string">'eccodes'</span>,cell(0,0);<span class="keyword">...</span>
+0084          <span class="string">'rxnMiriams'</span>,cell(0,0);<span class="keyword">...</span>
+0085           <span class="string">'rxnDeltaG'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0086            <span class="string">'rxnNotes'</span>,cell(0,0);<span class="keyword">...</span>
+0087       <span class="string">'rxnReferences'</span>,cell(0,0);<span class="keyword">...</span>
+0088 <span class="string">'rxnConfidenceScores'</span>,cell(0,0);<span class="keyword">...</span>
+0089            <span class="string">'metComps'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0090              <span class="string">'inchis'</span>,cell(0,0);<span class="keyword">...</span>
+0091           <span class="string">'metSmiles'</span>,cell(0,0);<span class="keyword">...</span>
+0092         <span class="string">'metFormulas'</span>,cell(0,0);<span class="keyword">...</span>
+0093          <span class="string">'metMiriams'</span>,cell(0,0);<span class="keyword">...</span>
+0094           <span class="string">'metDeltaG'</span>,{};<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0095          <span class="string">'metCharges'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0096            <span class="string">'metNotes'</span>,cell(0,0);<span class="keyword">...</span>
+0097               <span class="string">'comps'</span>,cell(0,0);<span class="keyword">...</span>
+0098           <span class="string">'compNames'</span>,cell(0,0);<span class="keyword">...</span>
+0099         <span class="string">'compOutside'</span>,cell(0,0);<span class="keyword">...</span>
+0100           <span class="string">'geneComps'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0101         <span class="string">'geneMiriams'</span>,cell(0,0);<span class="keyword">...</span>
+0102      <span class="string">'geneShortNames'</span>,cell(0,0);<span class="keyword">...</span>
+0103       <span class="string">'unconstrained'</span>,cell(0,0);<span class="keyword">...</span><span class="comment"> %Changed to double in the end.</span>
+0104             <span class="string">'metFrom'</span>,cell(0,0);<span class="keyword">...</span>
+0105             <span class="string">'rxnFrom'</span>,cell(0,0)};
+0106 <span class="keyword">for</span> i=1:size(modelFields,1)
+0107     model.(modelFields{i,1})=modelFields{i,2};
+0108 <span class="keyword">end</span>
+0109 
+0110 <span class="comment">% If GECKO model</span>
+0111 <span class="keyword">if</span> any(contains(line_key,<span class="string">'geckoLight'</span>))
+0112     isGECKO=true;
+0113     ecFields = {<span class="string">'geckoLight'</span>, false;<span class="keyword">...</span>
+0114                       <span class="string">'rxns'</span>, {};<span class="keyword">...</span>
+0115                       <span class="string">'kcat'</span>, {};<span class="keyword">...</span>
+0116                     <span class="string">'source'</span>, cell(0,0);<span class="keyword">...</span>
+0117                      <span class="string">'notes'</span>, cell(0,0);<span class="keyword">...</span>
+0118                    <span class="string">'eccodes'</span>, cell(0,0);<span class="keyword">...</span>
+0119                      <span class="string">'genes'</span>, cell(0,0);<span class="keyword">...</span>
+0120                    <span class="string">'enzymes'</span>, cell(0,0);<span class="keyword">...</span>
+0121                         <span class="string">'mw'</span>, cell(0,0);<span class="keyword">...</span>
+0122                   <span class="string">'sequence'</span>, cell(0,0);<span class="keyword">...</span>
+0123                      <span class="string">'concs'</span>, cell(0,0);<span class="keyword">...</span>
+0124                  <span class="string">'rxnEnzMat'</span>, []};
+0125     <span class="keyword">for</span> i=1:size(ecFields,1)
+0126         model.ec.(ecFields{i,1})=ecFields{i,2};
+0127     <span class="keyword">end</span>
+0128     ecGecko=cell(25000,2);      ecGeckoNo=1;
+0129     enzStoich=cell(100000,3);   enzStoichNo=1;
+0130 <span class="keyword">else</span>
+0131     isGECKO=false;
+0132 <span class="keyword">end</span>
+0133 
+0134 section = 0;
+0135 metMiriams=cell(100000,3);   metMirNo=1;
+0136 rxnMiriams=cell(100000,3);   rxnMirNo=1;
+0137 geneMiriams=cell(100000,3);  genMirNo=1;
+0138 subSystems=cell(100000,2);   subSysNo=1;
+0139 eccodes=cell(100000,2);      ecCodeNo=1;
+0140 equations=cell(100000,3);   equatiNo=1;
+0141 
+0142 <span class="keyword">for</span> i=1:numel(line_key)
+0143     tline_raw = line_raw{i};
+0144     tline_key = line_key{i};
+0145     tline_value = line_value{i};
+0146     <span class="comment">% import different sections</span>
+0147     <span class="keyword">switch</span> tline_raw
+0148         <span class="keyword">case</span> <span class="string">'- metaData:'</span>
+0149             section = 1;
+0150             <span class="keyword">if</span> verbose
+0151                 fprintf(<span class="string">'\t%d\n'</span>, section);
+0152             <span class="keyword">end</span>
+0153             <span class="keyword">continue</span> <span class="comment">% Go to next line</span>
+0154         <span class="keyword">case</span> <span class="string">'- metabolites:'</span>
+0155             section = 2;
+0156             <span class="keyword">if</span> verbose
+0157                 fprintf(<span class="string">'\t%d\n'</span>, section);
+0158             <span class="keyword">end</span>
+0159             pos=0;
+0160             <span class="keyword">continue</span>
+0161         <span class="keyword">case</span> <span class="string">'- reactions:'</span>
+0162             section = 3;
+0163             <span class="keyword">if</span> verbose
+0164                 fprintf(<span class="string">'\t%d\n'</span>, section);
+0165             <span class="keyword">end</span>
+0166             pos=0;
+0167             <span class="keyword">continue</span>
+0168         <span class="keyword">case</span> <span class="string">'- genes:'</span>
+0169             section = 4;
+0170             <span class="keyword">if</span> verbose
+0171                 fprintf(<span class="string">'\t%d\n'</span>, section);
+0172             <span class="keyword">end</span>
+0173             pos=0;
+0174             <span class="keyword">continue</span>
+0175         <span class="keyword">case</span> <span class="string">'- compartments: !!omap'</span>
+0176             section = 5;
+0177             <span class="keyword">if</span> verbose
+0178                 fprintf(<span class="string">'\t%d\n'</span>, section);
+0179             <span class="keyword">end</span>
+0180             pos=0;
+0181             <span class="keyword">continue</span>
+0182         <span class="keyword">case</span> <span class="string">'- ec-rxns:'</span>
+0183             section = 6;
+0184             <span class="keyword">if</span> verbose
+0185                 fprintf(<span class="string">'\t%d\n'</span>, section);
+0186             <span class="keyword">end</span>
+0187             pos=0;
+0188             <span class="keyword">continue</span>
+0189         <span class="keyword">case</span> <span class="string">'- ec-enzymes:'</span>
+0190             section = 7;
+0191             <span class="keyword">if</span> verbose
+0192                 fprintf(<span class="string">'\t%d\n'</span>, section);
+0193             <span class="keyword">end</span>
+0194             pos=0;
+0195             <span class="keyword">continue</span>
+0196     <span class="keyword">end</span>
+0197 
+0198     <span class="comment">% skip over empty keys</span>
+0199     <span class="keyword">if</span> isempty(tline_raw) || (isempty(tline_key) &amp;&amp; contains(tline_raw,<span class="string">'!!omap'</span>))
+0200         <span class="keyword">continue</span>;
+0201     <span class="keyword">end</span>
+0202     
+0203     <span class="comment">% import metaData</span>
+0204     <span class="keyword">if</span> section == 1
+0205         <span class="keyword">switch</span> tline_key
+0206             <span class="keyword">case</span> {<span class="string">'short_name'</span>,<span class="string">'id'</span>} <span class="comment">%short_name used by human-GEM</span>
+0207                 model.id = tline_value;
+0208             <span class="keyword">case</span> <span class="string">'name'</span>
+0209                 model.name = tline_value;                
+0210             <span class="keyword">case</span> <span class="string">'full_name'</span> <span class="comment">%used by human-GEM</span>
+0211                 model.description = tline_value;
+0212             <span class="keyword">case</span> <span class="string">'version'</span>
+0213                 model.version = tline_value;
+0214             <span class="keyword">case</span> <span class="string">'date'</span>
+0215                 model.date = tline_value;                
+0216             <span class="keyword">case</span> <span class="string">'taxonomy'</span>
+0217                 model.annotation.taxonomy = tline_value;
+0218             <span class="keyword">case</span> {<span class="string">'description'</span>,<span class="string">'note'</span>} <span class="comment">%description used by human-GEM</span>
+0219                 model.annotation.note = tline_value;
+0220             <span class="keyword">case</span> <span class="string">'github'</span>
+0221                 model.annotation.sourceUrl = tline_value;
+0222             <span class="keyword">case</span> <span class="string">'givenName'</span>
+0223                 model.annotation.givenName = tline_value;
+0224             <span class="keyword">case</span> <span class="string">'familyName'</span>
+0225                 model.annotation.familyName = tline_value;
+0226             <span class="keyword">case</span> <span class="string">'authors'</span>
+0227                 model.annotation.authorList = tline_value;
+0228             <span class="keyword">case</span> <span class="string">'email'</span>
+0229                 model.annotation.email = tline_value;
+0230             <span class="keyword">case</span> <span class="string">'organization'</span>
+0231                 model.annotation.organization = tline_value;
+0232             <span class="keyword">case</span> <span class="string">'geckoLight'</span>
+0233                 <span class="keyword">if</span> strcmp(tline_value,<span class="string">'true'</span>)
+0234                     model.ec.geckoLight = true;
+0235                 <span class="keyword">end</span>
+0236         <span class="keyword">end</span>; <span class="keyword">continue</span>
+0237     <span class="keyword">end</span>
+0238 
+0239     <span class="comment">% import metabolites:</span>
+0240     <span class="keyword">if</span> section == 2
+0241         <span class="keyword">switch</span> tline_key
+0242             <span class="keyword">case</span> <span class="string">'id'</span>
+0243                 pos = pos + 1;
+0244                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'mets'</span>, tline_value,pos);
+0245                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0246             <span class="keyword">case</span> <span class="string">'name'</span>
+0247                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metNames'</span>, tline_value, pos);
+0248                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0249             <span class="keyword">case</span> <span class="string">'compartment'</span>
+0250                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metComps'</span>, tline_value, pos);
+0251                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0252             <span class="keyword">case</span> <span class="string">'formula'</span>
+0253                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metFormulas'</span>, tline_value, pos);
+0254                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0255             <span class="keyword">case</span> <span class="string">'charge'</span>
+0256                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metCharges'</span>, tline_value, pos);
+0257                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0258             <span class="keyword">case</span> <span class="string">'notes'</span>
+0259                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metNotes'</span>, tline_value, pos);
+0260                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0261             <span class="keyword">case</span> <span class="string">'inchis'</span>
+0262                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'inchis'</span>, tline_value, pos);
+0263                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0264             <span class="keyword">case</span> <span class="string">'smiles'</span>
+0265                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metSmiles'</span>, tline_value, pos);
+0266                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;    
+0267             <span class="keyword">case</span> <span class="string">'deltaG'</span>
+0268                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metDeltaG'</span>, tline_value, pos);
+0269                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;                                
+0270             <span class="keyword">case</span> <span class="string">'metFrom'</span>
+0271                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'metFrom'</span>, tline_value, pos);
+0272                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0273             <span class="keyword">case</span> <span class="string">'annotation'</span>
+0274                 readList = <span class="string">'annotation'</span>;
+0275             <span class="keyword">otherwise</span>
+0276                 <span class="keyword">switch</span> readList
+0277                     <span class="keyword">case</span> <span class="string">'annotation'</span>
+0278                         [metMiriams, miriamKey] = <a href="#_sub3" class="code" title="subfunction [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)">gatherAnnotation</a>(pos,metMiriams,tline_key,tline_value,miriamKey,metMirNo);
+0279                         metMirNo = metMirNo + 1;
+0280                     <span class="keyword">otherwise</span>
+0281                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
+0282                 <span class="keyword">end</span>
+0283         <span class="keyword">end</span>; <span class="keyword">continue</span>
+0284     <span class="keyword">end</span>
+0285 
+0286     <span class="comment">% import reactions:</span>
+0287     <span class="keyword">if</span> section == 3
+0288         <span class="keyword">switch</span> tline_key
+0289             <span class="keyword">case</span> <span class="string">'id'</span>
+0290                 pos = pos + 1;
+0291                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxns'</span>, tline_value,pos);
+0292                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0293             <span class="keyword">case</span> <span class="string">'name'</span>
+0294                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnNames'</span>, tline_value, pos);
+0295                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0296             <span class="keyword">case</span> <span class="string">'lower_bound'</span>
+0297                 model.lb(pos,1) = {tline_value};
+0298                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0299             <span class="keyword">case</span> <span class="string">'upper_bound'</span>
+0300                 model.ub(pos,1) = {tline_value};
+0301                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0302             <span class="keyword">case</span> <span class="string">'rev'</span>
+0303                 model.rev(pos,1) = {tline_value};
+0304                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0305             <span class="keyword">case</span> <span class="string">'gene_reaction_rule'</span>
+0306                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'grRules'</span>, tline_value, pos);
+0307                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0308             <span class="keyword">case</span> <span class="string">'rxnNotes'</span>
+0309                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnNotes'</span>, tline_value, pos);
+0310                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0311             <span class="keyword">case</span> <span class="string">'rxnFrom'</span>
+0312                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnFrom'</span>, tline_value, pos);
+0313                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0314             <span class="keyword">case</span> <span class="string">'deltaG'</span>
+0315                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnDeltaG'</span>, tline_value, pos);
+0316                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;                
+0317             <span class="keyword">case</span> <span class="string">'objective_coefficient'</span>
+0318                 model.c(pos,1) = 1;
+0319                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0320             <span class="keyword">case</span> <span class="string">'references'</span>
+0321                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnReferences'</span>, tline_value, pos);
+0322                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0323             <span class="keyword">case</span> <span class="string">'confidence_score'</span>
+0324                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'rxnConfidenceScores'</span>, tline_value, pos);
+0325                 readList=<span class="string">''</span>; miriamKey=<span class="string">''</span>;
+0326             <span class="keyword">case</span> <span class="string">'eccodes'</span>
+0327                 <span class="keyword">if</span> isempty(tline_value)
+0328                     readList = <span class="string">'eccodes'</span>;
+0329                 <span class="keyword">else</span>
+0330                     eccodes(ecCodeNo,1:2)={pos,tline_value};
+0331                     ecCodeNo=ecCodeNo+1;
+0332                 <span class="keyword">end</span>
+0333             <span class="keyword">case</span> <span class="string">'subsystem'</span>
+0334                 <span class="keyword">if</span> isempty(tline_value)
+0335                     readList = <span class="string">'subsystem'</span>;
+0336                 <span class="keyword">else</span>
+0337                     subSystems(subSysNo,1:2)={pos,tline_value};
+0338                     subSysNo=subSysNo+1;
+0339                 <span class="keyword">end</span>
+0340             <span class="keyword">case</span> <span class="string">'metabolites'</span>
+0341                 readList = <span class="string">'equation'</span>;
+0342             <span class="keyword">case</span> <span class="string">'annotation'</span>
+0343                 readList = <span class="string">'annotation'</span>;
+0344                 
+0345             <span class="keyword">otherwise</span>
+0346                 <span class="keyword">switch</span> readList
+0347                     <span class="keyword">case</span> <span class="string">'eccodes'</span>
+0348                         eccodes(ecCodeNo,1:2)={pos,regexprep(tline_value,<span class="string">'^ +- &quot;?(.*)&quot;?$'</span>,<span class="string">'$1'</span>)};
+0349                         ecCodeNo=ecCodeNo+1;
+0350                     <span class="keyword">case</span> <span class="string">'subsystem'</span>
+0351                         subSystems(subSysNo,1:2)={pos,regexprep(tline_value,<span class="string">'^ +- &quot;?(.*)&quot;?$'</span>,<span class="string">'$1'</span>)};
+0352                         subSysNo=subSysNo+1;
+0353                     <span class="keyword">case</span> <span class="string">'annotation'</span>
+0354                         [rxnMiriams, miriamKey,rxnMirNo] = <a href="#_sub3" class="code" title="subfunction [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)">gatherAnnotation</a>(pos,rxnMiriams,tline_key,tline_value,miriamKey,rxnMirNo);
+0355                         rxnMirNo=rxnMirNo+1;
+0356                     <span class="keyword">case</span> <span class="string">'equation'</span>
+0357                         coeff = sscanf(tline_value,<span class="string">'%f'</span>);
+0358                         equations(equatiNo,1:3)={pos,tline_key,coeff};
+0359                         equatiNo=equatiNo+1;
+0360                     <span class="keyword">otherwise</span>
+0361                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
+0362                 <span class="keyword">end</span>                
+0363         <span class="keyword">end</span>; <span class="keyword">continue</span>
+0364     <span class="keyword">end</span>
+0365 
+0366     <span class="comment">% import genes:</span>
+0367     <span class="keyword">if</span> section == 4
+0368         <span class="keyword">switch</span> tline_key
+0369             <span class="keyword">case</span> <span class="string">'id'</span>
+0370                 pos = pos + 1;
+0371                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'genes'</span>, tline_value, pos);
+0372                 readList = <span class="string">''</span>;
+0373                 miriamKey = <span class="string">''</span>;
+0374             <span class="keyword">case</span> <span class="string">'name'</span>
+0375                 model = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model, <span class="string">'geneShortNames'</span>, tline_value, pos);
+0376             <span class="keyword">case</span> <span class="string">'annotation'</span>
+0377                 readList = <span class="string">'annotation'</span>;
+0378             <span class="keyword">otherwise</span>
+0379                 <span class="keyword">switch</span> readList
+0380                     <span class="keyword">case</span> <span class="string">'annotation'</span>
+0381                         [geneMiriams, miriamKey] = <a href="#_sub3" class="code" title="subfunction [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)">gatherAnnotation</a>(pos,geneMiriams,tline_key,tline_value,miriamKey,genMirNo);
+0382                         genMirNo = genMirNo + 1;
+0383                     <span class="keyword">otherwise</span>
+0384                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
+0385                 <span class="keyword">end</span>
+0386         <span class="keyword">end</span>; <span class="keyword">continue</span>
+0387     <span class="keyword">end</span>
+0388 
+0389     <span class="comment">% import compartments:</span>
+0390     <span class="keyword">if</span> section == 5
+0391         model.comps(end+1,1) = {tline_key};
+0392         model.compNames(end+1,1) = {tline_value};
+0393     <span class="keyword">end</span>
+0394 
+0395     <span class="comment">% import ec reaction info</span>
+0396     <span class="keyword">if</span> section == 6
+0397         <span class="keyword">switch</span> tline_key
+0398             <span class="keyword">case</span> <span class="string">'id'</span>
+0399                 pos = pos + 1;
+0400                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'rxns'</span>, tline_value, pos);
+0401                 readList=<span class="string">''</span>;
+0402             <span class="keyword">case</span> <span class="string">'kcat'</span>
+0403                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'kcat'</span>, tline_value, pos);
+0404                 readList=<span class="string">''</span>;
+0405             <span class="keyword">case</span> <span class="string">'source'</span>
+0406                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'source'</span>, tline_value, pos);
+0407                 readList=<span class="string">''</span>;
+0408             <span class="keyword">case</span> <span class="string">'notes'</span>
+0409                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'notes'</span>, tline_value, pos);
+0410                 readList=<span class="string">''</span>;
+0411             <span class="keyword">case</span> <span class="string">'eccodes'</span>
+0412                 <span class="keyword">if</span> isempty(tline_value)
+0413                     readList = <span class="string">'eccodes'</span>;
+0414                 <span class="keyword">else</span>
+0415                     ecGecko(ecGeckoNo,1:2)={pos,tline_value};
+0416                     ecGeckoNo=ecGeckoNo+1;
+0417                 <span class="keyword">end</span>
+0418             <span class="keyword">case</span> <span class="string">'enzymes'</span>
+0419                 readList = <span class="string">'enzStoich'</span>;
+0420             <span class="keyword">otherwise</span>
+0421                 <span class="keyword">switch</span> readList
+0422                     <span class="keyword">case</span> <span class="string">'eccodes'</span>
+0423                         ecGecko(ecGeckoNo,1:2)={pos,regexprep(tline_value,<span class="string">'^ +- &quot;?(.*)&quot;?$'</span>,<span class="string">'$1'</span>)};
+0424                         ecGeckoNo=ecGeckoNo+1;
+0425                     <span class="keyword">case</span> <span class="string">'enzStoich'</span>
+0426                         coeff = sscanf(tline_value,<span class="string">'%f'</span>);
+0427                         enzStoich(enzStoichNo,1:3)={pos,tline_key,coeff};
+0428                         enzStoichNo=enzStoichNo+1;
+0429                     <span class="keyword">otherwise</span>
+0430                         error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
+0431                 <span class="keyword">end</span>
+0432         <span class="keyword">end</span>; <span class="keyword">continue</span>
+0433     <span class="keyword">end</span>
+0434 
+0435     <span class="comment">% import ec enzyme info</span>
+0436     <span class="keyword">if</span> section == 7
+0437         <span class="keyword">switch</span> tline_key
+0438             <span class="keyword">case</span> <span class="string">'genes'</span>
+0439                 pos = pos + 1;
+0440                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'genes'</span>, tline_value, pos);
+0441             <span class="keyword">case</span> <span class="string">'enzymes'</span>
+0442                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'enzymes'</span>, tline_value, pos);
+0443             <span class="keyword">case</span> <span class="string">'mw'</span>
+0444                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'mw'</span>, tline_value, pos);
+0445             <span class="keyword">case</span> <span class="string">'sequence'</span>
+0446                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'sequence'</span>, tline_value, pos);
+0447             <span class="keyword">case</span> <span class="string">'concs'</span>
+0448                 model.ec = <a href="#_sub2" class="code" title="subfunction model = readFieldValue(model, fieldName, value, pos)">readFieldValue</a>(model.ec, <span class="string">'concs'</span>, tline_value, pos);
+0449             <span class="keyword">otherwise</span>
+0450                 error([<span class="string">'Unknown entry in yaml file: '</span> tline_raw])
+0451         <span class="keyword">end</span>; <span class="keyword">continue</span>
+0452     <span class="keyword">end</span>
+0453 <span class="keyword">end</span>
+0454 
+0455 <span class="comment">%Parse annotations</span>
+0456 <span class="keyword">if</span> ~isempty(metMiriams)
+0457     locs = cell2mat(metMiriams(:,1));
+0458     <span class="keyword">for</span> i=unique(locs)'
+0459         model.metMiriams{i,1}.name=metMiriams(locs==i,2);
+0460         model.metMiriams{i,1}.value=metMiriams(locs==i,3);
+0461     <span class="keyword">end</span>
+0462 <span class="keyword">end</span>
+0463 <span class="keyword">if</span> ~isempty(rxnMiriams)
+0464     locs = cell2mat(rxnMiriams(:,1));
+0465     <span class="keyword">for</span> i=unique(locs)'
+0466         model.rxnMiriams{i,1}.name=rxnMiriams(locs==i,2);
+0467         model.rxnMiriams{i,1}.value=rxnMiriams(locs==i,3);
+0468     <span class="keyword">end</span>
+0469 <span class="keyword">end</span>
+0470 <span class="keyword">if</span> ~isempty(geneMiriams)
+0471     locs = cell2mat(geneMiriams(:,1));
+0472     <span class="keyword">for</span> i=unique(locs)'
+0473         model.geneMiriams{i,1}.name=geneMiriams(locs==i,2);
+0474         model.geneMiriams{i,1}.value=geneMiriams(locs==i,3);
+0475     <span class="keyword">end</span>
+0476 <span class="keyword">end</span>
+0477 
+0478 <span class="comment">%Parse subSystems</span>
+0479 <span class="keyword">if</span> ~isempty(subSystems)
+0480     locs = cell2mat(subSystems(:,1));
+0481     <span class="keyword">for</span> i=unique(locs)'
+0482         model.subSystems{i,1}=subSystems(locs==i,2);
+0483     <span class="keyword">end</span>
+0484 <span class="keyword">end</span>
+0485 
+0486 <span class="comment">%Parse ec-codes</span>
+0487 <span class="keyword">if</span> ~isempty(eccodes)
+0488     locs = cell2mat(eccodes(:,1));
+0489     <span class="keyword">for</span> i=unique(locs)'
+0490         eccodesCat=strjoin(eccodes(locs==i,2),<span class="string">';'</span>);
+0491         model.eccodes{i,1}=eccodesCat;
+0492     <span class="keyword">end</span>
+0493     emptyEc=cellfun(<span class="string">'isempty'</span>,model.eccodes);
+0494     model.eccodes(emptyEc)={<span class="string">''</span>};
+0495 <span class="keyword">end</span>
+0496 
+0497 <span class="comment">% follow-up data processing</span>
+0498 <span class="keyword">if</span> verbose
+0499     fprintf(<span class="string">'\nimporting completed\nfollow-up processing...'</span>);
+0500 <span class="keyword">end</span>
+0501 [~, model.metComps] = ismember(model.metComps, model.comps);
+0502 [~, model.geneComps] = ismember(model.geneComps, model.comps);
+0503 [~, model.rxnComps] = ismember(model.rxnComps, model.comps);
+0504 
+0505 <span class="comment">% Fill S-matrix</span>
+0506 rxnIdx = cellfun(<span class="string">'isempty'</span>, equations(:,1));
+0507 equations(rxnIdx,:) = <span class="string">''</span>;
+0508 rxnIdx = cell2mat(equations(:,1));
+0509 [~,metIdx] = ismember(equations(:,2),model.mets);
+0510 coeffs = cell2mat(equations(:,3));
+0511 model.S=sparse(max(metIdx),max(rxnIdx));
+0512 linearIndices = sub2ind([max(metIdx), max(rxnIdx)],metIdx,rxnIdx);
+0513 model.S(linearIndices) = coeffs;
+0514 
+0515 <span class="comment">% Convert strings to numeric</span>
+0516 model.metCharges = str2double(model.metCharges);
+0517 model.lb = str2double(model.lb);
+0518 model.ub = str2double(model.ub);
+0519 model.rxnConfidenceScores = str2double(model.rxnConfidenceScores);
+0520 model.b = zeros(length(model.mets),1);
+0521 model.metDeltaG = str2double(model.metDeltaG);
+0522 model.rxnDeltaG = str2double(model.rxnDeltaG);
+0523 
+0524 <span class="comment">% Fill some other fields</span>
+0525 model.annotation.defaultLB = min(model.lb);
+0526 model.annotation.defaultUB = max(model.ub);
+0527 <span class="keyword">if</span> numel(model.lb)&lt;numel(model.rxns) <span class="comment">%No LB reported = min</span>
+0528     model.lb(end+1:numel(model.rxns)-numel(model.lb),1) = double(model.annotation.defaultLB);
+0529 <span class="keyword">end</span>
+0530 <span class="keyword">if</span> numel(model.ub)&lt;numel(model.rxns) <span class="comment">%No UB reported = max</span>
+0531     model.ub(end+1:numel(model.rxns)-numel(model.ub),1) = double(model.annotation.defaultUB);
+0532 <span class="keyword">end</span>
+0533 <span class="keyword">if</span> ~all(cellfun(<span class="string">'isempty'</span>,model.rev))
+0534     model.rev = str2double(model.rev);
+0535 <span class="keyword">else</span>
+0536     model.rev = [];
+0537 <span class="keyword">end</span>
+0538 <span class="keyword">if</span> numel(model.rev)&lt;numel(model.rxns) <span class="comment">%No rev reported, assume from LB and UB</span>
+0539     model.rev(end+1:numel(model.rxns)-numel(model.rev),1) = double(model.lb&lt;0 &amp; model.ub&gt;0);
+0540 <span class="keyword">end</span>
+0541 
+0542 <span class="comment">% Remove empty fields, otherwise fill to correct length</span>
+0543 <span class="comment">% Reactions</span>
+0544 <span class="keyword">for</span> i={<span class="string">'rxnNames'</span>,<span class="string">'grRules'</span>,<span class="string">'eccodes'</span>,<span class="string">'rxnNotes'</span>,<span class="string">'rxnReferences'</span>,<span class="keyword">...</span>
+0545        <span class="string">'rxnFrom'</span>,<span class="string">'subSystems'</span>,<span class="string">'rxnMiriams'</span>} <span class="comment">% Empty strings</span>
+0546    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'rxns'</span>);
+0547 <span class="keyword">end</span>
+0548 <span class="keyword">for</span> i={<span class="string">'c'</span>} <span class="comment">% Zeros</span>
+0549    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},0,<span class="string">'rxns'</span>,true);
+0550 <span class="keyword">end</span>
+0551 <span class="keyword">for</span> i={<span class="string">'rxnConfidenceScores'</span>,<span class="string">'rxnDeltaG'</span>} <span class="comment">% NaNs</span>
+0552    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},NaN,<span class="string">'rxns'</span>);
+0553 <span class="keyword">end</span>
+0554 <span class="keyword">for</span> i={<span class="string">'rxnComps'</span>} <span class="comment">% Ones, assume first compartment</span>
+0555    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},1,<span class="string">'rxns'</span>);
+0556 <span class="keyword">end</span>
+0557 <span class="comment">% Metabolites</span>
+0558 <span class="keyword">for</span> i={<span class="string">'metNames'</span>,<span class="string">'inchis'</span>,<span class="string">'metFormulas'</span>,<span class="string">'metMiriams'</span>,<span class="string">'metFrom'</span>,<span class="string">'metSmiles'</span>,<span class="string">'metNotes'</span>} <span class="comment">% Empty strings</span>
+0559    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'mets'</span>);
+0560 <span class="keyword">end</span>
+0561 <span class="keyword">for</span> i={<span class="string">'metCharges'</span>,<span class="string">'unconstrained'</span>} <span class="comment">% Zeros</span>
+0562    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},0,<span class="string">'mets'</span>);
+0563 <span class="keyword">end</span>
+0564 <span class="keyword">for</span> i={<span class="string">'metDeltaG'</span>} <span class="comment">% % NaNs</span>
+0565     model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},NaN,<span class="string">'mets'</span>);
+0566  <span class="keyword">end</span>
+0567 <span class="keyword">for</span> i={<span class="string">'metComps'</span>} <span class="comment">% Ones, assume first compartment</span>
+0568    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},1,<span class="string">'mets'</span>);
+0569 <span class="keyword">end</span>
+0570 <span class="comment">% Genes</span>
+0571 <span class="keyword">for</span> i={<span class="string">'geneMiriams'</span>,<span class="string">'geneShortNames'</span>} <span class="comment">% Empty strings</span>
+0572    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'genes'</span>);
+0573 <span class="keyword">end</span>
+0574 <span class="keyword">for</span> i={<span class="string">'geneComps'</span>} <span class="comment">% Ones, assume first compartment</span>
+0575    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},1,<span class="string">'genes'</span>);
+0576 <span class="keyword">end</span>
+0577 <span class="comment">% Comps</span>
+0578 <span class="keyword">for</span> i={<span class="string">'compNames'</span>} <span class="comment">% Empty strings</span>
+0579    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},{<span class="string">''</span>},<span class="string">'comps'</span>);
+0580 <span class="keyword">end</span>
+0581 <span class="keyword">for</span> i={<span class="string">'compOutside'</span>} <span class="comment">% First comp</span>
+0582    model = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model,i{1},model.comps{1},<span class="string">'comps'</span>);
+0583 <span class="keyword">end</span>
+0584 <span class="comment">% Single fields are kept, even if empty</span>
+0585 <span class="comment">% for i={'description','name','version','date','annotation'}</span>
+0586 <span class="comment">%     if isempty(model.(i{1}))</span>
+0587 <span class="comment">%         model = rmfield(model,i{1});</span>
+0588 <span class="comment">%     end</span>
+0589 <span class="comment">% end</span>
+0590 
+0591 <span class="comment">% Make rxnGeneMat fields and map to the existing model.genes field</span>
+0592 [genes, rxnGeneMat] = getGenesFromGrRules(model.grRules);
+0593 model.rxnGeneMat = sparse(numel(model.rxns),numel(model.genes));
+0594 [~,geneOrder] = ismember(genes,model.genes);
+0595 <span class="keyword">if</span> any(geneOrder == 0)
+0596     error([<span class="string">'The grRules includes the following gene(s), that are not in '</span><span class="keyword">...</span>
+0597            <span class="string">'the list of model genes: '</span>, genes{~geneOrder}])
+0598 <span class="keyword">end</span>
+0599 model.rxnGeneMat(:,geneOrder) = rxnGeneMat;
+0600 
+0601 <span class="comment">% Finalize GECKO model</span>
+0602 <span class="keyword">if</span> isGECKO
+0603     <span class="comment">% Fill in empty fields and empty entries</span>
+0604     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'source'</span>,<span class="string">'notes'</span>,<span class="string">'eccodes'</span>} <span class="comment">% Even keep empty</span>
+0605         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'rxns'</span>,true);
+0606     <span class="keyword">end</span>
+0607     <span class="keyword">for</span> i={<span class="string">'enzymes'</span>,<span class="string">'mw'</span>,<span class="string">'sequence'</span>}
+0608         model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,i{1},{<span class="string">''</span>},<span class="string">'genes'</span>,true);
+0609     <span class="keyword">end</span>
+0610     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'concs'</span>,{<span class="string">'NaN'</span>},<span class="string">'genes'</span>,true);
+0611     model.ec = <a href="#_sub1" class="code" title="subfunction model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)">emptyOrFill</a>(model.ec,<span class="string">'kcat'</span>,{<span class="string">'0'</span>},<span class="string">'genes'</span>,true);
+0612     <span class="comment">% Change string to double</span>
+0613     <span class="keyword">for</span> i={<span class="string">'kcat'</span>,<span class="string">'mw'</span>,<span class="string">'concs'</span>}
+0614         <span class="keyword">if</span> isfield(model.ec,i{1})
+0615             model.ec.(i{1}) = str2double(model.ec.(i{1}));
+0616         <span class="keyword">end</span>
+0617     <span class="keyword">end</span>
+0618     <span class="comment">% Fill rxnEnzMat</span>
+0619     rxnIdx              = cellfun(<span class="string">'isempty'</span>, enzStoich(:,1));
+0620     enzStoich(rxnIdx,:) = <span class="string">''</span>;
+0621     rxnIdx              = cell2mat(enzStoich(:,1));
+0622     [~,enzIdx]          = ismember(enzStoich(:,2),model.ec.enzymes);
+0623     coeffs              = cell2mat(enzStoich(:,3));
+0624     model.ec.rxnEnzMat  = zeros(max(rxnIdx), max(enzIdx));
+0625     linearIndices       = sub2ind([max(rxnIdx), max(enzIdx)], rxnIdx, enzIdx);
+0626     model.ec.rxnEnzMat(linearIndices) = coeffs;
+0627     <span class="comment">%Parse ec-codes</span>
+0628     <span class="keyword">if</span> ~isempty(ecGecko)
+0629         locs = cell2mat(ecGecko(:,1));
+0630         <span class="keyword">for</span> i=unique(locs)'
+0631             ecGeckoCat=strjoin(ecGecko(locs==i,2),<span class="string">';'</span>);
+0632             model.ec.eccodes{i,1}=ecGeckoCat;
+0633         <span class="keyword">end</span>
+0634         emptyEc=cellfun(<span class="string">'isempty'</span>,model.ec.eccodes);
+0635         model.ec.eccodes(emptyEc)={<span class="string">''</span>};
+0636     <span class="keyword">end</span>
+0637 <span class="keyword">end</span>
+0638 
+0639 <span class="keyword">if</span> verbose
+0640     fprintf(<span class="string">' Done!\n'</span>);
+0641 <span class="keyword">end</span>
+0642 <span class="keyword">end</span>
+0643 
+0644 <a name="_sub1" href="#_subfunctions" class="code">function model = emptyOrFill(model,field,emptyEntry,type,keepEmpty)</a>
+0645 <span class="keyword">if</span> nargin&lt;5
+0646     keepEmpty=false;
+0647 <span class="keyword">end</span>
+0648 <span class="keyword">if</span> isnumeric(emptyEntry)
+0649     emptyCells=isempty(model.(field));
+0650 <span class="keyword">else</span>
+0651     emptyCells=cellfun(<span class="string">'isempty'</span>,model.(field));
+0652 <span class="keyword">end</span>
+0653 <span class="keyword">if</span> all(emptyCells) &amp;&amp; ~keepEmpty
+0654     model = rmfield(model, field);
+0655 <span class="keyword">elseif</span> numel(model.(field))&lt;numel(model.(type))
+0656     model.(field)(end+1:numel(model.(type)),1)=emptyEntry;
+0657 <span class="keyword">end</span>
+0658 <span class="keyword">end</span>
+0659 
+0660 <a name="_sub2" href="#_subfunctions" class="code">function model = readFieldValue(model, fieldName, value, pos)</a>
+0661 <span class="keyword">if</span> numel(model.(fieldName))&lt;pos-1
+0662     model.(fieldName)(end+1:pos,1) = {<span class="string">''</span>};
 0663 <span class="keyword">end</span>
-0664 
-0665 <a name="_sub3" href="#_subfunctions" class="code">function [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)</a>
-0666 <span class="keyword">if</span> isempty(key)
-0667     key=miriamKey;
-0668 <span class="keyword">else</span>
-0669     miriamKey=key;
-0670 <span class="keyword">end</span>
-0671 <span class="keyword">if</span> ~isempty(value)
-0672     miriams(entryNumber,1:3) = {pos, key, strip(value)};
-0673 <span class="keyword">else</span>
-0674     entryNumber = entryNumber - 1;
-0675 <span class="keyword">end</span>
-0676 <span class="keyword">end</span></pre></div>
+0664 model.(fieldName)(pos,1) = {value};
+0665 <span class="keyword">end</span>
+0666 
+0667 <a name="_sub3" href="#_subfunctions" class="code">function [miriams, miriamKey,entryNumber] = gatherAnnotation(pos,miriams,key,value,miriamKey,entryNumber)</a>
+0668 <span class="keyword">if</span> isempty(key)
+0669     key=miriamKey;
+0670 <span class="keyword">else</span>
+0671     miriamKey=key;
+0672 <span class="keyword">end</span>
+0673 <span class="keyword">if</span> ~isempty(value)
+0674     miriams(entryNumber,1:3) = {pos, key, strip(value)};
+0675 <span class="keyword">else</span>
+0676     entryNumber = entryNumber - 1;
+0677 <span class="keyword">end</span>
+0678 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/doc/struct_conversion/ravenCobraWrapper.html
+++ b/doc/struct_conversion/ravenCobraWrapper.html
@@ -382,134 +382,138 @@ This function is called by:
 0307     <span class="keyword">if</span> isfield(newModel,<span class="string">'rxnReferences'</span>)
 0308         emptyEntry = cellfun(@isempty,newModel.rxnReferences);
 0309         newModel.rxnReferences(emptyEntry)={<span class="string">''</span>};
-0310     <span class="keyword">end</span>
-0311     <span class="keyword">if</span> any(isfield(model,geneCOBRAfields))
-0312         <span class="keyword">for</span> i=1:numel(model.genes)
-0313             counter=1;
-0314             newModel.geneMiriams{i,1}=[];
-0315             <span class="keyword">for</span> j = 1:length(geneCOBRAfields)
-0316                 <span class="keyword">if</span> isfield(model,geneCOBRAfields{j})
-0317                     geneAnnotation = eval([<span class="string">'model.'</span> geneCOBRAfields{j} <span class="string">'{i}'</span>]);
-0318                     <span class="keyword">if</span> ~isempty(geneAnnotation)
-0319                         geneAnnotation = strtrim(strsplit(geneAnnotation,<span class="string">';'</span>));
-0320                         <span class="keyword">for</span> a=1:length(geneAnnotation)
-0321                             newModel.geneMiriams{i,1}.name{counter,1} = geneNamespaces{j};
-0322                             newModel.geneMiriams{i,1}.value{counter,1} = geneAnnotation{a};
-0323                             counter=counter+1;
-0324                         <span class="keyword">end</span>
-0325                     <span class="keyword">end</span>
-0326                 <span class="keyword">end</span>
-0327             <span class="keyword">end</span>
-0328         <span class="keyword">end</span>
-0329     <span class="keyword">end</span>
-0330     <span class="keyword">if</span> isfield(model,<span class="string">'geneNames'</span>)
-0331         newModel.geneShortNames=model.geneNames;
-0332     <span class="keyword">end</span>
-0333     newModel.metNames=model.metNames;
-0334     <span class="keyword">for</span> i=1:numel(newModel.comps)
-0335         newModel.metNames=regexprep(newModel.metNames,[<span class="string">'\['</span>, newModel.comps{i}, <span class="string">'\]$'</span>],<span class="string">''</span>);
-0336         newModel.metNames=regexprep(newModel.metNames,[<span class="string">'\['</span>, newModel.compNames{i}, <span class="string">'\]$'</span>],<span class="string">''</span>);
-0337     <span class="keyword">end</span>
-0338     newModel.metNames=deblank(newModel.metNames);
-0339     newModel.metComps=regexprep(model.mets,<span class="string">'^.+\['</span>,<span class="string">''</span>);
-0340     newModel.metComps=regexprep(newModel.metComps,<span class="string">'\]$'</span>,<span class="string">''</span>);
-0341     [~, newModel.metComps]=ismember(newModel.metComps,newModel.comps);
-0342     <span class="keyword">if</span> isfield(model,<span class="string">'metInChIString'</span>)
-0343         newModel.inchis=regexprep(model.metInChIString,<span class="string">'^InChI='</span>,<span class="string">''</span>);
-0344     <span class="keyword">end</span>
-0345     printWarning=false;
-0346     <span class="keyword">if</span> any(isfield(model,[metCOBRAfields;<span class="string">'metKEGGID'</span>;<span class="string">'metPubChemID'</span>]))
-0347         <span class="keyword">for</span> i=1:numel(model.mets)
-0348             counter=1;
-0349             newModel.metMiriams{i,1}=[];
-0350             <span class="keyword">if</span> isfield(model,<span class="string">'metKEGGID'</span>)
-0351                 <span class="keyword">if</span> ~isempty(model.metKEGGID{i})
-0352                     <span class="keyword">if</span> strcmp(model.metKEGGID{i}(1),<span class="string">'C'</span>)
-0353                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'kegg.compound'</span>;
-0354                         newModel.metMiriams{i,1}.value{counter,1} = model.metKEGGID{i};
-0355                         counter=counter+1;
-0356                     <span class="keyword">elseif</span> strcmp(model.metKEGGID{i}(1),<span class="string">'G'</span>)
-0357                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'kegg.glycan'</span>;
+0310         diffNumel = numel(newModel.rxns) - numel(newModel.rxnReferences);
+0311         <span class="keyword">if</span> diffNumel &gt; 0
+0312             newModel.rxnReferences(end+1:end+diffNumel) = {<span class="string">''</span>};
+0313         <span class="keyword">end</span>
+0314     <span class="keyword">end</span>
+0315     <span class="keyword">if</span> any(isfield(model,geneCOBRAfields))
+0316         <span class="keyword">for</span> i=1:numel(model.genes)
+0317             counter=1;
+0318             newModel.geneMiriams{i,1}=[];
+0319             <span class="keyword">for</span> j = 1:length(geneCOBRAfields)
+0320                 <span class="keyword">if</span> isfield(model,geneCOBRAfields{j})
+0321                     geneAnnotation = eval([<span class="string">'model.'</span> geneCOBRAfields{j} <span class="string">'{i}'</span>]);
+0322                     <span class="keyword">if</span> ~isempty(geneAnnotation)
+0323                         geneAnnotation = strtrim(strsplit(geneAnnotation,<span class="string">';'</span>));
+0324                         <span class="keyword">for</span> a=1:length(geneAnnotation)
+0325                             newModel.geneMiriams{i,1}.name{counter,1} = geneNamespaces{j};
+0326                             newModel.geneMiriams{i,1}.value{counter,1} = geneAnnotation{a};
+0327                             counter=counter+1;
+0328                         <span class="keyword">end</span>
+0329                     <span class="keyword">end</span>
+0330                 <span class="keyword">end</span>
+0331             <span class="keyword">end</span>
+0332         <span class="keyword">end</span>
+0333     <span class="keyword">end</span>
+0334     <span class="keyword">if</span> isfield(model,<span class="string">'geneNames'</span>)
+0335         newModel.geneShortNames=model.geneNames;
+0336     <span class="keyword">end</span>
+0337     newModel.metNames=model.metNames;
+0338     <span class="keyword">for</span> i=1:numel(newModel.comps)
+0339         newModel.metNames=regexprep(newModel.metNames,[<span class="string">'\['</span>, newModel.comps{i}, <span class="string">'\]$'</span>],<span class="string">''</span>);
+0340         newModel.metNames=regexprep(newModel.metNames,[<span class="string">'\['</span>, newModel.compNames{i}, <span class="string">'\]$'</span>],<span class="string">''</span>);
+0341     <span class="keyword">end</span>
+0342     newModel.metNames=deblank(newModel.metNames);
+0343     newModel.metComps=regexprep(model.mets,<span class="string">'^.+\['</span>,<span class="string">''</span>);
+0344     newModel.metComps=regexprep(newModel.metComps,<span class="string">'\]$'</span>,<span class="string">''</span>);
+0345     [~, newModel.metComps]=ismember(newModel.metComps,newModel.comps);
+0346     <span class="keyword">if</span> isfield(model,<span class="string">'metInChIString'</span>)
+0347         newModel.inchis=regexprep(model.metInChIString,<span class="string">'^InChI='</span>,<span class="string">''</span>);
+0348     <span class="keyword">end</span>
+0349     printWarning=false;
+0350     <span class="keyword">if</span> any(isfield(model,[metCOBRAfields;<span class="string">'metKEGGID'</span>;<span class="string">'metPubChemID'</span>]))
+0351         <span class="keyword">for</span> i=1:numel(model.mets)
+0352             counter=1;
+0353             newModel.metMiriams{i,1}=[];
+0354             <span class="keyword">if</span> isfield(model,<span class="string">'metKEGGID'</span>)
+0355                 <span class="keyword">if</span> ~isempty(model.metKEGGID{i})
+0356                     <span class="keyword">if</span> strcmp(model.metKEGGID{i}(1),<span class="string">'C'</span>)
+0357                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'kegg.compound'</span>;
 0358                         newModel.metMiriams{i,1}.value{counter,1} = model.metKEGGID{i};
 0359                         counter=counter+1;
-0360                     <span class="keyword">end</span>
-0361                 <span class="keyword">end</span>
-0362             <span class="keyword">end</span>
-0363             <span class="keyword">if</span> isfield(model,<span class="string">'metPubChemID'</span>)
-0364                 <span class="keyword">if</span> ~isempty(model.metPubChemID{i})
-0365                     <span class="keyword">if</span> length(model.metPubChemID{i})&gt;3 &amp;&amp; strcmp(model.metPubChemID{i}(1:4),<span class="string">'CID:'</span>)
-0366                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'pubchem.compound'</span>;
-0367                         newModel.metMiriams{i,1}.value{counter,1} = model.metPubChemID{i};
-0368                         counter=counter+1;
-0369                     <span class="keyword">elseif</span> length(model.metPubChemID{i})&gt;3 &amp;&amp; strcmp(model.metPubChemID{i}(1:4),<span class="string">'SID:'</span>)
-0370                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'pubchem.substance'</span>;
+0360                     <span class="keyword">elseif</span> strcmp(model.metKEGGID{i}(1),<span class="string">'G'</span>)
+0361                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'kegg.glycan'</span>;
+0362                         newModel.metMiriams{i,1}.value{counter,1} = model.metKEGGID{i};
+0363                         counter=counter+1;
+0364                     <span class="keyword">end</span>
+0365                 <span class="keyword">end</span>
+0366             <span class="keyword">end</span>
+0367             <span class="keyword">if</span> isfield(model,<span class="string">'metPubChemID'</span>)
+0368                 <span class="keyword">if</span> ~isempty(model.metPubChemID{i})
+0369                     <span class="keyword">if</span> length(model.metPubChemID{i})&gt;3 &amp;&amp; strcmp(model.metPubChemID{i}(1:4),<span class="string">'CID:'</span>)
+0370                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'pubchem.compound'</span>;
 0371                         newModel.metMiriams{i,1}.value{counter,1} = model.metPubChemID{i};
 0372                         counter=counter+1;
-0373                     <span class="keyword">else</span>
-0374                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'pubchem.compound'</span>;
+0373                     <span class="keyword">elseif</span> length(model.metPubChemID{i})&gt;3 &amp;&amp; strcmp(model.metPubChemID{i}(1:4),<span class="string">'SID:'</span>)
+0374                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'pubchem.substance'</span>;
 0375                         newModel.metMiriams{i,1}.value{counter,1} = model.metPubChemID{i};
 0376                         counter=counter+1;
-0377                         printWarning=true;
-0378                     <span class="keyword">end</span>
-0379                 <span class="keyword">end</span>
-0380             <span class="keyword">end</span>            
-0381             <span class="keyword">for</span> j = 1:length(metCOBRAfields)
-0382                 <span class="keyword">if</span> isfield(model,metCOBRAfields{j})
-0383                     metAnnotation = eval([<span class="string">'model.'</span> metCOBRAfields{j} <span class="string">'{i}'</span>]);
-0384                     <span class="keyword">if</span> ~isempty(metAnnotation)
-0385                         metAnnotation = strtrim(strsplit(metAnnotation,<span class="string">';'</span>));
-0386                         <span class="keyword">for</span> a=1:length(metAnnotation)
-0387                             newModel.metMiriams{i,1}.name{counter,1} = metNamespaces{j};
-0388                             newModel.metMiriams{i,1}.value{counter,1} = metAnnotation{a};
-0389                             counter=counter+1;
-0390                         <span class="keyword">end</span>
-0391                     <span class="keyword">end</span>
-0392                 <span class="keyword">end</span>
-0393             <span class="keyword">end</span>
-0394         <span class="keyword">end</span>
-0395     <span class="keyword">end</span>
-0396     <span class="keyword">if</span> printWarning
-0397         fprintf(<span class="string">'Could not determine whether PubChemIDs are compounds (CID)\n or substances (SID). All annotated PubChemIDs will therefore \n be assigned as compounds (CID).\n'</span>);
-0398     <span class="keyword">end</span>
-0399 <span class="keyword">end</span>
-0400 
-0401 <span class="comment">% Order fields</span>
-0402 newModel=<a href="standardizeModelFieldOrder.html" class="code" title="function orderedModel=standardizeModelFieldOrder(model)">standardizeModelFieldOrder</a>(newModel); <span class="comment">% Corrects for both RAVEN and COBRA models</span>
+0377                     <span class="keyword">else</span>
+0378                         newModel.metMiriams{i,1}.name{counter,1} = <span class="string">'pubchem.compound'</span>;
+0379                         newModel.metMiriams{i,1}.value{counter,1} = model.metPubChemID{i};
+0380                         counter=counter+1;
+0381                         printWarning=true;
+0382                     <span class="keyword">end</span>
+0383                 <span class="keyword">end</span>
+0384             <span class="keyword">end</span>            
+0385             <span class="keyword">for</span> j = 1:length(metCOBRAfields)
+0386                 <span class="keyword">if</span> isfield(model,metCOBRAfields{j})
+0387                     metAnnotation = eval([<span class="string">'model.'</span> metCOBRAfields{j} <span class="string">'{i}'</span>]);
+0388                     <span class="keyword">if</span> ~isempty(metAnnotation)
+0389                         metAnnotation = strtrim(strsplit(metAnnotation,<span class="string">';'</span>));
+0390                         <span class="keyword">for</span> a=1:length(metAnnotation)
+0391                             newModel.metMiriams{i,1}.name{counter,1} = metNamespaces{j};
+0392                             newModel.metMiriams{i,1}.value{counter,1} = metAnnotation{a};
+0393                             counter=counter+1;
+0394                         <span class="keyword">end</span>
+0395                     <span class="keyword">end</span>
+0396                 <span class="keyword">end</span>
+0397             <span class="keyword">end</span>
+0398         <span class="keyword">end</span>
+0399     <span class="keyword">end</span>
+0400     <span class="keyword">if</span> printWarning
+0401         fprintf(<span class="string">'Could not determine whether PubChemIDs are compounds (CID)\n or substances (SID). All annotated PubChemIDs will therefore \n be assigned as compounds (CID).\n'</span>);
+0402     <span class="keyword">end</span>
 0403 <span class="keyword">end</span>
 0404 
-0405 <a name="_sub1" href="#_subfunctions" class="code">function rules=grrulesToRules(model)</a>
-0406 <span class="comment">%This function just takes grRules, changes all gene names to</span>
-0407 <span class="comment">%'x(geneNumber)' and also changes 'or' and 'and' relations to corresponding</span>
-0408 <span class="comment">%symbols</span>
-0409 replacingGenes=cell([size(model.genes,1) 1]);
-0410 <span class="keyword">for</span> i=1:numel(replacingGenes)
-0411     replacingGenes{i}=strcat(<span class="string">'x('</span>,num2str(i),<span class="string">')'</span>);
-0412 <span class="keyword">end</span>
-0413 rules = strcat({<span class="string">' '</span>},model.grRules,{<span class="string">' '</span>});
-0414 <span class="keyword">for</span> i=1:length(model.genes)
-0415     rules=regexprep(rules,[<span class="string">' '</span> model.genes{i} <span class="string">' '</span>],[<span class="string">' '</span> replacingGenes{i} <span class="string">' '</span>]);
-0416     rules=regexprep(rules,[<span class="string">'('</span> model.genes{i} <span class="string">' '</span>],[<span class="string">'('</span> replacingGenes{i} <span class="string">' '</span>]);
-0417     rules=regexprep(rules,[<span class="string">' '</span> model.genes{i} <span class="string">')'</span>],[<span class="string">' '</span> replacingGenes{i} <span class="string">')'</span>]);
-0418 <span class="keyword">end</span>
-0419 rules=regexprep(rules,<span class="string">' and '</span>,<span class="string">' &amp; '</span>);
-0420 rules=regexprep(rules,<span class="string">' or '</span>,<span class="string">' | '</span>);
-0421 rules=strtrim(rules);
+0405 <span class="comment">% Order fields</span>
+0406 newModel=<a href="standardizeModelFieldOrder.html" class="code" title="function orderedModel=standardizeModelFieldOrder(model)">standardizeModelFieldOrder</a>(newModel); <span class="comment">% Corrects for both RAVEN and COBRA models</span>
+0407 <span class="keyword">end</span>
+0408 
+0409 <a name="_sub1" href="#_subfunctions" class="code">function rules=grrulesToRules(model)</a>
+0410 <span class="comment">%This function just takes grRules, changes all gene names to</span>
+0411 <span class="comment">%'x(geneNumber)' and also changes 'or' and 'and' relations to corresponding</span>
+0412 <span class="comment">%symbols</span>
+0413 replacingGenes=cell([size(model.genes,1) 1]);
+0414 <span class="keyword">for</span> i=1:numel(replacingGenes)
+0415     replacingGenes{i}=strcat(<span class="string">'x('</span>,num2str(i),<span class="string">')'</span>);
+0416 <span class="keyword">end</span>
+0417 rules = strcat({<span class="string">' '</span>},model.grRules,{<span class="string">' '</span>});
+0418 <span class="keyword">for</span> i=1:length(model.genes)
+0419     rules=regexprep(rules,[<span class="string">' '</span> model.genes{i} <span class="string">' '</span>],[<span class="string">' '</span> replacingGenes{i} <span class="string">' '</span>]);
+0420     rules=regexprep(rules,[<span class="string">'('</span> model.genes{i} <span class="string">' '</span>],[<span class="string">'('</span> replacingGenes{i} <span class="string">' '</span>]);
+0421     rules=regexprep(rules,[<span class="string">' '</span> model.genes{i} <span class="string">')'</span>],[<span class="string">' '</span> replacingGenes{i} <span class="string">')'</span>]);
 0422 <span class="keyword">end</span>
-0423 
-0424 <a name="_sub2" href="#_subfunctions" class="code">function grRules=rulesTogrrules(model)</a>
-0425 <span class="comment">%This function takes rules, replaces &amp;/| for and/or, replaces the x(i)</span>
-0426 <span class="comment">%format with the actual gene ID, and takes out extra whitespace and</span>
-0427 <span class="comment">%redundant parenthesis introduced by COBRA, to create grRules.</span>
-0428 grRules = strrep(model.rules,<span class="string">'&amp;'</span>,<span class="string">'and'</span>);
-0429 grRules = strrep(grRules,<span class="string">'|'</span>,<span class="string">'or'</span>);
-0430 <span class="keyword">for</span> i = 1:length(model.genes)
-0431     grRules = strrep(grRules,[<span class="string">'x('</span> num2str(i) <span class="string">')'</span>],model.genes{i});
-0432 <span class="keyword">end</span>
-0433 grRules = strrep(grRules,<span class="string">'( '</span>,<span class="string">'('</span>);
-0434 grRules = strrep(grRules,<span class="string">' )'</span>,<span class="string">')'</span>);
-0435 grRules = regexprep(grRules,<span class="string">'^('</span>,<span class="string">''</span>); <span class="comment">%rules that start with a &quot;(&quot;</span>
-0436 grRules = regexprep(grRules,<span class="string">')$'</span>,<span class="string">''</span>); <span class="comment">%rules that end with a &quot;)&quot;</span>
-0437 <span class="keyword">end</span></pre></div>
+0423 rules=regexprep(rules,<span class="string">' and '</span>,<span class="string">' &amp; '</span>);
+0424 rules=regexprep(rules,<span class="string">' or '</span>,<span class="string">' | '</span>);
+0425 rules=strtrim(rules);
+0426 <span class="keyword">end</span>
+0427 
+0428 <a name="_sub2" href="#_subfunctions" class="code">function grRules=rulesTogrrules(model)</a>
+0429 <span class="comment">%This function takes rules, replaces &amp;/| for and/or, replaces the x(i)</span>
+0430 <span class="comment">%format with the actual gene ID, and takes out extra whitespace and</span>
+0431 <span class="comment">%redundant parenthesis introduced by COBRA, to create grRules.</span>
+0432 grRules = strrep(model.rules,<span class="string">'&amp;'</span>,<span class="string">'and'</span>);
+0433 grRules = strrep(grRules,<span class="string">'|'</span>,<span class="string">'or'</span>);
+0434 <span class="keyword">for</span> i = 1:length(model.genes)
+0435     grRules = strrep(grRules,[<span class="string">'x('</span> num2str(i) <span class="string">')'</span>],model.genes{i});
+0436 <span class="keyword">end</span>
+0437 grRules = strrep(grRules,<span class="string">'( '</span>,<span class="string">'('</span>);
+0438 grRules = strrep(grRules,<span class="string">' )'</span>,<span class="string">')'</span>);
+0439 grRules = regexprep(grRules,<span class="string">'^('</span>,<span class="string">''</span>); <span class="comment">%rules that start with a &quot;(&quot;</span>
+0440 grRules = regexprep(grRules,<span class="string">')$'</span>,<span class="string">''</span>); <span class="comment">%rules that end with a &quot;)&quot;</span>
+0441 <span class="keyword">end</span></pre></div>
 <hr><address>Generated by <strong><a href="http://www.artefact.tk/software/matlab/m2html/" title="Matlab Documentation in HTML">m2html</a></strong> &copy; 2005</address>
 </body>
 </html>

--- a/external/getBlast.m
+++ b/external/getBlast.m
@@ -99,7 +99,7 @@ cores = cores{1};
 
 %Create a database for the new organism and blast each of the refFastaFiles
 %against it
-[status, ~]=system(['"' fullfile(ravenPath,'software','blast+',['makeblastdb' binEnd]) '" -in ' fastaFile{1} ' -out "' fullfile(tmpDB, 'tmpDB') '" -dbtype prot']);
+[status, message]=system(['"' fullfile(ravenPath,'software','blast+',['makeblastdb' binEnd]) '" -in "' fastaFile{1} '" -out "' fullfile(tmpDB, 'tmpDB') '" -dbtype prot']);
 if developMode
     blastReport.dbHashes.phr{numel(blastReport.dbHashes.phr)+1}=getMD5Hash(fullfile(tmpDB, 'tmpDB.phr'));
     blastReport.dbHashes.pot{numel(blastReport.dbHashes.pot)+1}=getMD5Hash(fullfile(tmpDB, 'tmpDB.pot'));
@@ -107,21 +107,19 @@ if developMode
     blastReport.dbHashes.pto{numel(blastReport.dbHashes.pto)+1}=getMD5Hash(fullfile(tmpDB, 'tmpDB.pto'));
 end
 if status~=0
-    EM=['makeblastdb did not run successfully, error: ', num2str(status)];
-    dispEM(EM,true);
+    error('makeblastdb did not run successfully, error:\n%s',strip(message))
 end
 
 for i=1:numel(refFastaFiles)
     if ~hideVerbose
         fprintf(['BLASTing "' modelIDs{i} '" against "' organismID{1} '"..\n']);
     end
-    [status, ~]=system(['"' fullfile(ravenPath,'software','blast+',['blastp' binEnd]) '" -query ' refFastaFiles{i} ' -out "' outFile '_' num2str(i) '" -db "' fullfile(tmpDB, 'tmpDB') '" -evalue 10e-5 -outfmt "10 qseqid sseqid evalue pident length bitscore ppos" -num_threads "' cores '"']);
+    [status, message]=system(['"' fullfile(ravenPath,'software','blast+',['blastp' binEnd]) '" -query "' refFastaFiles{i} '" -out "' outFile '_' num2str(i) '" -db "' fullfile(tmpDB, 'tmpDB') '" -evalue 10e-5 -outfmt "10 qseqid sseqid evalue pident length bitscore ppos" -num_threads "' cores '"']);
     if developMode
         blastReport.blastTxtOutput{numel(blastReport.blastTxtOutput)+1}=importdata([outFile '_' num2str(i)]);
     end
     if status~=0
-        EM=['blastp did not run successfully, error: ', num2str(status)];
-        dispEM(EM,true);
+        error('blastp did not run successfully, error:\n%s',strip(message))
     end
 end
 delete([tmpDB filesep 'tmpDB*']);
@@ -132,12 +130,11 @@ for i=1:numel(refFastaFiles)
     if ~hideVerbose
         fprintf(['BLASTing "' organismID{1} '" against "' modelIDs{i} '"..\n']);
     end
-    [status, ~]=system(['"' fullfile(ravenPath,'software','blast+',['makeblastdb' binEnd]) '" -in ' refFastaFiles{i} ' -out "' fullfile(tmpDB, 'tmpDB') '" -dbtype prot']);
+    [status, message]=system(['"' fullfile(ravenPath,'software','blast+',['makeblastdb' binEnd]) '" -in "' refFastaFiles{i} '" -out "' fullfile(tmpDB, 'tmpDB') '" -dbtype prot']);
     if status~=0
-        EM=['makeblastdb did not run successfully, error: ', num2str(status)];
-        dispEM(EM,true);
+        error('makeblastdb did not run successfully, error:\n%s',strip(message))
     end
-    [status, ~]=system(['"' fullfile(ravenPath,'software','blast+',['blastp' binEnd]) '" -query ' fastaFile{1} ' -out "' outFile '_r' num2str(i) '" -db "' fullfile(tmpDB, 'tmpDB') '" -evalue 10e-5 -outfmt "10 qseqid sseqid evalue pident length bitscore ppos" -num_threads "' cores '"']);
+    [status, message]=system(['"' fullfile(ravenPath,'software','blast+',['blastp' binEnd]) '" -query "' fastaFile{1} '" -out "' outFile '_r' num2str(i) '" -db "' fullfile(tmpDB, 'tmpDB') '" -evalue 10e-5 -outfmt "10 qseqid sseqid evalue pident length bitscore ppos" -num_threads "' cores '"']);
     if developMode
         blastReport.dbHashes.phr{numel(blastReport.dbHashes.phr)+1}=getMD5Hash(fullfile(tmpDB, 'tmpDB.phr'));
         blastReport.dbHashes.pot{numel(blastReport.dbHashes.pot)+1}=getMD5Hash(fullfile(tmpDB, 'tmpDB.pot'));
@@ -146,8 +143,7 @@ for i=1:numel(refFastaFiles)
         blastReport.blastTxtOutput{numel(blastReport.blastTxtOutput)+1}=importdata([outFile '_r' num2str(i)]);
     end    
     if status~=0
-        EM=['blastp did not run successfully, error: ', num2str(status)];
-        dispEM(EM,true);
+        error('blastp did not run successfully, error:\n%s',strip(message))
     end
     delete([tmpDB filesep 'tmpDB*']);
 end

--- a/external/getDiamond.m
+++ b/external/getDiamond.m
@@ -101,21 +101,19 @@ if developMode
     diamondReport.dbHashes{numel(diamondReport.dbHashes)+1} = char(regexp(message,'[a-f0-9]{32}','match'));
 end
 if status~=0
-    EM=['DIAMOND makedb did not run successfully, error: ', num2str(status)];
-    dispEM(EM,true);
+    error('DIAMOND makedb did not run successfully, error:\n%s',strip(message))
 end
 
 for i=1:numel(refFastaFiles)
     if ~hideVerbose
         fprintf(['Running DIAMOND blastp with "' modelIDs{i} '" against "' organismID{1} '"..\n']);
     end
-    [status, ~]=system(['"' fullfile(ravenPath,'software','diamond',['diamond' binEnd]) '" blastp --query "' refFastaFiles{i} '" --out "' outFile '_' num2str(i) '" --db "' fullfile(tmpDB) '" --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads ' cores ]);
+    [status, message]=system(['"' fullfile(ravenPath,'software','diamond',['diamond' binEnd]) '" blastp --query "' refFastaFiles{i} '" --out "' outFile '_' num2str(i) '" --db "' fullfile(tmpDB) '" --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads ' cores ]);
     if developMode
         diamondReport.diamondTxtOutput{numel(diamondReport.diamondTxtOutput)+1}=importdata([outFile '_' num2str(i)]);
     end
     if status~=0
-        EM=['DIAMOND blastp did not run successfully, error: ', num2str(status)];
-        dispEM(EM,true);
+        error('DIAMOND blastp did not run successfully, error:\n%s',strip(message))
     end
 end
 delete([tmpDB filesep 'tmpDB*']);
@@ -128,17 +126,15 @@ for i=1:numel(refFastaFiles)
     end
     [status, message]=system(['"' fullfile(ravenPath,'software','diamond',['diamond' binEnd]) '" makedb --in "' refFastaFiles{i} '" --db "' fullfile(tmpDB) '"']);
     if status~=0
-        EM=['DIAMOND makedb did not run successfully, error: ', num2str(status)];
-        dispEM(EM,true);
+        error('DIAMOND makedb did not run successfully, error:\n%s',strip(message))
     end
-    [status, ~]=system(['"' fullfile(ravenPath,'software','diamond',['diamond' binEnd]) '" blastp --query "' fastaFile{1} '" --out "' outFile '_r' num2str(i) '" --db "' fullfile(tmpDB) '" --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads ' cores]);
+    [status, message]=system(['"' fullfile(ravenPath,'software','diamond',['diamond' binEnd]) '" blastp --query "' fastaFile{1} '" --out "' outFile '_r' num2str(i) '" --db "' fullfile(tmpDB) '" --more-sensitive --outfmt 6 qseqid sseqid evalue pident length bitscore ppos --threads ' cores]);
     if developMode
         diamondReport.dbHashes{numel(diamondReport.dbHashes)+1} = char(regexp(message,'[a-f0-9]{32}','match'));
         diamondReport.diamondTxtOutput{numel(diamondReport.diamondTxtOutput)+1}=importdata([outFile '_r' num2str(i)]);
     end
     if status~=0
-        EM=['DIAMOND blastp did not run successfully, error: ', num2str(status)];
-        dispEM(EM,true);
+        error('DIAMOND blastp did not run successfully, error:\n%s',strip(message))
     end
     delete([tmpDB filesep 'tmpDB*']);
 end

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -637,7 +637,11 @@ for i=1:numel(modelSBML.reaction)
             subsystems{counter,1}=cellstr(parseNote(modelSBML.reaction(i).notes,'SUBSYSTEM'));
             subsystems{counter,1}(cellfun('isempty',subsystems{counter,1})) = [];
             if strfind(modelSBML.reaction(i).notes,'Confidence Level')
-                rxnconfidencescores(counter)=str2num(parseNote(modelSBML.reaction(i).notes,'Confidence Level'));
+                confScore = parseNote(modelSBML.reaction(i).notes,'Confidence Level');
+                if isempty(confScore)
+                    confScore = 0;
+                end
+                rxnconfidencescores(counter)=str2double(confScore);
             end
             rxnreferences{counter,1}=parseNote(modelSBML.reaction(i).notes,'AUTHORS');
             rxnnotes{counter,1}=parseNote(modelSBML.reaction(i).notes,'NOTES');

--- a/io/readYAMLmodel.m
+++ b/io/readYAMLmodel.m
@@ -43,10 +43,12 @@ else
 end
 % If entry is broken of multiple lines, concatenate. Assumes at least 6
 % leading spaces to avoid metaData to be concatenated.
-newLine=regexp(line_raw,'^ {6,}([\w\(\)].*)','tokens');
-brokenLine=find(~cellfun(@isempty,newLine));
+newLine=regexp(line_raw,'^ {6,}([\w\(\)].*)','tokenExtents');
+brokenLine=find(~cellfun('isempty',newLine));
 for i=1:numel(brokenLine)
-    line_raw{brokenLine(i)-1} = strjoin({line_raw{brokenLine(i)-1},char(newLine{brokenLine(i)}{1})},' ');
+    extraLine = char(line_raw(brokenLine(i)));
+    extraLine = extraLine(newLine{brokenLine(i)}{1}(1):end);
+    line_raw{brokenLine(i)-1} = strjoin({line_raw{brokenLine(i)-1},extraLine},' ');
 end
 line_raw(brokenLine)=[];
 
@@ -488,7 +490,7 @@ if ~isempty(eccodes)
         eccodesCat=strjoin(eccodes(locs==i,2),';');
         model.eccodes{i,1}=eccodesCat;
     end
-    emptyEc=cellfun(@isempty,model.eccodes);
+    emptyEc=cellfun('isempty',model.eccodes);
     model.eccodes(emptyEc)={''};
 end
 
@@ -501,7 +503,7 @@ end
 [~, model.rxnComps] = ismember(model.rxnComps, model.comps);
 
 % Fill S-matrix
-rxnIdx = cellfun(@isempty, equations(:,1));
+rxnIdx = cellfun('isempty', equations(:,1));
 equations(rxnIdx,:) = '';
 rxnIdx = cell2mat(equations(:,1));
 [~,metIdx] = ismember(equations(:,2),model.mets);
@@ -528,7 +530,7 @@ end
 if numel(model.ub)<numel(model.rxns) %No UB reported = max
     model.ub(end+1:numel(model.rxns)-numel(model.ub),1) = double(model.annotation.defaultUB);
 end
-if ~all(cellfun(@isempty,model.rev))
+if ~all(cellfun('isempty',model.rev))
     model.rev = str2double(model.rev);
 else
     model.rev = [];
@@ -614,7 +616,7 @@ if isGECKO
         end
     end
     % Fill rxnEnzMat
-    rxnIdx              = cellfun(@isempty, enzStoich(:,1));
+    rxnIdx              = cellfun('isempty', enzStoich(:,1));
     enzStoich(rxnIdx,:) = '';
     rxnIdx              = cell2mat(enzStoich(:,1));
     [~,enzIdx]          = ismember(enzStoich(:,2),model.ec.enzymes);
@@ -629,7 +631,7 @@ if isGECKO
             ecGeckoCat=strjoin(ecGecko(locs==i,2),';');
             model.ec.eccodes{i,1}=ecGeckoCat;
         end
-        emptyEc=cellfun(@isempty,model.ec.eccodes);
+        emptyEc=cellfun('isempty',model.ec.eccodes);
         model.ec.eccodes(emptyEc)={''};
     end
 end
@@ -646,7 +648,7 @@ end
 if isnumeric(emptyEntry)
     emptyCells=isempty(model.(field));
 else
-    emptyCells=cellfun(@isempty,model.(field));
+    emptyCells=cellfun('isempty',model.(field));
 end
 if all(emptyCells) && ~keepEmpty
     model = rmfield(model, field);

--- a/struct_conversion/ravenCobraWrapper.m
+++ b/struct_conversion/ravenCobraWrapper.m
@@ -307,6 +307,10 @@ else
     if isfield(newModel,'rxnReferences')
         emptyEntry = cellfun(@isempty,newModel.rxnReferences);
         newModel.rxnReferences(emptyEntry)={''};
+        diffNumel = numel(newModel.rxns) - numel(newModel.rxnReferences);
+        if diffNumel > 0
+            newModel.rxnReferences(end+1:end+diffNumel) = {''};
+        end
     end
     if any(isfield(model,geneCOBRAfields))
         for i=1:numel(model.genes)


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `ravenCobraWrapper` handle empty rxnReferences from COBRA => RAVEN
  - `replaceMets` should not contract the whole model, only for the replaced metabolites
  - `getBlast` can handle paths containing spaces
  - `importModel` with empty confidenceScores entries
- feature:
  - `getIndexes` supports `ecenzymes`, `ecrxns` and `ecgenes` types, to query GECKO3 `model.ec` fields
- refactor:
  - Speedup `readYAMLmodel`

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [x] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved with a *merge commit*.
