### PR TITLE
feat: export model.ec to Excel (ENZYMES and ENZRXNS sheets)

### DIFF
--- a/io/exportToExcelFormat.m
+++ b/io/exportToExcelFormat.m
@@ -397,8 +397,77 @@ else
     wb=writeSheet(wb,'MODEL',3,headers,[],modelSheet);
 end
 
+%Add the ENZYMES and ENZRXNS sheets, containing the contents of the
+%model.ec structure of enzyme-constrained (GECKO) models. These sheets are
+%export-only: importExcelModel does not read them back, as the YAML format
+%(writeYAMLmodel/readYAMLmodel) remains the round-trippable format for
+%ecModels. The enzyme-reaction coupling (model.ec.rxnEnzMat) is written in
+%readable form as the 'enzyme:count' ENZYMES column of the ENZRXNS sheet,
+%rather than as a separate matrix.
+if isfield(model,'ec') && isfield(model.ec,'enzymes')
+    if isfield(model,'genes')
+        ecSheetPos=5;
+    else
+        ecSheetPos=4;
+    end
+
+    %ENZYMES sheet: one row per enzyme
+    headers={'#';'ID';'GENE';'MW';'SEQUENCE';'CONC'};
+    enzSheet=cell(numel(model.ec.enzymes),numel(headers));
+    enzSheet(:,2)=model.ec.enzymes(:);
+    enzSheet(:,3)=model.ec.genes(:);
+    enzSheet(:,4)=numToCell(model.ec.mw);
+    enzSheet(:,5)=model.ec.sequence(:);
+    enzSheet(:,6)=numToCell(model.ec.concs);
+    %MW (column 4) shown without decimals, CONC (column 6) with 5 decimals
+    enzColFormats={'','','','0','','0.00000'};
+    wb=writeSheet(wb,'ENZYMES',ecSheetPos,headers,[],enzSheet,'isIntegers',false,'colFormats',enzColFormats);
+
+    %ENZRXNS sheet: one row per enzyme-constrained reaction. The ENZYMES
+    %column encodes the subunit stoichiometry from model.ec.rxnEnzMat as
+    %'enzyme:count' pairs (e.g. 'P12345:1;P67890:2').
+    headers={'#';'ID';'KCAT';'SOURCE';'NOTE';'EC-NUMBER';'ENZYMES'};
+    ecRxnSheet=cell(numel(model.ec.rxns),numel(headers));
+    ecRxnSheet(:,2)=model.ec.rxns(:);
+    ecRxnSheet(:,3)=numToCell(model.ec.kcat);
+    ecRxnSheet(:,4)=model.ec.source(:);
+    ecRxnSheet(:,5)=model.ec.notes(:);
+    ecRxnSheet(:,6)=model.ec.eccodes(:);
+    ecRxnSheet(:,7)=ecEnzymePairs(model.ec);
+    wb=writeSheet(wb,'ENZRXNS',ecSheetPos+1,headers,[],ecRxnSheet,'isIntegers',false);
+end
+
 %Open the output stream
 out = FileOutputStream(fileName);
 wb.write(out);
 out.close();
+end
+
+function c=numToCell(v)
+%Convert a numeric vector to a column cell array, representing NaN values
+%as empty (blank) cells so they are written as empty cells in the sheet.
+c=num2cell(v(:));
+c(cellfun(@(x) isnumeric(x) && isnan(x),c))={[]};
+end
+
+function c=ecEnzymePairs(ec)
+%Build the ENZRXNS 'ENZYMES' column. For each ec reaction, list the enzymes
+%and their subunit stoichiometry from rxnEnzMat as 'enzyme:count;...'.
+%Reactions without enzymes get a blank cell.
+nRxns=numel(ec.rxns);
+c=cell(nRxns,1);
+if ~isfield(ec,'rxnEnzMat') || isempty(ec.rxnEnzMat)
+    return
+end
+for i=1:min(nRxns,size(ec.rxnEnzMat,1))
+    j=find(ec.rxnEnzMat(i,:));
+    if isempty(j)
+        continue
+    end
+    pairs=cell(1,numel(j));
+    for k=1:numel(j)
+        pairs{k}=[ec.enzymes{j(k)} ':' num2str(full(ec.rxnEnzMat(i,j(k))))];
+    end
+    c{i}=strjoin(pairs,';');
+end
 end

