### PR TITLE
fix: exportModel handling of nested subSystems

### DIFF
--- a/io/exportModel.m
+++ b/io/exportModel.m
@@ -564,11 +564,14 @@ if modelHasSubsystems
     model.subSystems(isChar)  = cellfun(@(s){s}, model.subSystems(isChar),  'UniformOutput', false);
     model.subSystems(cellfun(@isempty, model.subSystems)) = {{}};
 
-    % If some entries contain string scalars by mistake, coerce them:
-    model.subSystems = cellfun(@(c) cellfun(@char, c, 'UniformOutput', false), model.subSystems, 'UniformOutput', false);
+    % If some entries contain string scalars by mistake, coerce them. Also
+    % force each entry to a column cell array, so that reactions with
+    % different numbers of subsystems can be concatenated below (otherwise
+    % mixing e.g. 1x1 and 1x2 entries breaks vertcat):
+    model.subSystems = cellfun(@(c) reshape(cellfun(@char, c, 'UniformOutput', false), [], 1), model.subSystems, 'UniformOutput', false);
 
     % === 2) Flatten once: names and their reaction indices (vectorized) ===
-    flatNames = vertcat(model.subSystems{:});                    % 1×M cellstr of all subsystem labels
+    flatNames = vertcat(model.subSystems{:});                    % Mx1 cellstr of all subsystem labels
     if isempty(flatNames)
         % Nothing to do: no subsystems present
         return

--- a/testing/unit_tests/importExportTests.m
+++ b/testing/unit_tests/importExportTests.m
@@ -59,6 +59,36 @@ verifyTrue(testCase,filesize>18500);
 delete(fullfile(sourceDir,'testing','unit_tests','test_data','_test.xml'));
 end
 
+function testSBMLExportNestedSubSystems(testCase)
+%Regression test: a model where reactions have differing numbers of
+%subsystems (nested cell-of-cells, e.g. one reaction in two subsystems and
+%others in one) must be exportable to SBML. Previously exportModel failed
+%with "Dimensions of arrays being concatenated are not consistent" because
+%the subSystems flattening could not concatenate entries of unequal length.
+sourceDir=fileparts(fileparts(fileparts(which(mfilename))));
+load(fullfile(sourceDir,'testing','unit_tests','test_data','ecoli_textbook.mat'), 'model');
+
+%Assign nested subSystems: most reactions get a single subsystem, but a few
+%get multiple, which is the scenario that triggered the bug.
+nRxns=numel(model.rxns);
+model.subSystems=repmat({{'Subsystem A'}},nRxns,1);
+model.subSystems{1}={'Subsystem A','Subsystem B'};
+model.subSystems{2}={'Subsystem B','Subsystem C'};
+
+tmpFile=fullfile(sourceDir,'testing','unit_tests','test_data','_testNested.xml');
+%This call previously errored; verify it completes and round-trips.
+evalc('exportModel(model,tmpFile)');
+evalc('modelImported=importModel(tmpFile)');
+delete(tmpFile);
+
+%Subsystems should be preserved (order within a reaction is not guaranteed)
+srt=@(c) sort(reshape(c,1,[]));
+for i=1:3
+    j=find(strcmp(modelImported.rxns,model.rxns{i}));
+    verifyEqual(testCase,srt(modelImported.subSystems{j}),srt(model.subSystems{i}));
+end
+end
+
 function testYAMLexport(testCase)
 sourceDir=fileparts(fileparts(fileparts(which(mfilename))));
 load(fullfile(sourceDir,'tutorial','empty.mat'), 'emptyModel');


### PR DESCRIPTION
### Main improvements in this PR:
- fix:
  - `exportModel` failed with `Dimensions of arrays being concatenated are not consistent` (at the `vertcat(model.subSystems{:})` flattening step) when reactions had differing numbers of subsystems.

This is a valid model: `importModel` produces a nested `subSystems` field (cell-of-cells) whenever at least one reaction belongs to multiple SBML groups, leaving most entries as `1x1` cells and a few as `1xN`. `checkModelStruct` accepts such a model, but `exportModel` could not flatten it, because `vertcat` cannot concatenate row cell entries of unequal length.

The problem was therefore in **export**, not import. Each `subSystems` entry is now reshaped to a column cell array before flattening, so reactions with any number of subsystems concatenate correctly.

- test:
  - added `testSBMLExportNestedSubSystems` to `importExportTests.m`, which exports and re-imports a model with mixed-length nested `subSystems` and verifies the subsystems are preserved. This test fails on the previous code and passes with the fix.

#### Instructions on merging this PR:
- [X] This PR has `develop` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved as descriped [here](https://github.com/SysBioChalmers/RAVEN/wiki/Development-policy#make-a-new-release).
