### PR TITLE
kegg: fetch the HMM library from the raven-toolbox v0.1.0 release

### DIFF
--- a/reconstruction/kegg/getKEGGModelForOrganism.m
+++ b/reconstruction/kegg/getKEGGModelForOrganism.m
@@ -223,7 +223,7 @@ if ~isempty(dataDir)
         else
             fprintf('Downloading the HMM library file... ');
             try
-                websave([libraryFile '.gz'],['https://github.com/SysBioChalmers/RAVEN/releases/download/v2.11.0/kegg116_' hmmDomains{hmmIndex} '.hmm.gz']);
+                websave([libraryFile '.gz'],['https://github.com/SysBioChalmers/raven-toolbox/releases/download/v0.1.0/kegg116_' hmmDomains{hmmIndex} '.hmm.gz']);
             catch ME
                 if strcmp(ME.identifier,'MATLAB:webservices:HTTP404StatusCodeError')
                     error('Failed to download the HMM library file, the server returned a 404 error, try again later. If the problem persists please report it on the RAVEN GitHub Issues page: https://github.com/SysBioChalmers/RAVEN/issues')


### PR DESCRIPTION
`getKEGGModelForOrganism` downloads the concatenated KO HMM library
`kegg116_<domain>.hmm.gz` (added in #630). It pointed at the RAVEN `v2.11.0`
release, which only hosts the **legacy per-KO** zips (`euk90_kegg116.zip`,
`pro90_kegg116.zip`) — so the download would 404.

Point it at the **raven-toolbox `v0.1.0`** release, where that artefact is
actually published and SHA-pinned, and is the *same* file the Python port
(`raven_toolbox.data.ensure_kegg_hmm_library`) consumes — one shared artefact
for both tools.