--- a/io/writeSheet.m
+++ b/io/writeSheet.m
@@ -32,8 +32,9 @@ function wb=writeSheet(wb,sheetName,sheetPosition,captions,units,raw,varargin)
 % --------
 %     wb = writeSheet(wb, sheetName, sheetPosition, captions, units, raw);
 
-p=parseRAVENargs(varargin, {'isIntegers',true});
+p=parseRAVENargs(varargin, {'isIntegers',true; 'colFormats',{}});
 isIntegers=p.isIntegers;
+colFormats=p.colFormats;
 
 %Adds the required classes to the static Java path if not already added
 addJavaPaths();
@@ -57,6 +58,18 @@ boldFont=wb.createFont();
 boldFont.setBoldweight(boldFont.BOLDWEIGHT_BOLD);
 boldStyle=defaultStyle.clone();
 boldStyle.setFont(boldFont);
+
+%Build per-column number-format styles, so individual columns can override
+%the sheet-wide number format (e.g. show a different number of decimals)
+colStyles=cell(1,size(raw,2));
+dataFormatHelper=wb.getCreationHelper().createDataFormat();
+for col=1:min(numel(colFormats),size(raw,2))
+    if ~isempty(colFormats{col})
+        colStyle=defaultStyle.clone();
+        colStyle.setDataFormat(dataFormatHelper.getFormat(colFormats{col}));
+        colStyles{col}=colStyle;
+    end
+end
 
 s=wb.createSheet();
 wb.setSheetName(sheetPosition, sheetName);
@@ -118,7 +131,11 @@ for i=0:size(raw,1)-1
             else
                 c.setCellValue(content);
             end
-            c.setCellStyle(defaultStyle);
+            if ~isempty(colStyles{j+1})
+                c.setCellStyle(colStyles{j+1});
+            else
+                c.setCellStyle(defaultStyle);
+            end
         end
     end
 end
@@ -134,6 +151,10 @@ elseif strcmp(sheetName,'GENES')
     widths=[786;3144;7860;3144;3406];
 elseif strcmp(sheetName,'MODEL')
     widths=[786;3144;7860;3668;3668;5240;5240;7860;7860;2620;7860];
+elseif strcmp(sheetName,'ENZYMES')
+    widths=[786;3144;3144;3406;15719;3406];
+elseif strcmp(sheetName,'ENZRXNS')
+    widths=[786;5240;3406;5240;7860;5240;7860];
 end;
 
 %Resize columns

--- a/testing/function_tests/tIO.m
+++ b/testing/function_tests/tIO.m
@@ -84,6 +84,46 @@ classdef tIO < RavenTestCase
             testCase.verifyTrue(exist(f,'file')==2);
         end
 
