### PR TITLE
OS-independent offline binary bundle (suffix scheme + release workflow)

### DIFF
--- a/.github/scripts/assemble_offline_software.py
+++ b/.github/scripts/assemble_offline_software.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Populate RAVEN's software/ with every platform's external binaries.
+
+Downloads the per-platform binary ZIPs from raven-data and lays them out under
+``<raven>/software/<tool>/`` using RAVEN's suffix scheme — bare name = Linux,
+``.mac`` = macOS, ``.exe`` = Windows — plus the WoLFPSORT tree. With all
+platforms present in one tree, the whole RAVEN checkout can be zipped into a
+single **OS-independent** offline distribution (see the release-bundle workflow).
+
+Run from the RAVEN root, or pass ``--raven <dir>``. Requires network access to
+https://github.com/SysBioChalmers/raven-data .
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import urllib.request
+import zipfile
+from pathlib import Path
+
+RAVEN_DATA = "https://github.com/SysBioChalmers/raven-data/releases/download"
+# raven-data platform key -> RAVEN binary suffix.
+PLATFORMS = {"linux-x86_64": "", "macos-arm64": ".mac", "windows-x86_64": ".exe"}
+
+# (software subdir, raven-data bundle, {platform|"_": version}, {bare executable names})
+CLI_TOOLS = [
+    ("blast+",  "blast",   {"_": "2.17.0"},                          {"blastp", "makeblastdb"}),
+    ("diamond", "diamond", {"_": "2.1.17"},                          {"diamond"}),
+    ("hmmer",   "hmmer",   {"windows-x86_64": "3.3.2", "_": "3.4.0"}, {"hmmsearch"}),
+]
+
+
+def _fetch(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 (pinned raven-data URLs)
+        return resp.read()
+
+
+def _extract(zip_bytes: bytes, dest: Path, rename: dict[str, str]) -> None:
+    """Write each file member of the ZIP into ``dest``, applying ``rename`` and modes."""
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            target = dest / rename.get(info.filename, info.filename)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(zf.read(info))
+            mode = (info.external_attr >> 16) & 0o777
+            if mode:
+                target.chmod(mode)  # no-op for execute bits on Windows; honoured on the Linux runner
+
+
+def assemble(raven: Path) -> None:
+    soft = raven / "software"
+    for subdir, bundle, vmap, exes in CLI_TOOLS:
+        dest = soft / subdir
+        for plat, suffix in PLATFORMS.items():
+            version = vmap.get(plat, vmap["_"])
+            asset = f"{bundle}-{version}-{plat}.zip"
+            print(f"  {subdir}: {asset}")
+            # macOS ships bare names; rename them to <name>.mac. Linux keeps bare names,
+            # Windows already carries .exe — so only the macOS members need renaming.
+            rename = {e: e + ".mac" for e in exes} if suffix == ".mac" else {}
+            _extract(_fetch(f"{RAVEN_DATA}/{bundle}-{version}/{asset}"), dest, rename)
+
+    print("  WoLFPSORT: wolfpsort-0.2.zip")
+    _extract(_fetch(f"{RAVEN_DATA}/wolfpsort-0.2/wolfpsort-0.2.zip"), soft, {})
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--raven", type=Path, default=Path.cwd(), help="RAVEN root (default: cwd)")
+    args = p.parse_args(argv)
+    assemble(args.raven)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -1,0 +1,55 @@
+name: Offline binary bundle
+
+# Build the OS-independent offline RAVEN distribution: the full repo with
+# software/ populated with every platform's external binaries, so an air-gapped
+# user downloads one ZIP and runs RAVEN on any OS without fetching anything.
+# Attached automatically to each published release; also runnable on demand
+# against an existing tag.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and attach the bundle to
+        required: true
+
+permissions:
+  contents: write   # upload the bundle as a release asset
+
+jobs:
+  bundle:
+    name: Build OS-independent offline bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout RAVEN at the release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Populate software/ with every platform's binaries
+        run: python .github/scripts/assemble_offline_software.py
+
+      - name: Build RAVEN-<tag>-full.zip
+        id: zip
+        run: |
+          set -euo pipefail
+          NAME="RAVEN-${{ steps.tag.outputs.tag }}-full"
+          rsync -a --exclude '.git' ./ "${RUNNER_TEMP}/${NAME}/"
+          ( cd "${RUNNER_TEMP}" && zip -r -y -q "${GITHUB_WORKSPACE}/${NAME}.zip" "${NAME}" )
+          echo "name=${NAME}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Attach to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.tag.outputs.tag }}" "${{ steps.zip.outputs.name }}" --clobber

--- a/checkInstallation.m
+++ b/checkInstallation.m
@@ -307,8 +307,10 @@ function testBinary(ravenDir, tool, binName, versionArg)
 % Run a bundled binary with versionArg to confirm it executes; error if not.
 if ispc
     binEnd = '.exe'; % native Windows builds (raven-data windows-x86_64 ZIPs)
+elseif ismac
+    binEnd = '.mac';
 else
-    binEnd = ''; % Linux and macOS both use the bare binary name
+    binEnd = '';
 end
 cmd = ['"' fullfile(ravenDir,'software',tool,[binName binEnd]) '" ' versionArg];
 [status,~] = system(cmd);
@@ -351,10 +353,14 @@ if ispc
 end
 binDir = fullfile(ravenDir,'software');
 
-% blast+/diamond/hmmer are downloaded on demand (downloadRavenBinaries sets
-% their permissions after extraction); only the committed MEX binaries are
-% chmod'd here.
-binList = {fullfile(binDir,'GLPKmex','glpkcc.mexa64');              fullfile(binDir,'GLPKmex','glpkcc.mexglx');                 fullfile(binDir,'GLPKmex','glpkcc.mexmaci64');              fullfile(binDir,'GLPKmex','glpkcc.mexmaca64');
+% blast+/diamond/hmmer may be present from an on-demand download
+% (downloadRavenBinaries already chmods those) or from the offline bundle;
+% chmod whichever unix binaries are present. Missing entries are skipped below.
+binList = {fullfile(binDir,'blast+','blastp');                      fullfile(binDir,'blast+','blastp.mac');
+           fullfile(binDir,'blast+','makeblastdb');                 fullfile(binDir,'blast+','makeblastdb.mac');
+           fullfile(binDir,'diamond','diamond');                    fullfile(binDir,'diamond','diamond.mac');
+           fullfile(binDir,'hmmer','hmmsearch');                    fullfile(binDir,'hmmer','hmmsearch.mac');
+           fullfile(binDir,'GLPKmex','glpkcc.mexa64');              fullfile(binDir,'GLPKmex','glpkcc.mexglx');                 fullfile(binDir,'GLPKmex','glpkcc.mexmaci64');              fullfile(binDir,'GLPKmex','glpkcc.mexmaca64');
            fullfile(binDir,'libSBML','TranslateSBML_RAVEN.mexa64'); fullfile(binDir,'libSBML','TranslateSBML_RAVEN.mexglx');    fullfile(binDir,'libSBML','TranslateSBML_RAVEN.mexmaci64');  fullfile(binDir,'libSBML','TranslateSBML_RAVEN.mexmaca64');
            fullfile(binDir,'libSBML','OutputSBML_RAVEN.mexa64');    fullfile(binDir,'libSBML','OutputSBML_RAVEN.mexglx');       fullfile(binDir,'libSBML','OutputSBML_RAVEN.mexmaci64');     fullfile(binDir,'libSBML','OutputSBML_RAVEN.mexmaca64');};
 

--- a/installation/downloadRavenBinaries.m
+++ b/installation/downloadRavenBinaries.m
@@ -77,9 +77,13 @@ for i = 1:numel(tools)
             error('downloadRavenBinaries: unknown tool ''%s''.',tool);
     end
 
-    % On Windows the executables carry a .exe suffix.
-    if ispc && ~strcmp(tool,'WoLFPSORT')
-        sentinel = [sentinel '.exe']; %#ok<AGROW>
+    % macOS uses a .mac suffix and Windows a .exe suffix (Linux: bare name).
+    if ~strcmp(tool,'WoLFPSORT')
+        if ispc
+            sentinel = [sentinel '.exe']; %#ok<AGROW>
+        elseif ismac
+            sentinel = [sentinel '.mac']; %#ok<AGROW>
+        end
     end
     if exist(sentinel,'file')
         continue;   % already provisioned
@@ -98,6 +102,17 @@ for i = 1:numel(tools)
     unzip(zipPath,destDir);
     delete(zipPath);
 
+    % macOS uses the .mac suffix throughout RAVEN, but the raven-data macOS ZIP
+    % ships bare names, so rename the extracted executables to match.
+    if ismac && ~strcmp(tool,'WoLFPSORT')
+        for k = 1:numel(execs)
+            bare = fullfile(destDir,execs{k});
+            if isfile(bare)
+                movefile(bare, fullfile(destDir,[execs{k} '.mac']));
+            end
+        end
+    end
+
     % MATLAB's unzip does not preserve Unix execute permissions; restore them.
     if isunix
         if strcmp(tool,'WoLFPSORT')
@@ -105,8 +120,9 @@ for i = 1:numel(tools)
             system(['chmod -R +x "' fullfile(attrTarget,'bin') '"']);
         else
             attrTarget = destDir;
+            if ismac; sfx = '.mac'; else; sfx = ''; end
             for k = 1:numel(execs)
-                system(['chmod +x "' fullfile(destDir,execs{k}) '"']);
+                system(['chmod +x "' fullfile(destDir,[execs{k} sfx]) '"']);
             end
         end
         % Downloaded binaries are quarantined by macOS Gatekeeper and will not

--- a/reconstruction/homology/getBlast.m
+++ b/reconstruction/homology/getBlast.m
@@ -99,8 +99,10 @@ refFastaFiles = files(2:end);
 if ispc
     binEnd='.exe';
     setenv('BLASTDB_LMDB_MAP_SIZE','1000000');
+elseif ismac
+    binEnd='.mac';
 elseif isunix
-    binEnd=''; %Linux and macOS both use the bare binary name (raven-data macOS ZIP)
+    binEnd='';
 else
     dispEM('Unknown OS, exiting.')
     return

--- a/reconstruction/homology/getDiamond.m
+++ b/reconstruction/homology/getDiamond.m
@@ -88,8 +88,10 @@ refFastaFiles = files(2:end);
 %Identify the operating system
 if ispc
     binEnd='.exe';
+elseif ismac
+    binEnd='.mac';
 elseif isunix
-    binEnd=''; %Linux and macOS both use the bare binary name (raven-data macOS ZIP)
+    binEnd='';
 else
     dispEM('Unknown OS, exiting.')
     return

--- a/reconstruction/kegg/getKEGGModelForOrganism.m
+++ b/reconstruction/kegg/getKEGGModelForOrganism.m
@@ -385,8 +385,10 @@ end
 %library sequence set is already fixed.
 if ispc
     binEnd='.exe';
+elseif ismac
+    binEnd='.mac';
 else
-    binEnd=''; %Linux and macOS both use the bare binary name
+    binEnd='';
 end
 %Fetch the HMMER binary on demand if it is not already present
 if ~exist(fullfile(ravenPath,'software','hmmer',['hmmsearch' binEnd]),'file')

--- a/testing/function_tests/tBinaries.m
+++ b/testing/function_tests/tBinaries.m
@@ -39,7 +39,7 @@ classdef tBinaries < matlab.unittest.TestCase
 
     methods (Access = private)
         function p = binPath(~, tool, name)
-            if ispc; ext = '.exe'; else; ext = ''; end
+            if ispc; ext = '.exe'; elseif ismac; ext = '.mac'; else; ext = ''; end
             p = fullfile(findRAVENroot(),'software',tool,[name ext]);
         end
 


### PR DESCRIPTION
Follow-up to #644. That PR (on-demand binary download) was squash-merged at a stale head, so these two commits — which were on the branch but not on the PR's recorded head — didn't land. They add the **offline-install** half.

## Why
#644 fetches only the current platform's binary, with **bare names** (`blastp`, `blastp.exe`). An **OS-independent** offline bundle needs *all* platforms in one `software/blast+/`, where bare `blastp` (Linux) would collide with bare `blastp` (macOS). RAVEN's historical layout avoids this with the `.mac`/`.exe` **suffix scheme**.

## Changes
1. **Restore the `.mac` suffix scheme** — `binEnd='.mac'` on macOS in `getBlast`/`getDiamond`/`getKEGGModelForOrganism`/`checkInstallation`; restore the blast/diamond/hmmer entries in `makeBinaryExecutable` (skip-missing); and `downloadRavenBinaries` renames the fetched macOS binaries to `.mac`. (So `software/` always uses the suffix layout, whether populated on-demand or from the offline bundle.)
2. **Release workflow** (`.github/workflows/release-bundle.yml` + `.github/scripts/assemble_offline_software.py`) — on a published release (or on demand for a tag), populates `software/` with **every** platform's binaries (suffix layout) from raven-data and attaches **`RAVEN-<tag>-full.zip`**: the whole repo + all binaries, one OS-independent download for air-gapped installs.

## Validation
- **Windows (MATLAB R2024b):** `tBinaries` 4/4 pass; all edited files lint clean.
- **Assembler:** run locally — produces RAVEN's exact suffix layout (`blastp`/`blastp.mac`/`blastp.exe` + `nghttp2.dll`/`cygwin1.dll` + WoLFPSORT tree) with all platforms coexisting.
- The `binary-tests` CI job (ubuntu + macos) here re-validates the `.mac` path that the #644 merge bypassed.
