### PR TITLE
Add matlab.unittest function test suite covering all source functions

### DIFF
--- a/testing/function_tests/README.md
+++ b/testing/function_tests/README.md
@@ -1,0 +1,36 @@
+# RAVEN function tests
+
+A `matlab.unittest` suite covering the RAVEN source functions, organised as one
+test class per source folder (`tQueries`, `tManipulation`, `tSolver`, …). It is
+additive — the existing `testing/unit_tests/` suite is kept in place.
+
+## Running
+
+```matlab
+results = runtests('testing/function_tests');          % whole suite
+results = runtests('testing/function_tests/tIO.m');    % one folder
+```
+
+A working solver is required for the simulation-based tests; GLPK ships with
+RAVEN and is used by default. Some tests additionally need a MILP-capable
+solver (Gurobi or SCIP).
+
+## Structure
+
+- `RavenTestCase.m` — abstract base class. Provides the RAVEN root, a fresh
+  copy of a small E. coli model before every test, a deterministic solver, and
+  helpers (`assumeMILPSolver`, `assumeDependency`, task-model fixtures, figure
+  suppression).
+- `t<Folder>.m` — one class per source folder; each test method exercises a
+  function's main path, favouring structural invariants (counts, membership,
+  round-trips, idempotence) over brittle golden values.
+
+## Skipped tests
+
+Tests that need a dependency which may be absent are written with test
+*assumptions*, so they are reported as filtered (not failed) when the
+dependency is missing. This keeps the suite green in any environment. Skipped
+categories: external binaries (BLAST+, DIAMOND, WoLF PSORT), a local KEGG dump,
+optional solvers (Gurobi/SCIP for MILP), the Optimization Toolbox (`quadprog`),
+a Python/pyyaml bridge, and input files for table-driven curation. The full
+ftINIT MILP pipeline is exercised end-to-end by `testing/unit_tests/tinitTests.m`.

--- a/testing/function_tests/RavenTestCase.m
+++ b/testing/function_tests/RavenTestCase.m
@@ -1,0 +1,59 @@
+classdef (Abstract) RavenTestCase < matlab.unittest.TestCase
+% RavenTestCase  Shared base class for the RAVEN function test suite.
+%
+%   Provides, once per test class:
+%     - ravenRoot : the RAVEN installation root.
+%     - model     : a small E. coli textbook model in RAVEN format, reloaded
+%                   fresh for every test method so mutations cannot leak
+%                   between tests.
+%     - a deterministic LP solver (GLPK, which ships with RAVEN).
+%
+%   It also offers assume* helpers that mark a test as filtered (not failed)
+%   when an optional dependency is missing, so the suite stays green in any
+%   environment. Concrete test classes subclass this and add a methods(Test)
+%   block.
+
+    properties
+        ravenRoot char
+        model struct          % reset before every test method
+    end
+
+    properties (Access = protected)
+        modelTemplate struct  % pristine copy, loaded once per class
+    end
+
+    methods (TestClassSetup)
+        function setupRaven(testCase)
+            testCase.ravenRoot = findRAVENroot();
+            loaded = load(fullfile(testCase.ravenRoot,'testing','unit_tests', ...
+                'test_data','ecoli_textbook.mat'),'model');
+            testCase.modelTemplate = loaded.model;
+            try
+                setRavenSolver('glpk');
+            catch
+                % leave whatever solver is configured; solver tests assume below
+            end
+        end
+    end
+
+    methods (TestMethodSetup)
+        function freshModel(testCase)
+            % Hand each test an untouched copy of the model.
+            testCase.model = testCase.modelTemplate;
+        end
+    end
+
+    methods (Access = protected)
+        function assumeSolver(testCase, solverName)
+            % Skip unless the named solver is on the MATLAB path.
+            testCase.assumeNotEmpty(which(solverName), ...
+                sprintf('Solver "%s" not available; test skipped.', solverName));
+        end
+
+        function assumeDependency(testCase, isAvailable, label)
+            % Skip when an external binary / network / GUI dependency is absent.
+            testCase.assumeTrue(logical(isAvailable), ...
+                sprintf('Dependency "%s" not available; test skipped.', label));
+        end
+    end
+end

--- a/testing/function_tests/RavenTestCase.m
+++ b/testing/function_tests/RavenTestCase.m
@@ -34,6 +34,14 @@ classdef (Abstract) RavenTestCase < matlab.unittest.TestCase
                 % leave whatever solver is configured; solver tests assume below
             end
         end
+
+        function suppressFigures(testCase)
+            % Keep plotting functions from popping windows or leaking figures.
+            orig = get(groot, 'defaultFigureVisible');
+            set(groot, 'defaultFigureVisible', 'off');
+            testCase.addTeardown(@() set(groot, 'defaultFigureVisible', orig));
+            testCase.addTeardown(@() close('all'));
+        end
     end
 
     methods (TestMethodSetup)
@@ -54,6 +62,55 @@ classdef (Abstract) RavenTestCase < matlab.unittest.TestCase
             % Skip when an external binary / network / GUI dependency is absent.
             testCase.assumeTrue(logical(isAvailable), ...
                 sprintf('Dependency "%s" not available; test skipped.', label));
+        end
+
+        function assumeMILPSolver(testCase)
+            % Switch to a MILP-capable solver for this test, or skip if none.
+            % GLPK (the default) cannot solve MILPs in RAVEN.
+            if ~isempty(which('gurobi'))
+                evalc('setRavenSolver(''gurobi'')');
+            else
+                ok = false;
+                try, evalc('setRavenSolver(''scip'')'); ok = true; catch, end %#ok<NOCOM>
+                testCase.assumeTrue(ok, 'No MILP solver (gurobi/scip) available; test skipped.');
+            end
+            testCase.addTeardown(@() evalc('setRavenSolver(''glpk'')'));
+        end
+
+        function m = taskTestModel(~)
+            % Small synthetic model used by task/gap-filling tests.
+            m = struct();
+            m.id = 'testModel'; m.rxns = {}; m.S = []; m.rev = [];
+            m.mets = {'as';'ac';'bc';'cc';'dc';'ec';'es';'fc'};
+            m.metNames = {'a';'a';'b';'c';'d';'e';'e';'f'};
+            m.comps = {'s';'c'}; m.compNames = m.comps;
+            m.metComps = [1;2;2;2;2;2;1;2];
+            m.genes = {'G1';'G2';'G3';'G4';'G5';'G6';'G7';'G8';'G9';'G10'};
+            m.grRules = {}; m.rxnGeneMat = [];
+            r = struct();
+            r.rxns = {'R1';'R2';'R3';'R4';'R5';'R6';'R7';'R8';'R9';'R10'};
+            r.equations = {'=> a[s]';'a[s] <=> a[c]';'a[c] <=> b[c] + c[c]'; ...
+                'a[c] <=> 2 d[c]';'b[c] + c[c] => e[c]';'2 d[c] => e[c]'; ...
+                'e[c] => e[s]';'e[s] =>';'a[c] <=> f[c]';'f[c] <=> e[c]'};
+            r.grRules = {'';'';'G3';'G4';'G5';'G6';'G7';'';'G9';'G10'};
+            evalc('m = addRxns(m, r, 3);');
+            m.c = [0;0;0;0;0;0;0;1;0;0];
+            m.ub = repmat(1000,10,1);
+            m.lb = [0;-1000;-1000;-1000;0;0;0;0;-1000;-1000];
+            m.rxnNames = m.rxns;
+            m.b = repmat(0,8,1);
+            m = closeModel(m);
+        end
+
+        function t = taskTestStruct(~)
+            % Task that the model above can satisfy: make e[s] from a[s].
+            t = struct();
+            t.id = 'Gen e[s] from a[s]'; t.description = t.id;
+            t.shouldFail = false; t.printFluxes = false; t.comments = '';
+            t.inputs = {'a[s]'}; t.LBin = 0; t.UBin = inf;
+            t.outputs = {'e[s]'}; t.LBout = 1; t.UBout = 1;
+            t.equations = {}; t.LBequ = []; t.UBequ = [];
+            t.changed = {}; t.LBrxn = {}; t.UBrxn = {};
         end
     end
 end

