### PR TITLE
Trim design rationale and version history from function docs

### DIFF
--- a/INIT/ftINIT.m
+++ b/INIT/ftINIT.m
@@ -32,7 +32,7 @@ function [model, metProduction, addedRxnsForTasks, deletedRxnsInINIT, fullMipRes
 % --------------------
 % transcrData : struct
 %     gene expression data structure (optional if hpaData is supplied, default
-%     []). Used to be called arrayData. With fields:
+%     []). With fields:
 %
 %     - genes : cell array with the unique gene names.
 %     - tissues : cell array with the tissue names. The list may not be unique,

--- a/INIT/ftINITFillGapsForAllTasks.m
+++ b/INIT/ftINITFillGapsForAllTasks.m
@@ -1,8 +1,7 @@
 function [outModel, addedRxns]=ftINITFillGapsForAllTasks(model,refModel,inputFile,printOutput,rxnScores,taskStructure,params,verbose)
 % ftINITFillGapsForAllTasks
 %   Fills gaps in a model by including reactions from a reference model,
-%   so that the resulting model can perform all the tasks in a task list
-%   This is similar to the old fitTasks function but optimized for ftINIT.
+%   so that the resulting model can perform all the tasks in a task list.
 %
 %   Input:
 %   model           model structure

--- a/INIT/ftINITFillGapsMILP.m
+++ b/INIT/ftINITFillGapsMILP.m
@@ -2,10 +2,9 @@ function [x,I,exitFlag]=ftINITFillGapsMILP(model, varargin)
 % ftINITFillGapsMILP  Find the minimal set of fluxes that satisfy a model.
 %
 % Returns the minimal set of fluxes that satisfy the model using mixed integer
-% linear programming. This is an optimized variant of the old function
-% "getMinNrFluxes" that is adapted to ftINIT. It does not need to make an irrev
-% model, which takes time. The problem also becomes smaller (fewer integers but
-% larger matrix). Only tested with Gurobi.
+% linear programming. The formulation works on the reversible model directly,
+% using fewer integer variables (but a larger constraint matrix) than an
+% irrev-based formulation. Only tested with Gurobi.
 %
 % Parameters
 % ----------

--- a/INIT/getINITModel.m
+++ b/INIT/getINITModel.m
@@ -2,8 +2,7 @@ function [model, metProduction, essentialRxnsForTasks, addedRxnsForTasks, delete
 % getINITModel  Generate a model using the original INIT algorithm.
 %
 % Generates a model using the INIT algorithm, based on proteomics and/or
-% transcriptomics and/or metabolomics and/or metabolic tasks. This is the
-% original implementation of tINIT, which is replaced by ftINIT.
+% transcriptomics and/or metabolomics and/or metabolic tasks.
 %
 % This is the main function for automatic reconstruction of models based on the
 % (t)INIT algorithm (PLoS Comput Biol. 2012;8(5):e1002518, Mol Syst Biol.

--- a/INIT/runINIT.m
+++ b/INIT/runINIT.m
@@ -2,8 +2,7 @@ function [outModel, deletedRxns, metProduction, fValue]=runINIT(model,varargin)
 % runINIT  Generate a model using the original INIT algorithm.
 %
 % Generates a model using the INIT algorithm, based on proteomics and/or
-% transcriptomics and/or metabolomics and/or metabolic tasks. This is the
-% original implementation, which is now replaced with ftINIT.
+% transcriptomics and/or metabolomics and/or metabolic tasks.
 %
 % This function is the actual implementation of the algorithm. See
 % getINITModel for a higher-level function for model reconstruction. See PLoS

--- a/installation/downloadRavenBinaries.m
+++ b/installation/downloadRavenBinaries.m
@@ -15,8 +15,7 @@ function downloadRavenBinaries(tools)
 %   unzip it into the RAVEN software/ directory instead.
 %
 %   The binaries are hosted as release assets in
-%   https://github.com/SysBioChalmers/raven-data and are the same builds RAVEN
-%   previously committed under software/.
+%   https://github.com/SysBioChalmers/raven-data.
 %
 %   Usage: downloadRavenBinaries({'blast+','diamond'})
 %

--- a/io/importModel.m
+++ b/io/importModel.m
@@ -7,9 +7,8 @@ function model=importModel(varargin)
 %     a SBML file to import. A dialog window will open if no file name is
 %     specified.
 % removeExcMets : logical
-%     true if exchange metabolites should be removed. This is needed to be
-%     able to run simulations, but it could also be done using
-%     simplifyModel at a later stage (default true).
+%     if true, exchange metabolites are removed from the imported model
+%     (default true).
 % removePrefix : logical
 %     true if identifier prefixes should be removed when loading the model:
 %     G_ for genes, R_ for reactions, M_ for metabolites, and C_ for

--- a/utils/parseRAVENargs.m
+++ b/utils/parseRAVENargs.m
@@ -2,10 +2,10 @@ function args = parseRAVENargs(rawArgs, spec)
 % parseRAVENargs  Resolve optional arguments passed positionally or by name.
 %
 % Helper that lets a RAVEN function accept its optional arguments either in
-% the traditional positional order or as name-value pairs, without losing
-% backward compatibility. The required leading arguments stay explicit in the
-% function signature; the optional tail is collected into varargin and passed
-% here together with a specification of the optional parameters.
+% the traditional positional order or as name-value pairs. The required
+% leading arguments stay explicit in the function signature; the optional
+% tail is collected into varargin and passed here together with a
+% specification of the optional parameters.
 %
 % Parameters
 % ----------


### PR DESCRIPTION
## Summary

Systematic sweep of all 207 .m files (excluding software/) to remove design rationale and version history from function help text. The rule applied: help text describes what a function does and how to use it — not why a design choice was made or how something used to work. Inline code comments inside function bodies are left untouched.

No behaviour changes; help text only.

- `INIT/ftINIT.m` — removed "Used to be called arrayData." from `transcrData` parameter description
- `INIT/getINITModel.m` — removed "which is replaced by ftINIT" from function description
- `INIT/runINIT.m` — removed "which is now replaced with ftINIT" from function description
- `INIT/ftINITFillGapsMILP.m` — replaced "optimized variant of the old function getMinNrFluxes" with a factual description of the algorithm formulation
- `INIT/ftINITFillGapsForAllTasks.m` — removed "similar to the old fitTasks function" from function description
- `io/importModel.m` — replaced "This is needed to be able to run simulations, but it could also be done using simplifyModel" with a plain parameter description
- `utils/parseRAVENargs.m` — removed "without losing backward compatibility" from opening description
- `installation/downloadRavenBinaries.m` — removed "are the same builds RAVEN previously committed under software/" (version history)
