### PR TITLE
fix: importModel reads model notes

### DIFF
--- a/doc/io/importModel.html
+++ b/doc/io/importModel.html
@@ -852,8 +852,8 @@ This function is called by:
 0742     startString=strfind(modelSBML.notes,<span class="string">'xhtml&quot;&gt;'</span>);
 0743     endString=strfind(modelSBML.notes,<span class="string">'&lt;/body&gt;'</span>);
 0744     <span class="keyword">if</span> any(startString) &amp;&amp; any(endString)
-0745         model.annotation.note=modelSBML.notes(startString+7:endString-1);
-0746         model.annotation.note=regexprep(model.annotation.note,<span class="string">'&lt;p&gt;|&lt;/p&gt;'</span>,<span class="string">''</span>);
+0745         model.annotation.note=modelSBML.notes(startString(1)+7:endString-1);
+0746         model.annotation.note=regexprep(model.annotation.note,<span class="string">'&lt;p.*?&gt;|&lt;/p.*?&gt;'</span>,<span class="string">''</span>);
 0747         model.annotation.note=strtrim(model.annotation.note);
 0748         <span class="keyword">if</span> regexp(model.annotation.note,<span class="string">'This file was generated using the exportModel function in RAVEN Toolbox \d\.\d and OutputSBML in libSBML'</span>)
 0749             model.annotation=rmfield(model.annotation,<span class="string">'note'</span>); <span class="comment">% Default note added when running exportModel</span>

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -742,8 +742,8 @@ if isfield(modelSBML,'notes')
     startString=strfind(modelSBML.notes,'xhtml">');
     endString=strfind(modelSBML.notes,'</body>');
     if any(startString) && any(endString)
-        model.annotation.note=modelSBML.notes(startString+7:endString-1);
-        model.annotation.note=regexprep(model.annotation.note,'<p>|</p>','');
+        model.annotation.note=modelSBML.notes(startString(1)+7:endString-1);
+        model.annotation.note=regexprep(model.annotation.note,'<p.*?>|</p.*?>','');
         model.annotation.note=strtrim(model.annotation.note);
         if regexp(model.annotation.note,'This file was generated using the exportModel function in RAVEN Toolbox \d\.\d and OutputSBML in libSBML')
             model.annotation=rmfield(model.annotation,'note'); % Default note added when running exportModel


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `importModel` parsing of model notes in MATLAB R2025a (solves #586)

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [x] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved as descriped [here](https://github.com/SysBioChalmers/RAVEN/wiki/Development-policy#make-a-new-release).