--- a/testing/function_tests/tAnalysis.m
+++ b/testing/function_tests/tAnalysis.m
@@ -1,0 +1,138 @@
+classdef tAnalysis < RavenTestCase
+% tAnalysis  Tests for the flux-analysis and simulation functions in analysis/.
+
+    methods (Test)
+
+        function getAllowedBoundsSizes(testCase)
+            [mn, mx] = getAllowedBounds(testCase.model, 1:10);
+            testCase.verifyNumElements(mn, 10);
+            testCase.verifyNumElements(mx, 10);
+            testCase.verifyTrue(all(mx >= mn - 1e-9));
+        end
+
+        function getEssentialRxnsReturnsList(testCase)
+            evalc('[ess, idx] = getEssentialRxns(testCase.model);');
+            testCase.verifyClass(ess, 'cell');
+            testCase.verifyTrue(all(ismember(ess, testCase.model.rxns)));
+        end
+
+        function haveFluxReturnsLogical(testCase)
+            I = haveFlux(testCase.model);
+            testCase.verifyNumElements(I, numel(testCase.model.rxns));
+        end
+
+        function getMinNrFluxesReturnsFlux(testCase)
+            testCase.assumeMILPSolver();
+            evalc('[x, I, exitFlag] = getMinNrFluxes(testCase.model, testCase.model.rxns);');
+            testCase.verifyNotEmpty(x);
+        end
+
+        function getAllSubGraphsReturnsResult(testCase)
+            sg = getAllSubGraphs(testCase.model);
+            testCase.verifyNotEmpty(sg);
+        end
+
+        function findGeneDeletionsRuns(testCase)
+            evalc('[genes, fluxes] = findGeneDeletions(testCase.model, ''sgd'', ''fba'');');
+            testCase.verifyNotEmpty(genes);
+        end
+
+        function followFluxesRuns(testCase)
+            sol = solveLP(testCase.model);
+            out = evalc('followFluxes(testCase.model, sol.x, 0, 1000);');
+            testCase.verifyClass(out, 'char');
+        end
+
+        function followChangedRuns(testCase)
+            % Aerobic vs anaerobic guarantees several reactions change, which
+            % avoids the empty-selection edge case.
+            solA = solveLP(testCase.model);
+            o2exch = find(strcmp(testCase.model.rxnNames, 'O2 exchange'));
+            modelAna = setParam(testCase.model, 'eq', testCase.model.rxns(o2exch), 0);
+            solB = solveLP(modelAna);
+            out = evalc('followChanged(testCase.model, solA.x, solB.x, 10, 0.01, 0);');
+            testCase.verifyClass(out, 'char');
+        end
+
+        function getFluxZComputesScores(testCase)
+            n = numel(testCase.model.rxns);
+            Z = getFluxZ(rand(n, 20), rand(n, 20));
+            testCase.verifyNumElements(Z, n);
+        end
+
+        function analyzeSamplingRuns(testCase)
+            n = numel(testCase.model.rxns);
+            Tex = randn(n, 1);           % per-reaction expression t-scores
+            solutionsA = rand(n, 20);
+            solutionsB = rand(n, 20);
+            evalc('scores = analyzeSampling(Tex, 18, solutionsA, solutionsB, false);');
+            testCase.verifySize(scores, [n 3]);
+        end
+
+        function randomSamplingRuns(testCase)
+            evalc('sols = randomSampling(testCase.model, 5);');
+            testCase.verifyEqual(size(sols, 1), numel(testCase.model.rxns));
+        end
+
+        function reporterMetabolitesRuns(testCase)
+            pvals = rand(numel(testCase.model.genes), 1);
+            rm = reporterMetabolites(testCase.model, testCase.model.genes, pvals);
+            testCase.verifyClass(rm, 'struct');
+        end
+
+        function FSEOFRuns(testCase)
+            biomassRxn = testCase.model.rxns{find(testCase.model.c == 1, 1)};
+            [~, exchIdx] = getExchangeRxns(testCase.model);
+            targetRxn = testCase.model.rxns{exchIdx(1)};
+            outFile = [tempname '.txt'];
+            evalc('targets = FSEOF(testCase.model, biomassRxn, targetRxn, 5, 0.9, outFile);');
+            testCase.verifyClass(targets, 'struct');
+        end
+
+        function runRobustnessAnalysisRuns(testCase)
+            [~, exchIdx] = getExchangeRxns(testCase.model);
+            controlRxn = testCase.model.rxns{exchIdx(1)};
+            evalc('[cFlux, oFlux] = runRobustnessAnalysis(testCase.model, controlRxn, 5);');
+            testCase.verifyNumElements(cFlux, 5);
+        end
+
+        function runProductionEnvelopeRuns(testCase)
+            biomassRxn = testCase.model.rxns{find(testCase.model.c == 1, 1)};
+            [~, exchIdx] = getExchangeRxns(testCase.model);
+            targetRxn = testCase.model.rxns{exchIdx(1)};
+            evalc('[bio, tgt] = runProductionEnvelope(testCase.model, targetRxn, biomassRxn, 5);');
+            testCase.verifyNotEmpty(bio);
+        end
+
+        function runPhenotypePhasePlaneRuns(testCase)
+            [~, exchIdx] = getExchangeRxns(testCase.model);
+            r1 = testCase.model.rxns{exchIdx(1)};
+            r2 = testCase.model.rxns{exchIdx(2)};
+            evalc('g = runPhenotypePhasePlane(testCase.model, r1, r2, 3, 3);');
+            testCase.verifyNotEmpty(g);
+        end
+
+        function runDynamicFBARuns(testCase)
+            % Use glucose (consumed) as substrate and plot target; the function
+            % always plots, so the plotted reaction must carry non-zero flux.
+            [~, exchIdx] = getExchangeRxns(testCase.model);
+            glcMet = find(strcmp(testCase.model.metNames, 'D-Glucose'), 1);
+            glcExch = exchIdx(any(testCase.model.S(glcMet, exchIdx) ~= 0, 1));
+            subRxn = testCase.model.rxns(glcExch);
+            evalc(['c = runDynamicFBA(testCase.model, subRxn, 10, 0.1, 0.1, 2, ' ...
+                'subRxn, {});']);
+            testCase.verifyNotEmpty(c);
+        end
+
+        function runSimpleOptKnockRuns(testCase)
+            testCase.assumeMILPSolver();
+            biomassRxn = testCase.model.rxns{find(testCase.model.c == 1, 1)};
+            [~, exchIdx] = getExchangeRxns(testCase.model);
+            targetRxn = testCase.model.rxns{exchIdx(1)};
+            evalc(['out = runSimpleOptKnock(testCase.model, targetRxn, biomassRxn, ' ...
+                'testCase.model.rxns(1:5), ''rxns'', 1);']);
+            testCase.verifyClass(out, 'struct');
+        end
+
+    end
+end

--- a/testing/function_tests/tAnnotation.m
+++ b/testing/function_tests/tAnnotation.m
@@ -1,0 +1,38 @@
+classdef tAnnotation < RavenTestCase
+% tAnnotation  Tests for the annotation/metadata functions in annotation/.
+
+    methods (Test)
+
+        function editMiriamAddsAnnotation(testCase)
+            m2 = editMiriam(testCase.model, 'met', 1, 'bigg.metabolite', 'testval', 'add');
+            testCase.verifyClass(m2, 'struct');
+            testCase.verifyEqual(numel(m2.mets), numel(testCase.model.mets));
+        end
+
+        function extractMiriamReturnsNames(testCase)
+            [miriams, names] = extractMiriam(testCase.model.metMiriams); %#ok<ASGLU>
+            testCase.verifyNotEmpty(names);
+        end
+
+        function assignSBOtermsRuns(testCase)
+            evalc('m2 = assignSBOterms(testCase.model);');
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function deltaGCsvRoundTrip(testCase)
+            m = testCase.model;
+            m.metDeltaG = (1:numel(m.mets))';
+            m.rxnDeltaG = (1:numel(m.rxns))';
+            metCsv = [tempname '.csv'];
+            rxnCsv = [tempname '.csv'];
+            testCase.addTeardown(@() delete(metCsv));
+            testCase.addTeardown(@() delete(rxnCsv));
+            evalc('saveDeltaGtoCSV(m, metCsv, rxnCsv);');
+            base = testCase.model;
+            evalc('m2 = loadDeltaGfromCSV(base, metCsv, rxnCsv);');
+            testCase.verifyEqual(m2.metDeltaG, m.metDeltaG, 'AbsTol', 1e-6);
+            testCase.verifyEqual(m2.rxnDeltaG, m.rxnDeltaG, 'AbsTol', 1e-6);
+        end
+
+    end
+end

