### PR TITLE
fix: readYAMLmodel if entries are broken over multiple lines

### DIFF
--- a/doc/io/readYAMLmodel.html
+++ b/doc/io/readYAMLmodel.html
@@ -102,7 +102,7 @@ This function is called by:
 0045 <span class="comment">% leading spaces to avoid metaData to be concatenated.</span>
 0046 newLine=regexp(line_raw,<span class="string">'^ {6,}([\w\(\)].*)'</span>,<span class="string">'tokenExtents'</span>);
 0047 brokenLine=find(~cellfun(<span class="string">'isempty'</span>,newLine));
-0048 <span class="keyword">for</span> i=1:numel(brokenLine)
+0048 <span class="keyword">for</span> i=flip(1:numel(brokenLine))
 0049     extraLine = char(line_raw(brokenLine(i)));
 0050     extraLine = extraLine(newLine{brokenLine(i)}{1}(1):end);
 0051     line_raw{brokenLine(i)-1} = strjoin({line_raw{brokenLine(i)-1},extraLine},<span class="string">' '</span>);
@@ -115,7 +115,7 @@ This function is called by:
 0058 line_value = regexprep(line_raw, <span class="string">'.*:$'</span>,<span class="string">''</span>);
 0059 line_value = regexprep(line_value, <span class="string">'[^&quot;:]+: &quot;?(.+)&quot;?$'</span>,<span class="string">'$1'</span>);
 0060 line_value = regexprep(line_value, <span class="string">'(&quot;)|(^ {4,}- )'</span>,<span class="string">''</span>);
-0061 
+0061 line_value(strcmp(line_value,<span class="string">''''''</span>)) = {<span class="string">''</span>};
 0062 line_value(strcmp(line_value,line_raw)) = {<span class="string">''</span>};
 0063 
 0064 modelFields =   {<span class="string">'id'</span>,char();<span class="keyword">...</span>
@@ -197,7 +197,7 @@ This function is called by:
 0140 geneMiriams=cell(100000,3);  genMirNo=1;
 0141 subSystems=cell(100000,2);   subSysNo=1;
 0142 eccodes=cell(100000,2);      ecCodeNo=1;
-0143 equations=cell(100000,3);   equatiNo=1;
+0143 equations=cell(100000,3);    equatiNo=1;
 0144 
 0145 <span class="keyword">for</span> i=1:numel(line_key)
 0146     tline_raw = line_raw{i};

--- a/io/readYAMLmodel.m
+++ b/io/readYAMLmodel.m
@@ -140,7 +140,7 @@ rxnMiriams=cell(100000,3);   rxnMirNo=1;
 geneMiriams=cell(100000,3);  genMirNo=1;
 subSystems=cell(100000,2);   subSysNo=1;
 eccodes=cell(100000,2);      ecCodeNo=1;
-equations=cell(100000,3);   equatiNo=1;
+equations=cell(100000,3);    equatiNo=1;
 
 for i=1:numel(line_key)
     tline_raw = line_raw{i};


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `readYAMLmodel` can read files where entries were broken over more than 2 lines.
  - `readYAMLmodel` recognizes `''` as an empty string.
#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [x] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved as descriped [here](https://github.com/SysBioChalmers/RAVEN/wiki/Development-policy#make-a-new-release).
