### PR TITLE
fix: default ftINIT MILP solving to single-threaded Gurobi

### DIFF
--- a/INIT/INITStepDesc.m
+++ b/INIT/INITStepDesc.m
@@ -24,7 +24,9 @@ classdef INITStepDesc
                    %      .mets        Names of metabolites to remove
                    %      .compsToKeep Compartments for which metabolites should be kept.
       MILPParams %Cell array of MILPparams - dictates how many iterations that will be run in this step.
-                 %Typically, MIPGap and TimeLimit is specified
+                 %Typically, MIPGap and TimeLimit is specified. ftINIT additionally
+                 %defaults Threads to 1 (single-threaded Gurobi) for determinism;
+                 %set Threads here to override (0 = use all cores).
       AbsMIPGaps %If the objective is close to zero, a percentage of that is very small. 
                  %Therefore, also set an absolut value for this (typically 10 or 20). 
                  %For practical reasons, the first number is not used

--- a/INIT/ftINIT.m
+++ b/INIT/ftINIT.m
@@ -233,6 +233,13 @@ for initStep = 1:length(INITSteps)
         if ~isfield(params, 'TimeLimit')
             params.TimeLimit = 5000;
         end
+
+        %Default to single-threaded Gurobi MILP solving. Multi-threaded Gurobi
+        %can non-deterministically report the MILP as infeasible (issue #607).
+        %Override by setting 'Threads' in the step's MILPParams (0 = all cores).
+        if ~isfield(params, 'Threads')
+            params.Threads = 1;
+        end
         
         if ~first 
             %There is sometimes a problem with that the objective function becomes close to zero,

--- a/INIT/ftINITFillGapsMILP.m
+++ b/INIT/ftINITFillGapsMILP.m
@@ -207,6 +207,7 @@ params.intTol = 10^-9; %experment with this value
 params.TimeLimit = 300;
 params.Seed = 26;%This is weird - although it says "optimal solution found", we can get different results with different
                  %values of the objective function, where one is more optimal than the other (pretty big difference...)
+params.Threads = 1; %single-threaded Gurobi MILP for determinism, see issue #607
 %params.CSClientLog = 3;%generates a warning in gurobi, but may be of interest for other solvers
 
 % Optimize the problem


### PR DESCRIPTION
## Summary

Fixes #607. `ftINIT` can fail with "Model is infeasible" / "Failed to find good enough solution within the time frame. MIPGap: Inf" for some cell types (e.g. `vascularSmoothMuscleCells`, `pericyte`) when building context-specific models from Human-GEM v2.0.0, while the same pipeline succeeds with v1.19.0.

As diagnosed by @mfcesur in #607, the cause is **multi-threaded Gurobi solving the ftINIT MILP non-deterministically and spuriously returning infeasible**. Forcing single-thread (`Threads = 1`) makes all cell types reconstruct, and is the more robust setting across Gurobi versions.

RAVEN already forces single-thread Gurobi, but only inside parallel workers (`if ~isempty(getCurrentTask)` in `optimizeProb.m`). In a normal serial `ftINIT` run `getCurrentTask` is empty, so Gurobi defaults to all cores — the failing condition.

## Changes

- **`INIT/ftINIT.m`** — default `Threads = 1` for the per-step reconstruction MILP, set in the existing param-defaulting block (overridable via the step's `MILPParams`).
- **`INIT/ftINITFillGapsMILP.m`** — same default for the gap-filling MILP.
- **`INIT/INITStepDesc.m`** — document the new default/override on the `MILPParams` property.

The default is **overridable**: set `Threads` in a step's `MILPParams` (e.g. `0` = all cores) and it is respected (user params applied last via `structUpdate`). It is solver-safe: `glpk` is blocked for MILP, `scip` ignores `params`, and `cobra` only acts on `Threads` with a Gurobi backend. The existing `getCurrentTask` safeguard is retained — it also covers non-ftINIT parallel solves such as `randomSampling`.

## Testing

- `checkcode` clean on all three files.
- `tinitTests` ran locally, but the ftINIT MILP test (`testftINIT_T0001`) was skipped on the dev machine (no Gurobi/SCIP installed); CI (with Gurobi) exercises it.
- @mfcesur — could you confirm `vascularSmoothMuscleCells`/`pericyte` now reconstruct with **default** settings (no manual `Threads` edit)?