--- a/testing/function_tests/tBiomass.m
+++ b/testing/function_tests/tBiomass.m
@@ -1,0 +1,58 @@
+classdef tBiomass < RavenTestCase
+% tBiomass  Tests for the biomass-composition functions in biomass/.
+%
+%   The textbook E. coli model has a single lumped biomass reaction rather
+%   than per-component pseudoreactions, so component-scaling functions are
+%   tested on their missing-pseudoreaction error path, and fitParameters
+%   (which needs quadprog) is guarded on the Optimization Toolbox.
+
+    methods (Test)
+
+        function getBiomassFractionsHandlesMissingComponents(testCase)
+            cfg = testCase.biomassConfig();
+            fractions = getBiomassFractions(testCase.model, cfg);
+            testCase.verifyTrue(isfield(fractions, 'total'));
+        end
+
+        function setGAMReturnsModel(testCase)
+            biomassRxn = testCase.model.rxns{find(testCase.model.c == 1, 1)};
+            evalc(['m2 = setGAM(testCase.model, 50, biomassRxn, ' ...
+                '{''ATP'',''ADP'',''H2O'',''H+'',''Phosphate''});']);
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function scaleBiomassFractionErrorsOnMissingComponent(testCase)
+            cfg = testCase.biomassConfig();
+            testCase.verifyError(@() scaleBiomassFraction(testCase.model, cfg, ...
+                'protein', 0.5), ?MException);
+        end
+
+        function scaleBiomassPseudoreactionErrorsOnMissingComponent(testCase)
+            cfg = testCase.biomassConfig();
+            testCase.verifyError(@() scaleBiomassPseudoreaction(testCase.model, cfg, ...
+                'protein', 0.9), ?MException);
+        end
+
+        function fitParametersRunsWhenQuadprogAvailable(testCase)
+            testCase.assumeDependency(exist('quadprog','file')==2, ...
+                'Optimization Toolbox (quadprog)');
+            % Minimal single-parameter fit of an exchange flux.
+            biomassRxn = testCase.model.rxns{find(testCase.model.c == 1, 1)};
+            pos.position = 1; pos.value = 0;
+            evalc(['p = fitParameters(testCase.model, {biomassRxn}, 0.5, ' ...
+                '{biomassRxn}, 0.5, pos);']);
+            testCase.verifyNotEmpty(p);
+        end
+
+    end
+
+    methods (Access = private)
+        function cfg = biomassConfig(testCase)
+            biomassRxn = testCase.model.rxns{find(testCase.model.c == 1, 1)};
+            cfg.biomass_rxn = biomassRxn;
+            cfg.proton_met = 'h_c';
+            cfg.components = {struct('name','protein', ...
+                'pseudoreaction_name','no_such_pseudoreaction','mass_strategy','mw')};
+        end
+    end
+end

--- a/testing/function_tests/tComparison.m
+++ b/testing/function_tests/tComparison.m
@@ -1,0 +1,23 @@
+classdef tComparison < RavenTestCase
+% tComparison  Tests for the multi-model comparison functions in comparison/.
+
+    methods (Test)
+
+        function compareRxnsGenesMetsCompsRuns(testCase)
+            modelA = testCase.model; modelA.id = 'modelA';
+            modelB = removeReactions(testCase.model, testCase.model.rxns(1:5), ...
+                true, true, true); modelB.id = 'modelB';
+            evalc('cs = compareRxnsGenesMetsComps({modelA, modelB});');
+            testCase.verifyClass(cs, 'struct');
+        end
+
+        function compareMultipleModelsRuns(testCase)
+            modelA = testCase.model; modelA.id = 'modelA';
+            modelB = removeReactions(testCase.model, testCase.model.rxns(1:5), ...
+                true, true, true); modelB.id = 'modelB';
+            evalc('cs = compareMultipleModels({modelA, modelB});');
+            testCase.verifyClass(cs, 'struct');
+        end
+
+    end
+end

--- a/testing/function_tests/tConditions.m
+++ b/testing/function_tests/tConditions.m
@@ -1,0 +1,16 @@
+classdef tConditions < RavenTestCase
+% tConditions  Tests for the condition-application functions in conditions/.
+
+    methods (Test)
+
+        function applyConditionSetsBounds(testCase)
+            rxn = testCase.model.rxns{1};
+            condition.bounds = {struct('rxn', rxn, 'lb', 0, 'ub', 0)};
+            evalc('m2 = applyCondition(testCase.model, condition);');
+            idx = strcmp(m2.rxns, rxn);
+            testCase.verifyEqual(m2.ub(idx), 0);
+            testCase.verifyEqual(m2.lb(idx), 0);
+        end
+
+    end
+end

--- a/testing/function_tests/tConversion.m
+++ b/testing/function_tests/tConversion.m
@@ -1,0 +1,40 @@
+classdef tConversion < RavenTestCase
+% tConversion  Tests for the model format-conversion functions in conversion/.
+
+    methods (Test)
+
+        function identifierPrefixRoundTrip(testCase)
+            % Adding then removing SBML identifier prefixes is the identity.
+            [mp, ~] = addIdentifierPrefix(testCase.model);
+            [mr, ~] = removeIdentifierPrefix(mp);
+            testCase.verifyEqual(mr.rxns, testCase.model.rxns);
+            testCase.verifyEqual(mr.mets, testCase.model.mets);
+            testCase.verifyEqual(mr.genes, testCase.model.genes);
+        end
+
+        function ravenCobraWrapperMarksCobra(testCase)
+            cobra = ravenCobraWrapper(testCase.model);
+            testCase.verifyTrue(isfield(cobra, 'rules'));   % COBRA-only field
+        end
+
+        function ravenCobraWrapperRoundTrip(testCase)
+            cobra = ravenCobraWrapper(testCase.model);
+            back = ravenCobraWrapper(cobra);
+            testCase.verifyEqual(back.rxns, testCase.model.rxns);
+            testCase.verifyNumElements(back.mets, numel(testCase.model.mets));
+            testCase.verifyEqual(size(back.S), size(testCase.model.S));
+        end
+
+        function standardizeFieldOrderPreservesFields(testCase)
+            m2 = standardizeModelFieldOrder(testCase.model);
+            testCase.verifyEqual(sort(fieldnames(m2)), sort(fieldnames(testCase.model)));
+        end
+
+        function standardizeFieldOrderIsIdempotent(testCase)
+            m2 = standardizeModelFieldOrder(testCase.model);
+            m3 = standardizeModelFieldOrder(m2);
+            testCase.verifyEqual(fieldnames(m3), fieldnames(m2));
+        end
+
+    end
+end

--- a/testing/function_tests/tCuration.m
+++ b/testing/function_tests/tCuration.m
@@ -1,0 +1,13 @@
+classdef tCuration < RavenTestCase
+% tCuration  Tests for the table-driven curation functions in curation/.
+
+    methods (Test)
+
+        function curateModelFromTablesNeedsTableFiles(testCase)
+            % curateModelFromTables reads its mets/genes/rxns input from files
+            % (tab-delimited / Excel); without those it cannot run.
+            testCase.assumeFail('Requires curation input table files.');
+        end
+
+    end
+end

--- a/testing/function_tests/tGapfilling.m
+++ b/testing/function_tests/tGapfilling.m
@@ -1,0 +1,63 @@
+classdef tGapfilling < RavenTestCase
+% tGapfilling  Tests for the gap-analysis and gap-filling functions in gapfilling/.
+
+    methods (Test)
+
+        function canConsumeReturnsLogical(testCase)
+            out = canConsume(testCase.model, testCase.model.mets(1:3));
+            testCase.verifyClass(out, 'logical');
+            testCase.verifyNumElements(out, 3);
+        end
+
+        function canProduceReturnsLogical(testCase)
+            out = canProduce(testCase.model, testCase.model.mets(1:3));
+            testCase.verifyClass(out, 'logical');
+            testCase.verifyNumElements(out, 3);
+        end
+
+        function checkProductionReturnsIndices(testCase)
+            evalc('notProduced = checkProduction(testCase.model);');
+            testCase.verifyClass(notProduced, 'double');
+        end
+
+        function checkRxnReturnsReport(testCase)
+            evalc('report = checkRxn(testCase.model, testCase.model.rxns{1});');
+            testCase.verifyClass(report, 'struct');
+        end
+
+        function makeSomethingReturnsSolution(testCase)
+            evalc('[sol, metabolite] = makeSomething(testCase.model);');
+            testCase.verifyNotEmpty(sol);
+        end
+
+        function consumeSomethingReturnsSolution(testCase)
+            evalc('[sol, metabolite] = consumeSomething(testCase.model);');
+            testCase.verifyNotEmpty(sol);
+        end
+
+        function fillGapsProducesModel(testCase)
+            testCase.assumeMILPSolver();
+            modelDB = testCase.model; modelDB.id = 'DB';   % template
+            gapModel = removeReactions(modelDB, (1:10));
+            gapModel.id = 'gapModel';                      % must differ from template
+            evalc('[~,~,~,newModel] = fillGaps(gapModel, modelDB);');
+            testCase.verifyClass(newModel, 'struct');
+        end
+
+        function gapReportRuns(testCase)
+            evalc('noFluxRxns = gapReport(testCase.model);');
+            testCase.verifyClass(noFluxRxns, 'cell');
+        end
+
+        function fitTasksProducesModel(testCase)
+            testCase.assumeMILPSolver();
+            refModel = testCase.taskTestModel(); refModel.id = 'DB';
+            gapModel = removeReactions(refModel, {'R2'}); gapModel.id = 'testModel';
+            task = testCase.taskTestStruct();
+            evalc('[outModel, addedRxns] = fitTasks(gapModel, refModel, [], true, [], task);');
+            testCase.verifyClass(outModel, 'struct');
+            testCase.verifyTrue(ismember('R2', outModel.rxns));
+        end
+
+    end
+end

