### PR TITLE
Add base-MATLAB FASTA I/O, drop Bioinformatics Toolbox dependency

### DIFF
--- a/io/readFasta.m
+++ b/io/readFasta.m
@@ -1,0 +1,60 @@
+function fastaStruct=readFasta(fileName)
+% readFasta  Read sequences from a FASTA file.
+%
+% Reads a FASTA file into a structure array, providing the same Header and
+% Sequence fields as the Bioinformatics Toolbox fastaread, but using only
+% base MATLAB so that no toolbox is required.
+%
+% Parameters
+% ----------
+% fileName : char
+%     path to the FASTA file to read.
+%
+% Returns
+% -------
+% fastaStruct : struct
+%     structure array with one element per sequence, with the fields:
+%
+%     - Header : the header line, without the leading ">"
+%     - Sequence : the sequence with all line breaks removed
+%
+% Examples
+% --------
+%     fastaStruct = readFasta('proteins.fa');
+%
+% See also
+% --------
+% writeFasta
+
+fileName=char(fileName);
+fid=fopen(fileName,'r');
+if fid==-1
+    error('Cannot open FASTA file "%s".',fileName);
+end
+
+fastaStruct=struct('Header',{},'Sequence',{});
+header='';
+seq='';
+haveRecord=false;
+tline=fgetl(fid);
+while ischar(tline)
+    tline=strtrim(tline);
+    if ~isempty(tline) && tline(1)=='>'
+        if haveRecord
+            fastaStruct(end+1).Header=header; %#ok<AGROW>
+            fastaStruct(end).Sequence=seq;
+        end
+        header=strtrim(tline(2:end));
+        seq='';
+        haveRecord=true;
+    elseif ~isempty(tline)
+        seq=[seq tline]; %#ok<AGROW>
+    end
+    tline=fgetl(fid);
+end
+if haveRecord
+    fastaStruct(end+1).Header=header;
+    fastaStruct(end).Sequence=seq;
+end
+fclose(fid);
+end

--- a/io/writeFasta.m
+++ b/io/writeFasta.m
@@ -1,0 +1,45 @@
+function writeFasta(fileName,fastaStruct,lineWidth)
+% writeFasta  Write sequences to a FASTA file.
+%
+% Writes a structure array of sequences to a FASTA file, replacing the
+% Bioinformatics Toolbox fastawrite with base MATLAB so that no toolbox is
+% required. An existing file is overwritten.
+%
+% Parameters
+% ----------
+% fileName : char
+%     path to the FASTA file to write.
+% fastaStruct : struct
+%     structure array with one element per sequence, with the fields:
+%
+%     - Header : the header line (written after a leading ">")
+%     - Sequence : the sequence
+% lineWidth : double
+%     number of residues per sequence line (default 80).
+%
+% Examples
+% --------
+%     writeFasta('proteins.fa', fastaStruct);
+%
+% See also
+% --------
+% readFasta
+
+if nargin<3 || isempty(lineWidth)
+    lineWidth=80;
+end
+fileName=char(fileName);
+fid=fopen(fileName,'w');
+if fid==-1
+    error('Cannot open FASTA file "%s" for writing.',fileName);
+end
+
+for i=1:numel(fastaStruct)
+    fprintf(fid,'>%s\n',fastaStruct(i).Header);
+    seq=fastaStruct(i).Sequence;
+    for p=1:lineWidth:numel(seq)
+        fprintf(fid,'%s\n',seq(p:min(p+lineWidth-1,numel(seq))));
+    end
+end
+fclose(fid);
+end

--- a/reconstruction/kegg/getKEGGModelForOrganism.m
+++ b/reconstruction/kegg/getKEGGModelForOrganism.m
@@ -627,7 +627,7 @@ if ~isempty(missingAligned)
             %constraints from maxPhylDist, and save it as a temporary file,
             %and create the model from that
 
-            fastaStruct=fastaread(fullfile(dataDir,'fasta',[missingAligned{i} '.fa']));
+            fastaStruct=readFasta(fullfile(dataDir,'fasta',[missingAligned{i} '.fa']));
             phylDist=inf(numel(fastaStruct),1);
             for j=1:numel(fastaStruct)
                 %Get the organism abbreviation
@@ -659,7 +659,7 @@ if ~isempty(missingAligned)
             if numel(fastaStruct)>1
                 if seqIdentity~=-1
                     cdhitInpCustom=tempname;
-                    fastawrite(cdhitInpCustom,fastaStruct);
+                    writeFasta(cdhitInpCustom,fastaStruct);
                     if seqIdentity<=1 && seqIdentity>0.7
                         nparam='5';
                     elseif seqIdentity>0.6
@@ -689,7 +689,7 @@ if ~isempty(missingAligned)
                 else
                     %This means that CD-HIT should be skipped since
                     %seqIdentity is equal to -1
-                    fastawrite(tmpFile,fastaStruct);
+                    writeFasta(tmpFile,fastaStruct);
                 end
                 %Do the alignment for this file
                 if ismac
@@ -724,10 +724,7 @@ if ~isempty(missingAligned)
                 %empty file was written previously so that doesn't have to
                 %be dealt with
                 if numel(fastaStruct)==1
-                    warnState = warning; %Save the current warning state
-                    warning('off','Bioinfo:fastawrite:AppendToFile');
-                    fastawrite(fullfile(dataDir,'aligned',[missingAligned{i} '.faw']),fastaStruct);
-                    warning(warnState) %Reset warning state to previous settings
+                    writeFasta(fullfile(dataDir,'aligned',[missingAligned{i} '.faw']),fastaStruct);
                 end
             end
             %Move the temporary file to the real one


### PR DESCRIPTION
## Summary

Adds base-MATLAB FASTA read/write helpers and uses them in `getKEGGModelForOrganism`, removing its dependency on the Bioinformatics Toolbox (`fastaread`/`fastawrite`).

- **`io/readFasta.m`** — reads a FASTA file into a struct array with `.Header`/`.Sequence` fields (same shape the calling code already uses).
- **`io/writeFasta.m`** — writes such a struct array back out (80-residue line wrapping; overwrites existing file).
- **`reconstruction/kegg/getKEGGModelForOrganism.m`** — `fastaread`→`readFasta` (1 call), `fastawrite`→`writeFasta` (3 calls). The now-redundant `Bioinfo:fastawrite:AppendToFile` warning suppression is removed (the helper overwrites rather than appends; the targets are fresh temp files or empty `.faw` files, so behaviour is unchanged).

These helpers are reusable and could later replace ad-hoc FASTA handling in `getBlast`/`getDiamond`/`constructMultiFasta`.

## Verification

- Round-trip on `test_data/human_galactosidases.fa` (4 multi-line sequences): headers and sequences match exactly after `readFasta`→`writeFasta`→`readFasta`.
- `checkcode` clean on both new files and on the modified function.
- Note: the Bioinformatics Toolbox is not installed on the test machine, so `getKEGGModelForOrganism` could not previously run there at all — it now can. (`getKEGGModelForOrganism` itself still needs a local KEGG dump + external aligners to run end-to-end, so it remains gated in the test suite.)