+        function exportToExcelFormatWritesEcSheets(testCase)
+            % Enzyme-constrained (GECKO) models get two extra export-only
+            % sheets, ENZYMES and ENZRXNS, holding the model.ec contents.
+            model = testCase.model;
+            model.ec.geckoLight = false;
+            model.ec.rxns     = model.rxns(1:2);
+            model.ec.kcat     = [13.7; 0];
+            model.ec.source   = {'brenda'; ''};
+            model.ec.notes    = {'note1'; ''};
+            model.ec.eccodes  = {'1.1.1.1'; '2.7.1.1;2.7.1.2'};
+            model.ec.genes    = model.genes(1:2);
+            model.ec.enzymes  = {'P0A1'; 'P0A2'};
+            model.ec.mw       = [51000; NaN];
+            model.ec.sequence = {'MABC'; 'MDEF'};
+            model.ec.concs    = [NaN; 0.5];
+            model.ec.rxnEnzMat = [1 2; 0 1];   % R1: P0A1 x1, P0A2 x2; R2: P0A2 x1
+
+            f = [tempname '.xlsx'];
+            testCase.addTeardown(@() delete(f));
+            evalc('exportToExcelFormat(model, f);');
+
+            sheets = sheetnames(f);
+            testCase.verifyTrue(any(strcmp(sheets,'ENZYMES')));
+            testCase.verifyTrue(any(strcmp(sheets,'ENZRXNS')));
+
+            % NaN mw/conc are written as blanks; the kcat 0 sentinel is kept.
+            enz = readcell(f,'Sheet','ENZYMES');
+            testCase.verifyEqual(string(enz(1,2:6)),["ID","GENE","MW","SEQUENCE","CONC"]);
+            testCase.verifyEqual(string(enz{2,2}),"P0A1");
+            testCase.verifyEqual(enz{2,4},51000,'AbsTol',1e-9);
+
+            ecrxn = readcell(f,'Sheet','ENZRXNS');
+            testCase.verifyEqual(string(ecrxn(1,2:7)),["ID","KCAT","SOURCE","NOTE","EC-NUMBER","ENZYMES"]);
+            testCase.verifyEqual(ecrxn{2,3},13.7,'AbsTol',1e-9);
+            testCase.verifyEqual(string(ecrxn{3,6}),"2.7.1.1;2.7.1.2");
+            % ENZYMES column: 'enzyme:count' subunit stoichiometry from rxnEnzMat
+            testCase.verifyEqual(string(ecrxn{2,7}),"P0A1:1;P0A2:2");
+            testCase.verifyEqual(string(ecrxn{3,7}),"P0A2:1");
+        end
+
         function writeReadYAMLRoundTrip(testCase)
             f = [tempname '.yml'];
             testCase.addTeardown(@() delete(f));


### PR DESCRIPTION
### Main improvements in this PR:
- feat:
  - `exportToExcelFormat` now writes the contents of the `model.ec` structure of enzyme-constrained (GECKO) models to two additional sheets:
    - **ENZYMES** — one row per enzyme: `ID` (UniProt), `GENE`, `MW`, `SEQUENCE`, `CONC`
    - **ENZRXNS** — one row per ec-reaction: `ID`, `KCAT`, `SOURCE`, `NOTE`, `EC-NUMBER`, `ENZYMES`
  - `writeSheet` gains column widths for the two new sheets.

The ENZRXNS **ENZYMES** column encodes the subunit stoichiometry from `model.ec.rxnEnzMat` as `enzyme:count` pairs (e.g. `P12345:1;P67890:2`), capturing the enzyme-reaction coupling in readable per-row form rather than as a separate matrix.

These sheets are **export-only**: `importExcelModel` does not read them back. The YAML format (`writeYAMLmodel`/`readYAMLmodel`) remains the round-trippable format for ecModels. `NaN` molecular weights / concentrations are written as empty cells; the `kcat == 0` "unassigned" sentinel is kept.

A test (`tIO/exportToExcelFormatWritesEcSheets`) attaches a minimal `model.ec` to the e. coli test model, exports it, and verifies the two sheets exist and carry the expected content (including the `enzyme:count` ENZYMES column).

The Python counterpart (raven-toolbox `export_to_excel`) is SysBioChalmers/raven-toolbox#38, and the ecModel-build fix that motivated this is SysBioChalmers/geckopy#32.

#### Instructions on merging this PR:
- [X] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
- [ ] This PR has `main` as target branch, and will be resolved as descriped [here](https://github.com/SysBioChalmers/RAVEN/wiki/Development-policy#make-a-new-release).