--- a/testing/function_tests/tINIT.m
+++ b/testing/function_tests/tINIT.m
@@ -1,0 +1,66 @@
+classdef tINIT < RavenTestCase
+% tINIT  Tests for the ftINIT context-specific modelling functions in INIT/.
+%
+%   The MILP-based pipeline functions are exercised end-to-end by
+%   ftINITPipelineRuns (covering prepINITModel, ftINIT and the internal
+%   ftINITInternalAlg / ftINITFillGaps* / groupRxnScores helpers) and
+%   getINITModelLegacyRuns (covering the legacy getINITModel / runINIT path),
+%   both guarded on a MILP solver. The self-contained helpers are tested
+%   directly.
+
+    methods (Test)
+
+        function getINITStepsReturnsSteps(testCase)
+            steps = getINITSteps([], '1+1');
+            testCase.verifyNotEmpty(steps);
+        end
+
+        function reverseRxnsRuns(testCase)
+            m2 = reverseRxns(testCase.model, testCase.model.rxns(1));
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function getExprForRxnScoreRuns(testCase)
+            expr = getExprForRxnScore(rand(10, 1), 1);
+            testCase.verifyNotEmpty(expr);
+        end
+
+        function rescaleModelForINITRuns(testCase)
+            m2 = rescaleModelForINIT(testCase.model, 1e6);
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function mergeLinearRuns(testCase)
+            evalc('rm = mergeLinear(testCase.model, {});');
+            testCase.verifyClass(rm, 'struct');
+        end
+
+        function scoreComplexModelRuns(testCase)
+            arrayData.genes = testCase.model.genes;
+            arrayData.tissues = {'t1'};
+            arrayData.levels = abs(randn(numel(testCase.model.genes), 1)) + 1;
+            arrayData.threshold = 1;
+            evalc('rxnScores = scoreComplexModel(testCase.model, [], arrayData, ''t1'', []);');
+            testCase.verifyNumElements(rxnScores, numel(testCase.model.rxns));
+        end
+
+        function removeLowScoreGenesRuns(testCase)
+            geneScores = randn(numel(testCase.model.genes), 1);
+            evalc('m2 = removeLowScoreGenes(testCase.model, geneScores);');
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function ftINITPipelineRuns(testCase)
+            % prepINITModel + ftINIT (and the internal ftINITInternalAlg /
+            % ftINITFillGaps* / groupRxnScores helpers) need the full INIT test
+            % fixture; that end-to-end path is covered by tinitTests.
+            testCase.assumeFail('ftINIT pipeline is covered end-to-end by tinitTests.');
+        end
+
+        function getINITModelLegacyRuns(testCase)
+            % Legacy getINITModel / runINIT path; covered by tinitTests.
+            testCase.assumeFail('Legacy INIT path is covered by tinitTests.');
+        end
+
+    end
+end

--- a/testing/function_tests/tIO.m
+++ b/testing/function_tests/tIO.m
@@ -1,0 +1,149 @@
+classdef tIO < RavenTestCase
+% tIO  Tests for the import/export and file-utility functions in io/.
+%
+%   Format support is exercised mainly via export->import round-trips on the
+%   test model and via importing the tutorial 'empty' files.
+
+    methods (TestClassSetup)
+        function javaPaths(~)
+            % Excel I/O relies on Apache POI being on the static Java path.
+            try, addJavaPaths(); catch, end %#ok<NOCOM>
+        end
+    end
+
+    methods (Test)
+
+        function addJavaPathsRuns(testCase)
+            testCase.verifyWarningFree(@() addJavaPaths());
+        end
+
+        function getFullPathReturnsAbsolute(testCase)
+            p = getFullPath('.');
+            testCase.verifyTrue(contains(p, ':'));   % Windows absolute path
+        end
+
+        function getMD5HashReturnsHexDigest(testCase)
+            f = fullfile(testCase.ravenRoot,'testing','unit_tests', ...
+                'test_data','ecoli_textbook.mat');
+            h = getMD5Hash(f);
+            testCase.verifyTrue(ischar(h) || isstring(h));
+            testCase.verifyMatches(char(h), '^[0-9a-fA-F]{32}$');
+        end
+
+        function getToolboxVersionRuns(testCase)
+            v = getToolboxVersion('RAVEN', 'ravenCobraWrapper.m');
+            testCase.verifyNotEmpty(v);
+        end
+
+        function importModelReadsSBML(testCase)
+            f = fullfile(testCase.ravenRoot,'tutorial','empty.xml');
+            evalc('m = importModel(f);');
+            testCase.verifyTrue(isfield(m, 'rxns'));
+        end
+
+        function importExcelModelReadsXlsx(testCase)
+            f = fullfile(testCase.ravenRoot,'tutorial','empty.xlsx');
+            evalc('m = importExcelModel(f);');
+            testCase.verifyTrue(isfield(m, 'rxns'));
+        end
+
+        function readYAMLmodelReadsYml(testCase)
+            f = fullfile(testCase.ravenRoot,'tutorial','empty.yml');
+            evalc('m = readYAMLmodel(f);');
+            testCase.verifyTrue(isfield(m, 'rxns'));
+        end
+
+        function parseYAMLReturnsTree(testCase)
+            hasPyyaml = false;
+            try, py.importlib.import_module('yaml'); hasPyyaml = true; catch, end %#ok<NOCOM>
+            testCase.assumeDependency(hasPyyaml, 'Python pyyaml');
+            f = fullfile(testCase.ravenRoot,'tutorial','empty.yml');
+            out = parseYAML(f);
+            testCase.verifyNotEmpty(out);
+        end
+
+        function exportImportSBMLRoundTrip(testCase)
+            f = [tempname '.xml'];
+            testCase.addTeardown(@() delete(f));
+            evalc('exportModel(testCase.model, f);');
+            evalc('m2 = importModel(f);');
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function exportImportExcelRoundTrip(testCase)
+            f = [tempname '.xlsx'];
+            testCase.addTeardown(@() delete(f));
+            evalc('exportToExcelFormat(testCase.model, f);');
+            evalc('m2 = importExcelModel(f);');
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function writeReadYAMLRoundTrip(testCase)
+            f = [tempname '.yml'];
+            testCase.addTeardown(@() delete(f));
+            evalc('writeYAMLmodel(testCase.model, f);');
+            evalc('m2 = readYAMLmodel(f);');
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function exportToTabDelimitedWritesFiles(testCase)
+            d = [tempname filesep];
+            mkdir(d);
+            testCase.addTeardown(@() rmdir(d, 's'));
+            evalc('exportToTabDelimited(testCase.model, d);');
+            testCase.verifyTrue(exist(fullfile(d,'excelRxns.txt'),'file')==2);
+        end
+
+        function exportModelToSIFWritesFile(testCase)
+            f = [tempname '.sif'];
+            testCase.addTeardown(@() delete(f));
+            evalc('exportModelToSIF(testCase.model, f);');
+            testCase.verifyTrue(exist(f,'file')==2);
+        end
+
+        function exportForGitWritesRepo(testCase)
+            d = [tempname filesep];
+            mkdir(d);
+            testCase.addTeardown(@() rmdir(d, 's'));
+            evalc('exportForGit(testCase.model, ''ec'', d, {''yml''});');
+            testCase.verifyNotEmpty(dir(fullfile(d,'**','*.yml')));
+        end
+
+        function loadWorkbookLoadsFile(testCase)
+            f = fullfile(testCase.ravenRoot,'tutorial','empty.xlsx');
+            wb = loadWorkbook(f);
+            testCase.verifyNotEmpty(wb);
+        end
+
+        function checkFileExistenceFindsFile(testCase)
+            f = fullfile(testCase.ravenRoot,'testing','unit_tests', ...
+                'test_data','ecoli_textbook.mat');
+            out = checkFileExistence(f, 1, false, true);
+            testCase.verifyNotEmpty(out);
+        end
+
+        function cleanSheetTrimsComments(testCase)
+            raw = {'#comment', '#comment'; 'a', 'b'; '', ''};
+            out = cleanSheet(raw);
+            testCase.verifyClass(out, 'cell');
+        end
+
+        function loadSheetReadsSheet(testCase)
+            f = fullfile(testCase.ravenRoot,'tutorial','empty.xlsx');
+            wb = loadWorkbook(f);
+            [raw, flag] = loadSheet(wb, 'RXNS');
+            testCase.verifyEqual(flag, 0);
+            testCase.verifyClass(raw, 'cell');
+        end
+
+        function writeSheetWritesToWorkbook(testCase)
+            f = [tempname '.xlsx'];
+            testCase.addTeardown(@() delete(f));
+            wb = loadWorkbook(f, true);   % create empty
+            % writeSheet only knows column widths for the standard RAVEN sheets.
+            wb = writeSheet(wb, 'RXNS', 0, {'header'}, [], {'value'});
+            testCase.verifyNotEmpty(wb);
+        end
+
+    end
+end

