### PR TITLE
Trim design rationale and version history from Excel I/O function docs

### DIFF
--- a/io/exportToExcelFormat.m
+++ b/io/exportToExcelFormat.m
@@ -9,11 +9,10 @@ function exportToExcelFormat(model,varargin)
 % Name-Value Arguments
 % --------------------
 % fileName : char
-%     file name of the Excel file. Only xlsx format is supported. In order
-%     to preserve backward compatibility this could also be only a path, in
-%     which case the model is exported to a set of tab-delimited text files
-%     via exportToTabDelimited. A dialog window will open if fileName is
-%     empty.
+%     file name of the Excel file. Only xlsx format is supported. This can
+%     also be only a path, in which case the model is exported to a set of
+%     tab-delimited text files via exportToTabDelimited. A dialog window
+%     will open if fileName is empty.
 % sortIds : logical
 %     whether metabolites, reactions and genes should be sorted
 %     alphabetically by their identifiers (default false).
@@ -52,9 +51,7 @@ if ~strcmpi(B,'.xlsx')
     dispEM(EM);
 end
 
-%Accumulate the sheets, then write them all to the .xlsx at the end. The
-%writer (writeExcel) generates the Office Open XML directly, so no Java /
-%Apache POI is involved and an existing output file is overwritten.
+%Accumulate the sheets, then write them all to the .xlsx at the end.
 sheets=struct('name',{},'header',{},'data',{},'widths',{},'isIntegers',{},'colFormats',{});
 
 %Construct equations
@@ -381,12 +378,9 @@ end
 sheets=appendSheet(sheets,'MODEL',headers,modelSheet,true,{});
 
 %Add the ENZYMES and ENZRXNS sheets, containing the contents of the
-%model.ec structure of enzyme-constrained (GECKO) models. These sheets are
-%export-only; the YAML format (writeYAMLmodel/readYAMLmodel) remains the
-%round-trippable format for ecModels. The enzyme-reaction coupling
-%(model.ec.rxnEnzMat) is written in
-%readable form as the 'enzyme:count' ENZYMES column of the ENZRXNS sheet,
-%rather than as a separate matrix.
+%model.ec structure of enzyme-constrained (GECKO) models. The
+%enzyme-reaction coupling (model.ec.rxnEnzMat) is written as the
+%'enzyme:count' ENZYMES column of the ENZRXNS sheet.
 if isfield(model,'ec') && isfield(model.ec,'enzymes')
     %ENZYMES sheet: one row per enzyme
     headers={'#';'ID';'GENE';'MW';'SEQUENCE';'CONC'};
@@ -419,8 +413,8 @@ writeExcel(fileName,sheets);
 end
 
 function sheets=appendSheet(sheets,name,header,data,isIntegers,colFormats)
-%Append one worksheet definition for writeExcel. Column widths follow the
-%historical per-sheet layout (see sheetWidths).
+%Append one worksheet definition for writeExcel (see sheetWidths for the
+%per-sheet column widths).
 n=numel(sheets)+1;
 sheets(n).name=name;
 sheets(n).header=header;
@@ -431,19 +425,19 @@ sheets(n).colFormats=colFormats;
 end
 
 function w=sheetWidths(name)
-%Per-sheet column widths in character units. These reproduce the historical
-%Apache POI layout, whose widths were expressed in 1/256th of a character.
+%Per-sheet column widths. The stored values are in 1/256th of a character
+%and are converted to character units below.
 switch name
-    case 'RXNS';    poi=[786;2358;7860;15719;3406;7860;3406;3406;2358;3406;7860;7860;3668;7860;7860;4192];
-    case 'METS';    poi=[786;7860;7860;3668;7860;7860;7860;3406;3668;1834];
-    case 'COMPS';   poi=[786;3144;7860;3144;7860];
-    case 'GENES';   poi=[786;3144;7860;3144;3406];
-    case 'MODEL';   poi=[786;3144;7860;3668;3668;5240;5240;7860;7860;2620;7860];
-    case 'ENZYMES'; poi=[786;3144;3144;3406;15719;3406];
-    case 'ENZRXNS'; poi=[786;5240;3406;5240;7860;5240;7860];
-    otherwise;      poi=[];
+    case 'RXNS';    w256=[786;2358;7860;15719;3406;7860;3406;3406;2358;3406;7860;7860;3668;7860;7860;4192];
+    case 'METS';    w256=[786;7860;7860;3668;7860;7860;7860;3406;3668;1834];
+    case 'COMPS';   w256=[786;3144;7860;3144;7860];
+    case 'GENES';   w256=[786;3144;7860;3144;3406];
+    case 'MODEL';   w256=[786;3144;7860;3668;3668;5240;5240;7860;7860;2620;7860];
+    case 'ENZYMES'; w256=[786;3144;3144;3406;15719;3406];
+    case 'ENZRXNS'; w256=[786;5240;3406;5240;7860;5240;7860];
+    otherwise;      w256=[];
 end
