### PR TITLE
De-duplicate exportModel and remove dead code

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -145,17 +145,6 @@ if ~isfield(model,'rxnMiriams')
     model.rxnMiriams=cell(numel(model.rxns),1);
 end
 
-if sbmlLevel<3
-    %Check if genes have associated compartments
-    if ~isfield(model,'geneComps') && isfield(model,'genes')
-        if supressWarnings==false
-            EM='There are no compartments specified for genes. All genes will be assigned to the first compartment. This is because the SBML structure requires all elements to be assigned to a compartment';
-            dispEM(EM,false);
-        end
-        model.geneComps=ones(numel(model.genes),1);
-    end
-end
-
 %Convert ids to SBML-convenient format. This is to avoid the data loss when
 %unsupported characters are included in ids. Here we are using part from
 %convertSBMLID, originating from the COBRA Toolbox
@@ -261,17 +250,13 @@ for i=1:numel(model.comps)
     end
     %Prepare Miriam strings
     if ~isempty(model.compMiriams{i})
-        [~,sbo_ind] = ismember('sbo',model.compMiriams{i}.name);
-        if sbo_ind > 0
-            modelSBML.compartment(i).sboTerm=str2double(regexprep(model.compMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
-            % remove the SBO term from compMiriams so the information is
-            % not duplicated in the "annotation" field later on
-            model.compMiriams{i}.name(sbo_ind) = [];
-            model.compMiriams{i}.value(sbo_ind) = [];
+        [sboTerm,model.compMiriams{i}] = extractSBO(model.compMiriams{i});
+        if ~isempty(sboTerm)
+            modelSBML.compartment(i).sboTerm=sboTerm;
         end
     end
     if ~isempty(model.compMiriams{i}) && isfield(modelSBML.compartment(i),'annotation')
-        modelSBML.compartment(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.comps{i} '">'];
+        modelSBML.compartment(i).annotation=rdfAnnotationHeader(model.comps{i});
         modelSBML.compartment(i).annotation=[modelSBML.compartment(i).annotation '<bqbiol:is><rdf:Bag>'];
         modelSBML.compartment(i).annotation=[modelSBML.compartment(i).annotation getMiriam(model.compMiriams{i}) '</rdf:Bag></bqbiol:is></rdf:Description></rdf:RDF></annotation>'];
     end
@@ -336,13 +321,9 @@ for i=1:numel(model.mets)
         end
     end
     if ~isempty(model.metMiriams{i})
-        [~,sbo_ind] = ismember('sbo',model.metMiriams{i}.name);
-        if sbo_ind > 0
-            modelSBML.species(i).sboTerm=str2double(regexprep(model.metMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
-            % remove the SBO term from metMiriams so the information is
-            % not duplicated in the "annotation" field later on
-            model.metMiriams{i}.name(sbo_ind) = [];
-            model.metMiriams{i}.value(sbo_ind) = [];
+        [sboTerm,model.metMiriams{i}] = extractSBO(model.metMiriams{i});
+        if ~isempty(sboTerm)
+            modelSBML.species(i).sboTerm=sboTerm;
         end
     end
     if isfield(modelSBML.species,'annotation')
@@ -359,7 +340,7 @@ for i=1:numel(model.mets)
                 end
             end
             if ~isempty(model.metMiriams{i}) || hasInchi==true
-                modelSBML.species(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.mets{i} '">'];
+                modelSBML.species(i).annotation=rdfAnnotationHeader(model.mets{i});
                 modelSBML.species(i).annotation=[modelSBML.species(i).annotation '<bqbiol:is><rdf:Bag>'];
                 if ~isempty(model.metMiriams{i})
                     modelSBML.species(i).annotation=[modelSBML.species(i).annotation getMiriam(model.metMiriams{i})];
@@ -392,17 +373,13 @@ if isfield(model,'genes')
             modelSBML.fbc_geneProduct(i).metaid=model.genes{i};
         end
         if ~isempty(model.geneMiriams{i})
-            [~,sbo_ind] = ismember('sbo',model.geneMiriams{i}.name);
-            if sbo_ind > 0
-                modelSBML.fbc_geneProduct(i).sboTerm=str2double(regexprep(model.geneMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
-                % remove the SBO term from compMiriams so the information is
-                % not duplicated in the "annotation" field later on
-                model.geneMiriams{i}.name(sbo_ind) = [];
-                model.geneMiriams{i}.value(sbo_ind) = [];
+            [sboTerm,model.geneMiriams{i}] = extractSBO(model.geneMiriams{i});
+            if ~isempty(sboTerm)
+                modelSBML.fbc_geneProduct(i).sboTerm=sboTerm;
             end
         end
         if ~isempty(model.geneMiriams{i}) && isfield(modelSBML.fbc_geneProduct(i),'annotation')
-            modelSBML.fbc_geneProduct(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.genes{i} '">'];
+            modelSBML.fbc_geneProduct(i).annotation=rdfAnnotationHeader(model.genes{i});
             modelSBML.fbc_geneProduct(i).annotation=[modelSBML.fbc_geneProduct(i).annotation '<bqbiol:is><rdf:Bag>'];
             modelSBML.fbc_geneProduct(i).annotation=[modelSBML.fbc_geneProduct(i).annotation getMiriam(model.geneMiriams{i}) '</rdf:Bag></bqbiol:is></rdf:Description></rdf:RDF></annotation>'];
         end
@@ -492,19 +469,15 @@ for i=1:numel(model.rxns)
 
     % Export SBO terms from rxnMiriams
     if ~isempty(model.rxnMiriams{i})
-        [~,sbo_ind] = ismember('sbo',model.rxnMiriams{i}.name);
-        if sbo_ind > 0
-            modelSBML.reaction(i).sboTerm=str2double(regexprep(model.rxnMiriams{i}.value{sbo_ind},'SBO:','','ignorecase'));
-            % remove the SBO term from rxnMiriams so the information is not
-            % duplicated in the "annotation" field later on
-            model.rxnMiriams{i}.name(sbo_ind) = [];
-            model.rxnMiriams{i}.value(sbo_ind) = [];
+        [sboTerm,model.rxnMiriams{i}] = extractSBO(model.rxnMiriams{i});
+        if ~isempty(sboTerm)
+            modelSBML.reaction(i).sboTerm=sboTerm;
         end
     end
 
     %Export annotation information from rxnMiriams
     if (~isempty(model.rxnMiriams{i}) && isfield(modelSBML.reaction(i),'annotation')) || ~isempty(model.eccodes{i})
-        modelSBML.reaction(i).annotation=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' model.rxns{i} '">'];
+        modelSBML.reaction(i).annotation=rdfAnnotationHeader(model.rxns{i});
         modelSBML.reaction(i).annotation=[modelSBML.reaction(i).annotation '<bqbiol:is><rdf:Bag>'];
         if ~isempty(model.eccodes{i})
             eccodes=regexp(model.eccodes{i},';','split');
@@ -747,6 +720,29 @@ for i=1:numel(unitFieldNames)
 end
 end
 
+function [sboTerm,miriam]=extractSBO(miriam)
+%Extracts an SBO term from a miriam structure, if present. Returns the
+%parsed SBO term as a number (or [] if no 'sbo' entry exists) and the
+%miriam structure with the SBO entry removed, so that it is not duplicated
+%in the "annotation" field later on.
+
+sboTerm=[];
+[~,sbo_ind] = ismember('sbo',miriam.name);
+if sbo_ind > 0
+    sboTerm=str2double(regexprep(miriam.value{sbo_ind},'SBO:','','ignorecase'));
+    miriam.name(sbo_ind) = [];
+    miriam.value(sbo_ind) = [];
+end
+end
+
+function hdr=rdfAnnotationHeader(metaid)
+%Returns the RDF/XML annotation header string with the given meta id
+%interpolated. Used as the common boilerplate for compartment, species,
+%gene and reaction annotations.
+
+hdr=['<annotation><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/"><rdf:Description rdf:about="#meta_' metaid '">'];
+end
+
 function miriamString=getMiriam(miriamStruct)
 %Returns a string with list elements for a miriam structure ('<rdf:li
 %rdf:resource="https://identifiers.org/go/GO:0005739"/>' for example). This
@@ -780,30 +776,5 @@ for j_met=1:size(met_idx,1)
     else
         tmp_Rxn.reactant = [ tmp_Rxn.reactant, sbml_tmp_species_ref];
     end
-end
-end
-
-function vecT = columnVector(vec)
-% Code below taken from COBRA Toolbox under GNU General Public License v3.0
-% license file in readme/GPL.MD.
-%
-% Converts a vector to a column vector
-%
-% USAGE:
-%
-%   vecT = columnVector(vec)
-%
-% INPUT:
-%   vec:     a vector
-%
-% OUTPUT:
-%   vecT:    a column vector
-
-[n, m] = size(vec);
-
-if n < m
-    vecT = vec';
-else
-    vecT = vec;
 end
 end


### PR DESCRIPTION
## Summary
`exportModel` already writes only SBML L3V1 FBCv2 (no legacy/alternate output paths), so this is a **behaviour-preserving cleanup** with no change to the emitted SBML.

## Changes
- Extract the **SBO-term extraction-from-MIRIAM** pattern — repeated nearly verbatim for compartments, metabolites, genes and reactions — into a local `extractSBO(miriam)` helper (returns the parsed SBO term, or `[]` when absent, and the miriam with the `sbo` entry stripped). Call sites assign `sboTerm` only when present, exactly as before.
- Extract the repeated **RDF/XML annotation header** boilerplate (compartments/species/genes/reactions) into `rdfAnnotationHeader(metaid)`, reproduced byte-for-byte. The model-level `<dc:creator>` annotation is left as-is.
- Remove the unused `columnVector` sub-function.
- Remove the dead `if sbmlLevel<3` branch (`sbmlLevel` is hard-coded to 3).

## Verification
SBML output is **byte-identical** (ignoring the export timestamp) for `empty.xml` and `iAL1006 v1.00.xml` (a rich model: 3945 SBO terms, miriams, genes, subsystems), confirming the extracted helpers reproduce the original output exactly. `importExportTests` passes 7/7.

`io/exportModel.m`: **810 → 780 lines**.