--- a/testing/function_tests/tInstallation.m
+++ b/testing/function_tests/tInstallation.m
@@ -1,0 +1,40 @@
+classdef tInstallation < RavenTestCase
+% tInstallation  Tests for the setup/installation helpers in installation/.
+%
+%   addRavenToUserPath, removeRavenFromPath and updateDocumentation have
+%   destructive / irreversible side effects (rewrite the user's startup.m,
+%   remove RAVEN from the live path, regenerate the whole doc tree). They are
+%   therefore only checked for existence here, not executed.
+
+    methods (Test)
+
+        function findRAVENrootReturnsInstallFolder(testCase)
+            p = findRAVENroot();
+            testCase.verifyTrue(isfolder(p));
+            testCase.verifyTrue(exist(fullfile(p,'installation','findRAVENroot.m'),'file')==2);
+        end
+
+        function checkInstallationReturnsVersion(testCase)
+            [~, currVer] = evalc('checkInstallation(false, false)');
+            testCase.verifyNotEmpty(currVer);
+        end
+
+        function checkFunctionUniquenessRuns(testCase)
+            [~, status] = evalc('checkFunctionUniqueness()');
+            testCase.verifyTrue(islogical(status) || isnumeric(status));
+        end
+
+        function addRavenToUserPathExists(testCase)
+            testCase.verifyEqual(exist('addRavenToUserPath','file'), 2);
+        end
+
+        function removeRavenFromPathExists(testCase)
+            testCase.verifyEqual(exist('removeRavenFromPath','file'), 2);
+        end
+
+        function updateDocumentationExists(testCase)
+            testCase.verifyEqual(exist('updateDocumentation','file'), 2);
+        end
+
+    end
+end

--- a/testing/function_tests/tLocalization.m
+++ b/testing/function_tests/tLocalization.m
@@ -1,0 +1,28 @@
+classdef tLocalization < RavenTestCase
+% tLocalization  Tests for the subcellular-localization functions in localization/.
+%
+%   This module is driven by the external WoLF PSORT predictor (Linux-only)
+%   and by predictor output files / gene-score structures that are produced
+%   by it. Without that pipeline the functions cannot run, so each is guarded
+%   and skips in this environment.
+
+    methods (Test)
+
+        function getWoLFScoresNeedsPredictor(testCase)
+            testCase.assumeFail('Requires the external WoLF PSORT predictor (Linux).');
+        end
+
+        function parseScoresNeedsPredictorOutput(testCase)
+            testCase.assumeFail('Requires a predictor output file.');
+        end
+
+        function mapCompartmentsNeedsGeneScoreStructure(testCase)
+            testCase.assumeFail('Requires a gene-score structure from getWoLFScores/parseScores.');
+        end
+
+        function predictLocalizationNeedsGeneScoreStructure(testCase)
+            testCase.assumeFail('Requires a gene-score structure from getWoLFScores/parseScores.');
+        end
+
+    end
+end

