### PR TITLE
feat: optional reaction splitting for LP numerical conditioning

### DIFF
--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -3,7 +3,13 @@ function res = optimizeProb(prob,params,verbose)
 %   Optimize an LP or MILP formulated in cobra terms.
 %
 %   prob	cobra style LP/MILP problem struct to be optimised
-%   params	solver specific parameters (optional)
+%   params	solver specific parameters (optional). In addition to solver
+%   		parameters, the field "maxRatio" can be set to a number > 1 to
+%   		improve numerical conditioning: before solving (LP only) any
+%   		column whose coefficients span more than maxRatio is split via
+%   		auxiliary metabolites/variables, preserving the feasible region.
+%   		See splitProbForConditioning. The field is consumed here and not
+%   		forwarded to the solver.
 %   verbose if true MILP progress is shown (optional, default true)
 %
 %   res		the output structure from the selected solver RAVENSOLVER
@@ -55,6 +61,22 @@ if milp
     defaultparams.MIPGap     = 1e-12;
     defaultparams.Seed       = 1;
 end
+
+%% Optionally improve numerical conditioning before solving. This is opt-in
+% through params.maxRatio and only applied to LPs. Columns whose coefficients
+% span more than maxRatio are split via auxiliary metabolites/variables, which
+% preserves the feasible region but reduces the spread within each column. The
+% added rows/columns are stripped from the result further down.
+condApplied = false;
+if isfield(params,'maxRatio')
+    maxRatio = params.maxRatio;
+    params   = rmfield(params,'maxRatio');
+    if ~milp && isnumeric(maxRatio) && isscalar(maxRatio) && isfinite(maxRatio) && maxRatio>1
+        [prob, condInfo] = splitProbForConditioning(prob, maxRatio);
+        condApplied = condInfo.applied;
+    end
+end
+
 res.obj=[];
 switch solver
     %% Use whatever solver is set by COBRA Toolbox changeCobraSolver
@@ -252,6 +274,17 @@ switch solver
 end
 if res.stat>0
     res.full=res.full(1:size(prob.a,2));
+end
+%Strip the auxiliary rows/columns that were added for conditioning, so that
+%the result matches the dimensions of the original problem. res.full is
+%already truncated to the original variables above (prob.a is left untouched).
+if condApplied
+    if isfield(res,'dual') && numel(res.dual)>condInfo.nOrigRows
+        res.dual=res.dual(1:condInfo.nOrigRows);
+    end
+    if isfield(res,'rcost') && numel(res.rcost)>condInfo.nOrigCols
+        res.rcost=res.rcost(1:condInfo.nOrigCols);
+    end
 end
 end
 

--- a/solver/solveLP.m
+++ b/solver/solveLP.m
@@ -15,7 +15,14 @@ function [solution, hsSolOut]=solveLP(model,minFlux,params,hsSol)
 %                       interpret. Note that this optimization can be very
 %                       slow
 %                 (optional, default 0)
-%   params        *obsolete option*
+%   params        solver parameters, forwarded to optimizeProb. Mostly
+%                 obsolete, but the field "maxRatio" (a number > 1) can be set
+%                 to improve numerical conditioning of ill-scaled models: any
+%                 reaction whose stoichiometric coefficients span more than
+%                 maxRatio is transiently split via auxiliary metabolites
+%                 before solving, which preserves the feasible region (and
+%                 thus the flux distribution of the original reactions). A
+%                 common value is 1e6 (optional, no splitting by default)
 %   hsSol         hot-start solution for the LP solver. This can
 %                 significantly speed up the process if many similar
 %                 optimization problems are solved iteratively. Only used

