### PR TITLE
kegg: fetch the HMM library from the raven-data kegg118 release

### DIFF
--- a/reconstruction/kegg/getKEGGModelForOrganism.m
+++ b/reconstruction/kegg/getKEGGModelForOrganism.m
@@ -198,7 +198,8 @@ libraryFile='';
 %pre-trained HMM set, compatible with the current RAVEN version. The
 %reconstruction uses the concatenated KO HMM library (a single
 %gzip-compressed flatfile, queried in one hmmsearch); if it is not already
-%present it is downloaded from the corresponding RAVEN release.
+%present it is downloaded from the corresponding raven-data release
+%(https://github.com/SysBioChalmers/raven-data).
 if ~isempty(dataDir)
     hmmOptions={'kegg118_eukaryotes','kegg118_prokaryotes'};
     if ~endsWith(dataDir,hmmOptions) %Check if dataDir ends with any of the hmmOptions.
@@ -224,7 +225,7 @@ if ~isempty(dataDir)
         else
             fprintf('Downloading the HMM library file... ');
             try
-                websave([libraryFile '.gz'],['https://github.com/SysBioChalmers/raven-toolbox/releases/download/v0.3.0/' hmmName '.hmm.gz']);
+                websave([libraryFile '.gz'],['https://github.com/SysBioChalmers/raven-data/releases/download/kegg118/' hmmName '.hmm.gz']);
             catch ME
                 if strcmp(ME.identifier,'MATLAB:webservices:HTTP404StatusCodeError')
                     error('Failed to download the HMM library file, the server returned a 404 error, try again later. If the problem persists please report it on the RAVEN GitHub Issues page: https://github.com/SysBioChalmers/RAVEN/issues')


### PR DESCRIPTION
`getKEGGModelForOrganism` downloads the prebuilt KO HMM libraries on demand. `develop3` already targets KEGG 118 but points at a `raven-toolbox` release (`v0.3.0`). This repoints the download to the dedicated **[`raven-data`](https://github.com/SysBioChalmers/raven-data)** repository, where the shared artefacts are now hosted as release assets.

## Change
- `reconstruction/kegg/getKEGGModelForOrganism.m`: the `websave` URL →
  `https://github.com/SysBioChalmers/raven-data/releases/download/kegg118/<hmmName>.hmm.gz`
  (e.g. `kegg118_eukaryotes.hmm.gz`), plus the doc comment now names raven-data.

## Why raven-data
The HMM libraries (~135–155 MB each) exceed GitHub's 100 MB git-file limit, so they can only live as release assets. Hosting them in a dedicated data repo (rather than attached to a code release) keeps code releases clean, isolates the assets' licenses, and gives MATLAB RAVEN and Python raven-toolbox one shared, SHA256-indexed source of truth (`manifest.json`). See the [raven-data README](https://github.com/SysBioChalmers/raven-data) and raven-toolbox's `docs/maintenance/artefact_hosting.md`.

## Verified
The `kegg118` release exists in raven-data with all four assets; the new URL resolves (302 → asset, `HTTP 200`). Companion raven-toolbox PR: SysBioChalmers/raven-toolbox#43.