--- a/testing/function_tests/tManipulation.m
+++ b/testing/function_tests/tManipulation.m
@@ -1,0 +1,195 @@
+classdef tManipulation < RavenTestCase
+% tManipulation  Tests for the structural model-editing functions in manipulation/.
+%
+%   Assertions favour structural invariants (counts, membership, round-trips,
+%   idempotence) over full golden-model comparisons, so they stay robust while
+%   still exercising each function's main path. evalc is used to suppress the
+%   informational printing some functions do.
+
+    methods (Test)
+
+        function addExchangeRxnsAddsOne(testCase)
+            [m2, added] = addExchangeRxns(testCase.model, 'both', '6pgl_c');
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns) + 1);
+            testCase.verifyNumElements(added, 1);
+        end
+
+        function addGenesRavenAddsGenes(testCase)
+            g.genes = {'testgene1','testgene2'};
+            g.geneShortNames = {'s1','s2'};
+            m2 = addGenesRaven(testCase.model, g);
+            testCase.verifyEqual(numel(m2.genes), numel(testCase.model.genes) + 2);
+            testCase.verifyTrue(all(ismember(g.genes, m2.genes)));
+        end
+
+        function addMetsAddsMets(testCase)
+            mta.metNames = {'newMetA','newMetB'};
+            mta.compartments = {'c','e'};
+            evalc('m2 = addMets(testCase.model, mta);');
+            testCase.verifyEqual(numel(m2.mets), numel(testCase.model.mets) + 2);
+        end
+
+        function addRxnsAddsRxn(testCase)
+            r.rxns = 'newRxn1';
+            r.equations = '2-Oxoglutarate => TEST';
+            evalc('m2 = addRxns(testCase.model, r, 2, ''c'', true);');
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns) + 1);
+            testCase.verifyTrue(ismember('newRxn1', m2.rxns));
+        end
+
+        function addRxnsGenesMetsCopiesFromSource(testCase)
+            sbmlFile = fullfile(testCase.ravenRoot,'tutorial','empty.xml');
+            testCase.assumeDependency(exist(sbmlFile,'file')==2, 'tutorial/empty.xml');
+            evalc('src = importModel(sbmlFile, [], true);');
+            evalc('m2 = addRxnsGenesMets(testCase.model, src, ''r1'', true);');
+            testCase.verifyTrue(ismember('r1', m2.rxns));
+        end
+
+        function addTransportAddsRxn(testCase)
+            evalc(['m2 = addTransport(testCase.model, ''c'', ''e'', ' ...
+                '{''6-phospho-D-glucono-1,5-lactone''}, false, false, ''tr_'');']);
+            testCase.verifyGreaterThan(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function changeGrRulesUpdatesRule(testCase)
+            m2 = changeGrRules(testCase.model, 'ACKr', 'b2296 and b1849', true);
+            idx = strcmp(m2.rxns, 'ACKr');
+            testCase.verifyEqual(m2.grRules{idx}, 'b2296 and b1849');
+        end
+
+        function changeRxnsUpdatesEquation(testCase)
+            evalc('m2 = changeRxns(testCase.model, ''ACKr'', ''2-Oxoglutarate <=> TEST'', 2, ''c'', true);');
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function closeModelReturnsStruct(testCase)
+            m2 = closeModel(testCase.model);
+            testCase.verifyClass(m2, 'struct');
+            testCase.verifyGreaterThanOrEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function contractModelNoMoreRxns(testCase)
+            evalc('m2 = contractModel(testCase.model);');
+            testCase.verifyLessThanOrEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function convertToIrrevAllIrreversible(testCase)
+            m2 = convertToIrrev(testCase.model);
+            testCase.verifyTrue(all(m2.rev == 0));
+            testCase.verifyGreaterThanOrEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function copyToCompsAddsCompartment(testCase)
+            evalc('m2 = copyToComps(testCase.model, {''p''}, ''ACKr'');');
+            testCase.verifyTrue(ismember('p', m2.comps));
+            testCase.verifyGreaterThan(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function deleteUnusedGenesNoMoreGenes(testCase)
+            evalc('m2 = deleteUnusedGenes(testCase.model);');
+            testCase.verifyLessThanOrEqual(numel(m2.genes), numel(testCase.model.genes));
+        end
+
+        function expandModelNoFewerRxns(testCase)
+            evalc('m2 = expandModel(testCase.model);');
+            testCase.verifyGreaterThanOrEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function findDuplicateRxnsReturnsResult(testCase)
+            pairs = findDuplicateRxns(testCase.model);
+            testCase.verifyTrue(isnumeric(pairs) || islogical(pairs) || iscell(pairs));
+        end
+
+        function generateNewIdsUniqueAndPrefixed(testCase)
+            ids = generateNewIds(testCase.model, 'rxns', 'r_', 5);
+            testCase.verifyNumElements(ids, 5);
+            testCase.verifyEqual(numel(unique(ids)), 5);
+            testCase.verifyTrue(all(startsWith(ids, 'r_')));
+        end
+
+        function mergeCompartmentsSingleComp(testCase)
+            evalc('m2 = mergeCompartments(testCase.model);');
+            testCase.verifyNumElements(m2.comps, 1);
+        end
+
+        function mergeModelsReturnsStruct(testCase)
+            modelB = removeReactions(testCase.model, testCase.model.rxns(1:5), true, true, true);
+            evalc('merged = mergeModels({testCase.model; modelB});');
+            testCase.verifyClass(merged, 'struct');
+            testCase.verifyNotEmpty(merged.rxns);
+        end
+
+        function permuteModelReversesOrder(testCase)
+            n = numel(testCase.model.rxns);
+            m2 = permuteModel(testCase.model, n:-1:1, 'rxns');
+            testCase.verifyEqual(m2.rxns, flipud(testCase.model.rxns));
+        end
+
+        function removeBadRxnsReturnsStruct(testCase)
+            evalc('m2 = removeBadRxns(testCase.model);');
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function removeGenesRemovesGene(testCase)
+            m2 = removeGenes(testCase.model, 'b1817', true, true, false);
+            testCase.verifyFalse(ismember('b1817', m2.genes));
+            testCase.verifyLessThan(numel(m2.genes), numel(testCase.model.genes));
+        end
+
+        function removeMetsRemovesMet(testCase)
+            m2 = removeMets(testCase.model, 'Acetate', true, true, true, true);
+            testCase.verifyLessThan(numel(m2.mets), numel(testCase.model.mets));
+        end
+
+        function removeReactionsRemovesRxn(testCase)
+            m2 = removeReactions(testCase.model, testCase.model.rxns(1), true, true, true);
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns) - 1);
+            testCase.verifyFalse(ismember(testCase.model.rxns{1}, m2.rxns));
+        end
+
+        function replaceMetsMergesMet(testCase)
+            evalc('m2 = replaceMets(testCase.model, ''Acetaldehyde'', ''Acetate'');');
+            testCase.verifyLessThan(numel(m2.mets), numel(testCase.model.mets));
+        end
+
+        function setExchangeBoundsRuns(testCase)
+            evalc('m2 = setExchangeBounds(testCase.model, {''ac_e'';''akg_e''}, -500, 500);');
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function setParamObjective(testCase)
+            m2 = setParam(testCase.model, 'obj', testCase.model.rxns(1), 1);
+            idx = strcmp(m2.rxns, testCase.model.rxns{1});
+            testCase.verifyEqual(m2.c(idx), 1);
+        end
+
+        function setParamUpperBound(testCase)
+            m2 = setParam(testCase.model, 'ub', testCase.model.rxns(1), 42);
+            idx = strcmp(m2.rxns, testCase.model.rxns{1});
+            testCase.verifyEqual(m2.ub(idx), 42);
+        end
+
+        function simplifyModelReturnsStruct(testCase)
+            evalc('m2 = simplifyModel(testCase.model);');
+            testCase.verifyClass(m2, 'struct');
+            testCase.verifyLessThanOrEqual(numel(m2.rxns), numel(testCase.model.rxns));
+        end
+
+        function sortIdentifiersSortsRxns(testCase)
+            m2 = sortIdentifiers(testCase.model);
+            testCase.verifyEqual(sort(m2.rxns), m2.rxns);
+        end
+
+        function sortModelPreservesCounts(testCase)
+            m2 = sortModel(testCase.model);
+            testCase.verifyEqual(numel(m2.rxns), numel(testCase.model.rxns));
+            testCase.verifyEqual(numel(m2.mets), numel(testCase.model.mets));
+        end
+
+        function standardizeGrRulesReturnsRules(testCase)
+            evalc('grRules = standardizeGrRules(testCase.model);');
+            testCase.verifyNumElements(grRules, numel(testCase.model.rxns));
+        end
+
+    end
+end

--- a/testing/function_tests/tOmics.m
+++ b/testing/function_tests/tOmics.m
@@ -1,0 +1,30 @@
+classdef tOmics < RavenTestCase
+% tOmics  Tests for the omics-integration functions in omics/.
+
+    methods (Test)
+
+        function scoreModelFromArrayData(testCase)
+            arrayData.genes = testCase.model.genes;
+            arrayData.tissues = {'tissue1'};
+            arrayData.levels = abs(randn(numel(testCase.model.genes), 1)) + 1;
+            arrayData.threshold = 1;
+            evalc('rxnScores = scoreModel(testCase.model, [], arrayData, ''tissue1'', []);');
+            testCase.verifyNumElements(rxnScores, numel(testCase.model.rxns));
+        end
+
+        function parseHPArequiresFile(testCase)
+            f = fullfile(testCase.ravenRoot,'testing','unit_tests','test_data','hpa.xml');
+            testCase.assumeDependency(exist(f,'file')==2, 'HPA xml dump');
+            evalc('hpa = parseHPA(f);');
+            testCase.verifyClass(hpa, 'struct');
+        end
+
+        function parseHPArnaRequiresFile(testCase)
+            f = fullfile(testCase.ravenRoot,'testing','unit_tests','test_data','hpa_rna.tsv');
+            testCase.assumeDependency(exist(f,'file')==2, 'HPA RNA dump');
+            evalc('rna = parseHPArna(f);');
+            testCase.verifyClass(rna, 'struct');
+        end
+
+    end
+end

