### PR TITLE
Fix tIO/getFullPathReturnsAbsolute on non-Windows CI runner

### DIFF
--- a/testing/function_tests/tIO.m
+++ b/testing/function_tests/tIO.m
@@ -19,7 +19,13 @@ classdef tIO < RavenTestCase
 
         function getFullPathReturnsAbsolute(testCase)
             p = getFullPath('.');
-            testCase.verifyTrue(contains(p, ':'));   % Windows absolute path
+            if ispc
+                % Windows: drive letter (C:\) or UNC (\\server).
+                testCase.verifyTrue(~isempty(regexp(p, '^([A-Za-z]:|\\\\)', 'once')));
+            else
+                % Unix/macOS: absolute paths start with /.
+                testCase.verifyTrue(startsWith(p, '/'));
+            end
         end
 
         function getMD5HashReturnsHexDigest(testCase)


### PR DESCRIPTION
## Summary

Fixes a function test that fails on a non-Windows runner, surfaced by the GitHub-hosted CI (#624).

- **`tIO/getFullPathReturnsAbsolute`** — the absolute-path assertion was Windows-only (`contains(p, ':')`). On Linux/macOS an absolute path is `/home/...` (no colon), so the test failed spuriously. It now checks a drive-letter/UNC prefix on Windows and a leading `/` on Unix/macOS.

## Verification

Passes on Windows (drive-letter branch); the Unix branch checks a leading `/`.