-w=poi(:).'/256;
+w=w256(:).'/256;
 end
 
 function c=numToCell(v)

--- a/io/exportToTabDelimited.m
+++ b/io/exportToTabDelimited.m
@@ -22,9 +22,6 @@ function exportToTabDelimited(model,varargin)
 %
 % Notes
 % -----
-% This functionality was previously a part of exportToExcelFormat. The
-% naming of the resulting text files is to preserve backward compatibility.
-%
 % No checks are made regarding the correctness of the model. Use
 % checkModelStruct to identify problems in the model structure.
 

--- a/io/writeExcel.m
+++ b/io/writeExcel.m
@@ -1,10 +1,10 @@
 function writeExcel(fileName,sheets)
 % writeExcel  Write one or more sheets to an .xlsx (Office Open XML) file.
 %
-% Writes spreadsheet data to the SpreadsheetML (.xlsx) format without any
-% external library (no Apache POI / Java) and without MATLAB toolboxes. An
-% .xlsx file is a ZIP archive of XML parts; this function generates those
-% parts and packs them with the built-in zip function.
+% Writes data to one or more worksheets of an .xlsx file. Each sheet can
+% have a bold header row (frozen at the top), column widths and per-column
+% number formats. Numeric, text and logical cell values are supported;
+% empty values are written as blank cells.
 %
 % Parameters
 % ----------

--- a/tasks/parseTaskList.m
+++ b/tasks/parseTaskList.m
@@ -118,15 +118,15 @@ if strcmp(extractAfter(inputFile,strlength(inputFile) - 4), '.txt')
     fclose(fid);
     raw = [C{:}];%unnest the cell array of cell arrays into a 2-dim cell array
 else
-    %Read the TASKS sheet from an Excel file with base MATLAB (readcell
-    %handles both .xls and .xlsx; no external library or toolbox needed).
+    %Read the TASKS sheet from an Excel file (readcell handles both .xls
+    %and .xlsx).
     try
         raw=readcell(inputFile,'Sheet','TASKS');
     catch
         dispEM(['Could not load sheet "TASKS" from ' inputFile]);
     end
-    %readcell marks blank cells as "missing"; the previous Apache POI reader
-    %used [] for blanks, which the downstream cleanSheet/parsing expects.
+    %Normalise blank cells (which readcell returns as "missing") to [], as
+    %expected by the downstream cleanSheet/parsing.
     raw(cellfun(@(x) all(ismissing(x)),raw))={[]};
 end
 


### PR DESCRIPTION
## Summary

Function documentation should describe **what a function does**, not why a particular design choice was made or how it was done previously. This removes such rationale / version-history notes from the Excel I/O functions; the differences between versions are tracked separately, not in the per-function docs.

## Changes (documentation/comments only — no behaviour change)

- **`writeExcel`** — help summary now describes the writing behaviour (sheets, bold/frozen header, widths, number formats, supported value types) instead of "no Apache POI / Java, no toolboxes … a ZIP of XML parts packed with `zip`".
- **`exportToExcelFormat`** — dropped the "no Java / Apache POI is involved" note, the "these widths reproduce the historical Apache POI layout" note, and the "in order to preserve backward compatibility" rationale in the `fileName` doc. Renamed the internal `poi` width variable to `w256`.
- **`exportToTabDelimited`** — removed the "this functionality was previously a part of exportToExcelFormat … to preserve backward compatibility" Notes paragraph.
- **`parseTaskList`** — reworded the Excel-read comments to drop the "previous Apache POI reader" / "no external library or toolbox needed" framing, keeping the functional description.

## Notes

Stacked on `feat/excel-no-poi` (#646), since these files only exist on that branch; the base will retarget to develop3 once #646 merges.

Verified: `exportToExcelFormat` still exports and round-trips (`readcell`), and `checkcode` reports no new warnings.