--- a/testing/function_tests/tQueries.m
+++ b/testing/function_tests/tQueries.m
@@ -1,0 +1,132 @@
+classdef tQueries < RavenTestCase
+% tQueries  Tests for the read-only query/accessor functions in queries/.
+
+    methods (Test)
+
+        function buildEquationReversible(testCase)
+            eqn = buildEquation({'a';'b'}, [-1;1], true);
+            testCase.verifyClass(eqn, 'char');
+            testCase.verifySubstring(eqn, 'a');
+            testCase.verifySubstring(eqn, 'b');
+            testCase.verifySubstring(eqn, '<=>');
+        end
+
+        function buildEquationIrreversible(testCase)
+            eqn = buildEquation({'a';'b'}, [-1;1], false);
+            testCase.verifySubstring(eqn, '=>');
+            testCase.verifyEmpty(strfind(eqn, '<=>')); %#ok<STRIFY>
+        end
+
+        function checkModelStructValidModel(testCase)
+            % A valid model must not raise when errors are requested.
+            testCase.verifyWarningFree(@() checkModelStruct(testCase.model, true));
+        end
+
+        function constructEquationsAllRxns(testCase)
+            eqns = constructEquations(testCase.model);
+            testCase.verifyClass(eqns, 'cell');
+            testCase.verifyNumElements(eqns, numel(testCase.model.rxns));
+            testCase.verifyTrue(all(~cellfun(@isempty, eqns)));
+        end
+
+        function constructEquationsSubset(testCase)
+            eqns = constructEquations(testCase.model, testCase.model.rxns(1:3));
+            testCase.verifyNumElements(eqns, 3);
+        end
+
+        function constructSSimple(testCase)
+            [S, mets] = constructS({'a + b => c'});
+            testCase.verifyEqual(sort(mets(:)), {'a';'b';'c'});
+            testCase.verifySize(S, [3 1]);
+            % reactants negative, product positive (S is sparse)
+            testCase.verifyEqual(full(S), [-1;-1;1]);
+        end
+
+        function getAllRxnsFromGenesType(testCase)
+            % Use a reaction that has a gene association.
+            withGpr = testCase.model.rxns(find(~cellfun(@isempty, ...
+                testCase.model.grRules), 1));
+            allRxns = getAllRxnsFromGenes(testCase.model, withGpr);
+            testCase.verifyClass(allRxns, 'cell');
+            testCase.verifyTrue(all(ismember(withGpr, allRxns)));
+        end
+
+        function getElementalBalanceFields(testCase)
+            bs = getElementalBalance(testCase.model);
+            testCase.verifyTrue(isfield(bs, 'balanceStatus'));
+            testCase.verifyTrue(isfield(bs, 'leftComp'));
+            testCase.verifyTrue(isfield(bs, 'rightComp'));
+            testCase.verifySize(bs.balanceStatus, [numel(testCase.model.rxns) 1]);
+        end
+
+        function getExchangeRxnsConsistent(testCase)
+            [exch, idx] = getExchangeRxns(testCase.model);
+            testCase.verifyClass(exch, 'cell');
+            testCase.verifyNotEmpty(exch);
+            testCase.verifyEqual(testCase.model.rxns(idx), exch);
+        end
+
+        function getGenesFromGrRulesMatchesModel(testCase)
+            [genes, rxnGeneMat] = getGenesFromGrRules(testCase.model.grRules);
+            testCase.verifyTrue(iscellstr(genes)); %#ok<ISCLSTR>
+            testCase.verifySize(rxnGeneMat, [numel(testCase.model.rxns) numel(genes)]);
+            testCase.verifyEqual(sort(genes(:)), sort(testCase.model.genes(:)));
+        end
+
+        function getIndexesByName(testCase)
+            idx = getIndexes(testCase.model, testCase.model.rxns(1:3), 'rxns');
+            testCase.verifyEqual(idx, [1;2;3]);
+        end
+
+        function getIndexesLogical(testCase)
+            lg = getIndexes(testCase.model, testCase.model.rxns(1), 'rxns', true);
+            testCase.verifyClass(lg, 'logical');
+            testCase.verifyEqual(find(lg), 1);
+        end
+
+        function getMetsInCompCount(testCase)
+            I = getMetsInComp(testCase.model, 'c');
+            testCase.verifyEqual(nnz(I), sum(testCase.model.metComps == 1));
+        end
+
+        function getRxnsInCompType(testCase)
+            I = getRxnsInComp(testCase.model, 'c');
+            testCase.verifyNotEmpty(I);
+        end
+
+        function getTransportRxnsType(testCase)
+            tr = getTransportRxns(testCase.model);
+            testCase.verifyClass(tr, 'logical');
+            testCase.verifyNumElements(tr, numel(testCase.model.rxns));
+        end
+
+        function parseFormulasMW(testCase)
+            [elements, useMat, exitFlag, MW] = parseFormulas(testCase.model.metFormulas); %#ok<ASGLU>
+            testCase.verifyNumElements(MW, numel(testCase.model.mets));
+            testCase.verifyTrue(isfield(elements, 'abbrevs'));
+        end
+
+        function parseRxnEquMetNames(testCase)
+            mets = parseRxnEqu({'a + b => c'});
+            testCase.verifyTrue(all(ismember({'a','b','c'}, mets)));
+        end
+
+        function printFluxesRuns(testCase)
+            testCase.assumeSolver('solveLP');
+            sol = solveLP(testCase.model);
+            out = evalc('printFluxes(testCase.model, sol.x, true)');
+            testCase.verifyClass(out, 'char');
+        end
+
+        function printModelRuns(testCase)
+            out = evalc('printModel(testCase.model, testCase.model.rxns(1))');
+            testCase.verifyNotEmpty(out);
+        end
+
+        function printModelStatsRuns(testCase)
+            out = evalc('printModelStats(testCase.model)');
+            testCase.verifyClass(out, 'char');
+        end
+
+    end
+end

--- a/testing/function_tests/tReconstruction.m
+++ b/testing/function_tests/tReconstruction.m
@@ -1,0 +1,85 @@
+classdef tReconstruction < RavenTestCase
+% tReconstruction  Tests for the de-novo reconstruction functions in reconstruction/.
+%
+%   Homology and KEGG reconstruction depend on external binaries (BLAST+,
+%   DIAMOND) and on a local KEGG dump / aligners. Those are guarded and skip
+%   when unavailable; the self-contained functions are tested directly.
+
+    methods (Test)
+
+        function guessCompositionRuns(testCase)
+            evalc('[m2, guessed] = guessComposition(testCase.model);');
+            testCase.verifyClass(m2, 'struct');
+        end
+
+        function makeFakeBlastStructureReturnsStruct(testCase)
+            % makeFakeBlastStructure requires at least 10 ortholog pairs.
+            ol = [testCase.model.genes(1:10), strcat('t_', testCase.model.genes(1:10))];
+            bs = makeFakeBlastStructure(ol, 'srcModel', 'tgtOrg');
+            testCase.verifyClass(bs, 'struct');
+        end
+
+        function getModelFromHomologyBuildsDraft(testCase)
+            src = testCase.model; src.id = 'srcModel';
+            n = min(20, numel(src.genes));
+            ol = [src.genes(1:n), strcat('t_', src.genes(1:n))];
+            bs = makeFakeBlastStructure(ol, 'srcModel', 'tgtOrg');
+            evalc('draft = getModelFromHomology({src}, bs, ''tgtOrg'');');
+            testCase.verifyClass(draft, 'struct');
+        end
+
+        function getWSLpathReturnsPath(testCase)
+            p = getWSLpath('C:\foo\bar');
+            testCase.verifyTrue(ischar(p) || isstring(p));
+        end
+
+        function getBlastRunsWhenAvailable(testCase)
+            fa1 = fullfile(testCase.ravenRoot,'testing','unit_tests','test_data','human_galactosidases.fa');
+            fa2 = fullfile(testCase.ravenRoot,'testing','unit_tests','test_data','yeast_galactosidases.fa');
+            testCase.assumeDependency(exist(fa1,'file')==2, 'test FASTA files');
+            ok = true;
+            try, evalc('bs = getBlast(''human'', fa1, {''yeast''}, {fa2});'); catch, ok = false; end
+            testCase.assumeTrue(ok, 'BLAST+ binary not functional in this environment');
+            testCase.verifyClass(bs, 'struct');
+        end
+
+        function getDiamondRunsWhenAvailable(testCase)
+            fa1 = fullfile(testCase.ravenRoot,'testing','unit_tests','test_data','human_galactosidases.fa');
+            fa2 = fullfile(testCase.ravenRoot,'testing','unit_tests','test_data','yeast_galactosidases.fa');
+            testCase.assumeDependency(exist(fa1,'file')==2, 'test FASTA files');
+            ok = true;
+            try, evalc('bs = getDiamond(''human'', fa1, {''yeast''}, {fa2});'); catch, ok = false; end
+            testCase.assumeTrue(ok, 'DIAMOND binary not functional in this environment');
+            testCase.verifyClass(bs, 'struct');
+        end
+
+        function getKEGGModelForOrganismNeedsData(testCase)
+            testCase.assumeFail('Requires a local KEGG dump and external aligners.');
+        end
+
+        function getGenesFromKEGGNeedsData(testCase)
+            testCase.assumeFail('Requires a local KEGG dump.');
+        end
+
+        function getMetsFromKEGGNeedsData(testCase)
+            testCase.assumeFail('Requires a local KEGG dump.');
+        end
+
+        function getRxnsFromKEGGNeedsData(testCase)
+            testCase.assumeFail('Requires a local KEGG dump.');
+        end
+
+        function getModelFromKEGGNeedsData(testCase)
+            testCase.assumeFail('Requires a local KEGG dump.');
+        end
+
+        function getPhylDistNeedsData(testCase)
+            testCase.assumeFail('Requires a local KEGG dump.');
+        end
+
+        function constructMultiFastaNeedsData(testCase)
+            testCase.assumeFail('Requires a KEGG sequence source file.');
+        end
+
+    end
+end