--- a/solver/splitProbForConditioning.m
+++ b/solver/splitProbForConditioning.m
@@ -1,0 +1,134 @@
+function [prob, condInfo] = splitProbForConditioning(prob, maxRatio)
+% splitProbForConditioning
+%   Reformulates an LP problem to improve its numerical conditioning by
+%   splitting columns whose coefficients span more than a given ratio. In a
+%   metabolic model a column corresponds to a reaction, and a wide spread of
+%   stoichiometric coefficients within one reaction (e.g. a biomass reaction
+%   with both major substrates and trace cofactors) cannot be removed by the
+%   diagonal row/column scaling that LP solvers apply, and may lead to
+%   unreliable solutions or spurious infeasibility.
+%
+%   Each offending small coefficient is replaced by a chain consisting of an
+%   auxiliary "star" metabolite (a new equality constraint row) and one or
+%   more conversion variables (new columns), such that no individual column
+%   has a coefficient ratio exceeding maxRatio. The feasible region of the
+%   original problem is preserved exactly: the new rows are steady-state (=0)
+%   constraints and the new variables are fully determined by them, so the
+%   values of all original variables are unchanged.
+%
+%   The function is meant to be called inside optimizeProb, on the COBRA-style
+%   problem struct, immediately before the problem is passed to the solver.
+%   The auxiliary rows are appended at the bottom of prob.A and the auxiliary
+%   columns at the right, so the indices of all original constraints and
+%   variables are preserved. This allows the augmentation to be stripped from
+%   the solver output (see condInfo).
+%
+% Input:
+%   prob        COBRA-style LP problem struct, with at least the fields A, b,
+%               c, lb, ub, csense and vartype
+%   maxRatio    maximum allowed ratio between the largest and smallest
+%               absolute coefficient within any single column
+%
+% Output:
+%   prob        the (possibly) augmented problem struct. Identical to the
+%               input if no column needed splitting
+%   condInfo    struct describing the augmentation:
+%       applied     true if any column was split
+%       nSplits     number of auxiliary metabolite/conversion pairs added
+%       nOrigRows   number of constraint rows before augmentation
+%       nOrigCols   number of variables (columns) before augmentation
+%
+% Usage: [prob, condInfo] = splitProbForConditioning(prob, maxRatio)
+
+[nOrigRows, nOrigCols] = size(prob.A);
+condInfo.applied   = false;
+condInfo.nSplits   = 0;
+condInfo.nOrigRows = nOrigRows;
+condInfo.nOrigCols = nOrigCols;
+
+%Detection uses a small slack so that reactions that are only marginally over
+%the threshold are left alone. This also makes the transformation idempotent:
+%a freshly split column sits exactly at maxRatio and is not split again.
+detectRatio = maxRatio * 1.01;
+
+%Work on triplets to avoid repeated resizing of the sparse matrix
+[I, J, V] = find(prob.A);
+absV = abs(V);
+
+%Largest/smallest absolute coefficient and number of nonzeros per column
+cMax   = accumarray(J, absV, [nOrigCols 1], @max, 0);
+cMin   = accumarray(J, absV, [nOrigCols 1], @min, inf);
+nnzCol = accumarray(J, 1,    [nOrigCols 1], @sum, 0);
+
+%Single-coefficient columns (e.g. exchange reactions or slack variables) have
+%an undefined ratio and are never split
+badCols = find(nnzCol >= 2 & (cMax ./ cMin) > detectRatio);
+if isempty(badCols)
+    return
+end
+
+%Flag the entries that are too small within their (bad) column. These are
+%removed from the original matrix and re-introduced via the auxiliary chain.
+smallThresh = cMax(J) / maxRatio;
+removeEntry = ismember(J, badCols) & (absV < smallThresh);
+
+%Keep all entries that are not removed
+keep = ~removeEntry;
+newI = I(keep);
+newJ = J(keep);
+newV = V(keep);
+
+%Auxiliary entries are accumulated here
+addI = zeros(0,1); addJ = zeros(0,1); addV = zeros(0,1);
+convLb = zeros(0,1); convUb = zeros(0,1);
+nStar = 0;   %auxiliary metabolite rows added so far
+nConv = 0;   %conversion variable columns added so far
+
+remIdx = find(removeEntry);
+for k = 1:numel(remIdx)
+    e         = remIdx(k);
+    metRow    = I(e);
+    parentCol = J(e);
+    coef      = V(e);
+    curCmax   = cMax(parentCol);
+    %Deliver the (signed) coefficient "coef" of metabolite "metRow" into
+    %column "parentCol", splitting recursively until it is within range
+    while true
+        small = curCmax / maxRatio;
+        if abs(coef) >= small
+            %Coefficient is acceptable; place it directly
+            addI(end+1,1) = metRow;    addJ(end+1,1) = parentCol; addV(end+1,1) = coef; %#ok<AGROW>
+            break
+        end
+        %Otherwise introduce a star metabolite and a conversion variable
+        beta    = sign(coef) * small;
+        nStar   = nStar + 1; starRow = nOrigRows + nStar;
+        nConv   = nConv + 1; convCol = nOrigCols + nConv;
+        %The parent column now consumes the star metabolite (coefficient beta)
+        addI(end+1,1) = starRow; addJ(end+1,1) = parentCol; addV(end+1,1) = beta; %#ok<AGROW>
+        %The conversion variable produces one unit of the star metabolite
+        addI(end+1,1) = starRow; addJ(end+1,1) = convCol;   addV(end+1,1) = 1;    %#ok<AGROW>
+        %Conversion variables are determined by the equality and left unbounded
+        convLb(end+1,1) = -inf; convUb(end+1,1) = inf; %#ok<AGROW>
+        %Deliver the residual coefficient into the new conversion column. Its
+        %reference scale is 1 (the production coefficient of the star met).
+        coef      = -coef / beta;
+        parentCol = convCol;
+        curCmax   = 1;
+    end
+end
+
+condInfo.applied = true;
+condInfo.nSplits = nStar;
+
+%Assemble the augmented matrix and extend the problem vectors. New rows are
+%appended at the bottom, new columns at the right.
+prob.A = sparse([newI; addI], [newJ; addJ], [newV; addV], ...
+    nOrigRows + nStar, nOrigCols + nConv);
+prob.b       = [prob.b(:);       zeros(nStar,1)];
+prob.csense  = [prob.csense(:).', repmat('E',1,nStar)];
+prob.c       = [prob.c(:);       zeros(nConv,1)];
+prob.lb      = [prob.lb(:);      convLb];
+prob.ub      = [prob.ub(:);      convUb];
+prob.vartype = [prob.vartype(:).', repmat('C',1,nConv)];
+end

--- a/testing/unit_tests/conditioningTests.m
+++ b/testing/unit_tests/conditioningTests.m
@@ -1,0 +1,114 @@
+%run this test case with the command
+%results = runtests('conditioningTests.m')
+function tests = conditioningTests
+tests = functiontests(localfunctions);
+end
+
+function singleSplitTest(testCase)
+%A column (reaction) with coefficients 10, 1 and 1e-8 has a ratio of 1e9,
+%well above the threshold, and should be split exactly once.
+maxRatio = 1e6;
+prob = makeProb(sparse([10, 2, 0; 1, 0, 3; 1e-8, 1, 0]));
+
+[probNew, condInfo] = splitProbForConditioning(prob, maxRatio);
+
+verifyTrue(testCase, condInfo.applied)
+verifyEqual(testCase, condInfo.nSplits, 1)
+verifyEqual(testCase, condInfo.nOrigRows, 3)
+verifyEqual(testCase, condInfo.nOrigCols, 3)
+
+%No column may exceed maxRatio after the split
+verifyLessThanOrEqual(testCase, maxColRatio(probNew.A), maxRatio*1.0001)
+
+%The feasible region must be preserved and the problem vectors extended
+verifyEquivalent(testCase, prob, probNew, condInfo)
+end
+
+function recursiveSplitTest(testCase)
+%A coefficient of 1e-13 against a max of 10 has a ratio of 1e12, which needs
+%two levels of splitting when maxRatio is 1e6.
+maxRatio = 1e6;
+prob = makeProb(sparse([10, 0; 1e-13, 4]));
+
+[probNew, condInfo] = splitProbForConditioning(prob, maxRatio);
+
+verifyTrue(testCase, condInfo.applied)
+verifyGreaterThanOrEqual(testCase, condInfo.nSplits, 2)
+verifyLessThanOrEqual(testCase, maxColRatio(probNew.A), maxRatio*1.0001)
+verifyEquivalent(testCase, prob, probNew, condInfo)
+end
+
+function noSplitTest(testCase)
+%A well-scaled problem must be returned untouched.
+maxRatio = 1e6;
+prob = makeProb(sparse([10, 2; 1, 3]));
+
+[probNew, condInfo] = splitProbForConditioning(prob, maxRatio);
+
+verifyFalse(testCase, condInfo.applied)
+verifyEqual(testCase, probNew.A, prob.A)
+end
+
+function idempotenceTest(testCase)
+%Splitting an already-conditioned problem a second time changes nothing.
+maxRatio = 1e6;
+prob = makeProb(sparse([10, 2, 0; 1, 0, 3; 1e-8, 1, 0]));
+
+[probNew, ~]      = splitProbForConditioning(prob, maxRatio);
+[~, condInfo2]    = splitProbForConditioning(probNew, maxRatio);
+
+verifyFalse(testCase, condInfo2.applied)
+end
+
+% --- helpers --------------------------------------------------------------
+
+function prob = makeProb(A)
+[m,n]        = size(A);
+prob.A       = A;
+prob.b       = zeros(m,1);
+prob.c       = [1; zeros(n-1,1)];
+prob.lb      = -1000*ones(n,1);
+prob.ub      =  1000*ones(n,1);
+prob.csense  = repmat('E',1,m);
+prob.osense  = 1;
+prob.vartype = repmat('C',1,n);
+end
+
+function r = maxColRatio(A)
+A = abs(A);
+r = 0;
+for j = 1:size(A,2)
+    v = nonzeros(A(:,j));
+    if numel(v) >= 2
+        r = max(r, max(v)/min(v));
+    end
+end
+end
+
+function verifyEquivalent(testCase, prob, probNew, condInfo)
+%Verify that the augmented problem has the same feasible region in the
+%original variables, and that all problem vectors were extended consistently.
+nR = condInfo.nOrigRows;
+nC = condInfo.nOrigCols;
+nS = condInfo.nSplits;
+
+Aaug = full(probNew.A);
+TL = Aaug(1:nR,      1:nC);
+TR = Aaug(1:nR,      nC+1:end);
+BL = Aaug(nR+1:end,  1:nC);
+BR = Aaug(nR+1:end,  nC+1:end);
+
+%The conversion variables are pinned by the star-metabolite rows:
+%  BL*x + BR*conv = 0  ->  conv = -BR\BL * x
+%so the original constraint rows evaluate to (TL + TR*(-BR\BL))*x, which must
+%reproduce the original constraint matrix exactly.
+M = -BR\BL;
+verifyLessThan(testCase, max(abs((TL + TR*M) - full(prob.A)),[],'all'), 1e-9)
+
+verifyEqual(testCase, numel(probNew.b),       nR+nS)
+verifyEqual(testCase, numel(probNew.csense),  nR+nS)
+verifyEqual(testCase, numel(probNew.c),       nC+nS)
+verifyEqual(testCase, numel(probNew.lb),      nC+nS)
+verifyEqual(testCase, numel(probNew.ub),      nC+nS)
+verifyEqual(testCase, numel(probNew.vartype), nC+nS)
+end


### PR DESCRIPTION
### Main improvements in this PR:
- feat:
  - `solveLP` can scale reactions with a large range of stochiometric coefficients.

Ill-scaled reactions (e.g. biomass with both major substrates and trace cofactors) have intra-column coefficient ratios that solver row/column scaling cannot fix, leading to unreliable or spuriously infeasible LP solutions. This adds an opt-in transformation that splits such columns via auxiliary "star" metabolites and conversion variables, preserving the feasible region exactly.

The split is applied transiently to the LP problem inside optimizeProb (LP only), just before the solver call, so the model struct is left untouched. It is enabled by setting params.maxRatio; the auxiliary rows/columns are stripped from res.full/dual/rcost so callers see unchanged dimensions.

#### Instructions on merging this PR:
<!-- Chose ONE of the following two options
and replace [ ] with [X] to check the box.-->
- [x] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved as descriped [here](https://github.com/SysBioChalmers/RAVEN/wiki/Development-policy#make-a-new-release).
