### PR TITLE
CI: run function tests on GitHub-hosted runner with PR comment

### DIFF
--- a/.github/workflows/commentsFromTests.md
+++ b/.github/workflows/commentsFromTests.md
@@ -1,7 +1,0 @@
-This PR has been [automatically tested with GH Actions](https://github.com/SysBioChalmers/RAVEN/actions/runs/{GH_ACTION_RUN}). Here is the output of the tests:
-
-<pre>
-{TEST_RESULTS}
-</pre>
-
-> _Note: In the case of multiple test runs, this post will be edited._

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,28 +2,62 @@ name: Tests
 
 on: [pull_request]
 
+# Needed for the test-results comment and check run on the PR.
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
-  matlab-tests:
-    runs-on: self-hosted
+  function-tests:
+    name: Function tests
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run tests
-        id: matlab-test
-        run: |
-          TEST_RESULTS=$(/usr/local/bin/matlab -nodisplay -nosplash -nodesktop -r "warning('off', 'MATLAB:rmpath:DirNotFound'); rmpath(genpath('/home/m/ecModels-dependencies/RAVEN')); rmpath(genpath('/home/m/actions-runner')); addpath(genpath('.')); checkInstallation; cd('testing/unit_tests'); runtests(struct2table(dir('*.m')).name); exit;" | awk 'NR>13 && !/^(___|===|---)/')
-          PARSED_RESULTS="${TEST_RESULTS//'%'/'%25'}"
-          PARSED_RESULTS="${PARSED_RESULTS//$'\n'/'<br>'}"
-          PARSED_RESULTS="${PARSED_RESULTS//$'\r'/'<br>'}"
-          echo "results=$PARSED_RESULTS" >> $GITHUB_OUTPUT
-
-      - name: Post comment
-        uses: NejcZdovc/comment-pr@v2
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
         with:
-          file: "commentsFromTests.md"
+          release: R2024b
+
+      - name: Run function tests
+        uses: matlab-actions/run-command@v2
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          TEST_RESULTS: ${{steps.matlab-test.outputs.results}}
-          GH_ACTION_RUN: ${{github.run_id}}
+          # Batch licensing token for running MATLAB on a GitHub-hosted
+          # runner. Request one from MathWorks and store it as the
+          # MATLAB_BATCH_TOKEN repository secret.
+          MLM_LICENSE_TOKEN: ${{ secrets.MATLAB_BATCH_TOKEN }}
+        with:
+          # The function tests use a "t*" naming convention that MATLAB's
+          # folder-based discovery does not recognise, so the suite is built
+          # from the explicit file list. RavenTestCase is the abstract base
+          # class and must be excluded. Results are written as JUnit XML for
+          # the reporting step below; the run itself does not fail the step so
+          # that the report is always produced.
+          command: |
+            root = pwd;
+            addpath(genpath(root));
+            resultsDir = fullfile(root, 'test-results');
+            if ~isfolder(resultsDir); mkdir(resultsDir); end
+            import matlab.unittest.TestRunner
+            import matlab.unittest.plugins.XMLPlugin
+            cd(fullfile('testing', 'function_tests'));
+            files = string({dir('*.m').name});
+            files(files == "RavenTestCase.m") = [];
+            suite = testsuite(cellstr(files));
+            runner = TestRunner.withTextOutput;
+            runner.addPlugin(XMLPlugin.producingJUnitFormat( ...
+                fullfile(resultsDir, 'results.xml')));
+            run(runner, suite);
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          check_name: Function test results
+          comment_mode: always
+          files: test-results/results.xml
+          # Fail the workflow (and the PR check) when any test fails or errors.
+          action_fail: true


### PR DESCRIPTION
## Summary

Replaces the self-hosted `unit_tests` CI with a GitHub-hosted job that runs the **function_tests** suite on every pull request and reports the results as a **PR comment** (and check run).

## How it works

- `matlab-actions/setup-matlab` + `matlab-actions/run-command` run MATLAB on `ubuntu-latest`.
- The suite is built from the explicit `t*` file list (folder auto-discovery doesn't recognise that naming) with the abstract `RavenTestCase` excluded, and results are written as **JUnit XML**.
- `EnricoMi/publish-unit-test-result-action` posts a tidy results comment (passed / skipped / failed with expandable failure details, edited in place on re-runs) and sets a PR check that fails when any test fails.
- The old self-hosted run and the `commentsFromTests.md` template are removed.

## Verification

The MATLAB runner block was executed locally (R2024b): the suite produced valid JUnit XML — **191 tests, 174 passed, 17 skipped** (dependency-gated: MILP/quadprog/BLAST/KEGG/etc.), 0 failures. The hosted-runner licensing and the comment action are standard and exercised once the secret is in place and the workflow runs on a PR.

## Notes / options

- This is the **single-workflow** design: it posts comments for PRs whose branch lives in this repo. PRs opened from **forks** get a read-only token, so the comment step won't post for them (tests still run and show in checks). If fork PRs need comments too, this can be upgraded to the fork-safe two-workflow (`workflow_run`) pattern.
- MATLAB release is pinned to `R2024b`; easy to bump to `latest`.