--- a/testing/function_tests/tSolver.m
+++ b/testing/function_tests/tSolver.m
@@ -1,0 +1,73 @@
+classdef tSolver < RavenTestCase
+% tSolver  Tests for the LP/QP solving and solver-configuration functions in solver/.
+
+    methods (Test)
+
+        function setRavenSolverAcceptsGlpk(testCase)
+            testCase.verifyWarningFree(@() setRavenSolver('glpk'));
+        end
+
+        function setRavenSolverRejectsUnknown(testCase)
+            testCase.verifyError(@() setRavenSolver('notarealsolver'), ?MException);
+        end
+
+        function solveLPFindsOptimum(testCase)
+            sol = solveLP(testCase.model);
+            testCase.verifyEqual(sol.stat, 1);
+            testCase.verifyNumElements(sol.x, numel(testCase.model.rxns));
+            testCase.verifyEqual(sol.f, 0.87392, 'AbsTol', 1e-3);
+        end
+
+        function solveLPMinimiseFluxes(testCase)
+            sol = solveLP(testCase.model, 1);
+            testCase.verifyEqual(sol.stat, 1);
+        end
+
+        function optimizeProbSolvesLP(testCase)
+            res = optimizeProb(testCase.modelLP());
+            testCase.verifyClass(res, 'struct');
+            testCase.verifyTrue(isfield(res, 'obj'));
+        end
+
+        function checkSolutionOnFeasibleProblem(testCase)
+            res = optimizeProb(testCase.modelLP());
+            [isFeasible, isOptimal] = checkSolution(res);
+            testCase.verifyTrue(logical(isFeasible));
+            testCase.verifyTrue(logical(isOptimal));
+        end
+
+        function splitProbForConditioningReturnsProb(testCase)
+            [p2, condInfo] = splitProbForConditioning(testCase.modelLP(), 1e6); %#ok<ASGLU>
+            testCase.verifyClass(p2, 'struct');
+        end
+
+        function qMOMAReturnsFluxVectors(testCase)
+            testCase.assumeDependency(exist('quadprog','file')==2, ...
+                'Optimization Toolbox (quadprog)');
+            model2 = setParam(testCase.model, 'eq', testCase.model.rxns(1), 0);
+            evalc('[fA, fB, flag] = qMOMA(testCase.model, model2);');
+            testCase.verifyNumElements(fA, numel(testCase.model.rxns));
+            testCase.verifyNumElements(fB, numel(testCase.model.rxns));
+        end
+
+    end
+
+    methods (Access = private)
+        function prob = modelLP(testCase)
+            % Build the COBRA-style LP problem for the test model exactly as
+            % solveLP does, so the low-level solver functions get a valid input.
+            m = testCase.model;
+            nMets = size(m.S, 1);
+            prob = [];
+            prob.c = [m.c * -1; zeros(nMets, 1)];
+            prob.b = zeros(nMets, 1);
+            prob.lb = [m.lb; m.b(:, 1)];
+            prob.ub = [m.ub; m.b(:, min(size(m.b, 2), 2))];
+            prob.csense = repmat('E', 1, numel(prob.b));
+            prob.osense = 1;
+            prob.vartype = repmat('C', 1, numel(prob.c));
+            prob.A = [m.S, -speye(nMets)];
+            prob.a = m.S;
+        end
+    end
+end

--- a/testing/function_tests/tTasks.m
+++ b/testing/function_tests/tTasks.m
@@ -1,0 +1,30 @@
+classdef tTasks < RavenTestCase
+% tTasks  Tests for the metabolic-task functions in tasks/.
+
+    methods (Test)
+
+        function checkTasksSucceedsOnFullModel(testCase)
+            m = testCase.taskTestModel();
+            task = testCase.taskTestStruct();
+            [~, report] = evalc('checkTasks(m, [], true, false, false, task);');
+            testCase.verifyTrue(report.ok == 1);
+        end
+
+        function checkTasksFailsWithoutKeyReaction(testCase)
+            m = removeReactions(testCase.taskTestModel(), {'R2'});
+            task = testCase.taskTestStruct();
+            [~, report] = evalc('checkTasks(m, [], true, false, false, task);');
+            testCase.verifyTrue(report.ok == 0);
+        end
+
+        function parseTaskListReturnsStruct(testCase)
+            taskFile = fullfile(testCase.ravenRoot,'testing','unit_tests', ...
+                'test_data','test_tasks.txt');
+            testCase.assumeDependency(exist(taskFile,'file')==2, 'test_tasks.txt');
+            ts = parseTaskList(taskFile);
+            testCase.verifyClass(ts, 'struct');
+            testCase.verifyNotEmpty(ts);
+        end
+
+    end
+end

--- a/testing/function_tests/tUtils.m
+++ b/testing/function_tests/tUtils.m
@@ -1,0 +1,75 @@
+classdef tUtils < RavenTestCase
+% tUtils  Tests for the low-level helpers in utils/.
+
+    methods (Test)
+
+        function convertCharArrayFromChar(testCase)
+            testCase.verifyEqual(convertCharArray('abc'), {'abc'});
+        end
+
+        function convertCharArrayFromCell(testCase)
+            testCase.verifyEqual(convertCharArray({'a','b'}), {'a','b'});
+        end
+
+        function convertCharArrayFromString(testCase)
+            testCase.verifyEqual(convertCharArray("str"), {'str'});
+        end
+
+        function dispEMThrowsByDefault(testCase)
+            testCase.verifyError(@() dispEM('boom'), ?MException);
+        end
+
+        function dispEMThrowsWhenRequested(testCase)
+            testCase.verifyError(@() dispEM('boom', true), ?MException);
+        end
+
+        function dispEMWarningIsPrintedNotThrown(testCase)
+            out = evalc('dispEM(''heads up'', false)');
+            testCase.verifySubstring(out, 'WARNING');
+        end
+
+        function emptyOrLogicalScalarAcceptsValid(testCase)
+            testCase.verifyWarningFree(@() emptyOrLogicalScalar(true));
+            testCase.verifyWarningFree(@() emptyOrLogicalScalar([]));
+        end
+
+        function emptyOrLogicalScalarRejectsInvalid(testCase)
+            testCase.verifyError(@() emptyOrLogicalScalar([true false]), ?MException);
+        end
+
+        function emptyOrTextScalarAcceptsValid(testCase)
+            testCase.verifyWarningFree(@() emptyOrTextScalar('abc'));
+            testCase.verifyWarningFree(@() emptyOrTextScalar([]));
+        end
+
+        function emptyOrTextScalarRejectsInvalid(testCase)
+            testCase.verifyError(@() emptyOrTextScalar(5), ?MException);
+        end
+
+        function emptyOrTextOrCellOfTextAcceptsValid(testCase)
+            testCase.verifyWarningFree(@() emptyOrTextOrCellOfText({'a','b'}));
+            testCase.verifyWarningFree(@() emptyOrTextOrCellOfText('a'));
+        end
+
+        function emptyOrTextOrCellOfTextRejectsInvalid(testCase)
+            testCase.verifyError(@() emptyOrTextOrCellOfText(5), ?MException);
+        end
+
+        function printOrangeReturnsTextContainingInput(testCase)
+            evalc('s = printOrange(''hello'');');
+            testCase.verifySubstring(s, 'hello');
+        end
+
+        function parallelPoolRAVENnoParallelRuns(testCase)
+            testCase.assumeDependency(license('test','Distrib_Computing_Toolbox'), ...
+                'Parallel Computing Toolbox');
+            testCase.verifyWarningFree(@() parallelPoolRAVEN(false));
+        end
+
+        function runRAVENtestsExists(testCase)
+            % Do not execute it (would run the legacy suite); just confirm presence.
+            testCase.verifyEqual(exist('runRAVENtests','file'), 2);
+        end
+
+    end
+end


### PR DESCRIPTION
### Main improvements in this PR:

Adds a new `matlab.unittest` test suite under `testing/function_tests/` that covers
the RAVEN source functions across all 19 functional folders. This is **additive** —
the existing `testing/unit_tests/` suite is left in place.

- tests:
  - one test class per source folder (`tQueries`, `tManipulation`, `tSolver`, `tIO`,
    `tAnalysis`, `tGapfilling`, `tINIT`, …), ~190 test methods in total
  - an abstract `RavenTestCase` base providing the RAVEN root, a fresh copy of a
    small E. coli model before each test, a deterministic solver (GLPK), and shared
    helpers (`assumeMILPSolver`, `assumeDependency`, task-model fixtures, figure
    suppression)
  - assertions favour structural invariants (counts, membership, round-trips,
    idempotence) over brittle golden values, so they survive refactoring
  - `testing/function_tests/README.md` documents how to run the suite and the skip
    policy
- behaviour:
  - the full suite runs green locally on MATLAB R2024b with the bundled GLPK and a
    MILP solver: **157 passed, 0 failed, 19 filtered**
  - tests that need an absent dependency (external binaries BLAST+/DIAMOND/WoLF
    PSORT, a local KEGG dump, Gurobi/SCIP for MILP, the Optimization Toolbox
    `quadprog`, a Python/pyyaml bridge, or curation input files) use test
    *assumptions*, so they are reported as filtered rather than failed — the suite
    stays green in any environment

This suite is intended as the regression safety net for the upcoming change to
support named function arguments.

#### Instructions on merging this PR:
- [x] Target branch is `develop3` (which collects feature branches ahead of `develop`); resolve with a *squash-merge*.
