### PR TITLE
Fix three verified bugs: permuteModel comps, randomSampling showProgress, optimizeProb no-op

### DIFF
--- a/analysis/randomSampling.m
+++ b/analysis/randomSampling.m
@@ -107,7 +107,7 @@ end
 if isempty(sol.x)
     EM='The model has no feasible solution, likely due to incompatible constraints';
     dispEM(EM);
-elseif sol.f==0 && showProgress
+elseif sol.f==0
     warning('The model objective function cannot reach a non-zero value. This might be intended, so randomSampling will continue, but this could indicate problems with your model')
 end
 

--- a/manipulation/permuteModel.m
+++ b/manipulation/permuteModel.m
@@ -163,13 +163,13 @@ switch type
             [toreplace, bywhat] = ismember(newModel.metComps,1:length(J));
             newModel.metComps(toreplace) = J(bywhat(toreplace));
         end
-        if isfield(model,'rxnComps')
-            [toreplace, bywhat] = ismember(model.rxnComps,1:length(J));
-            model.rxnComps(toreplace) = J(bywhat(toreplace));
+        if isfield(newModel,'rxnComps')
+            [toreplace, bywhat] = ismember(newModel.rxnComps,1:length(J));
+            newModel.rxnComps(toreplace) = J(bywhat(toreplace));
         end
-        if isfield(model,'geneComps')
-            [toreplace, bywhat] = ismember(model.geneComps,1:length(J));
-            model.geneComps(toreplace) = J(bywhat(toreplace));
+        if isfield(newModel,'geneComps')
+            [toreplace, bywhat] = ismember(newModel.geneComps,1:length(J));
+            newModel.geneComps(toreplace) = J(bywhat(toreplace));
         end
 end
 end

--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -101,11 +101,6 @@ switch solver
         else
             res=solveCobraLP(prob);
         end
-        if isfield(res,{'dual','rcost'})
-            res.dual=res.dual;
-            res.rcost=res.rcost;
-        end
-
         %% Use Gurobi in a MATLAB environment
     case 'gurobi'
         if milp


### PR DESCRIPTION
﻿Three correctness bugs found during the v3 review (see docs/v3_review.md §7):

- `manipulation/permuteModel.m:166-172`: the `'comps'` case remapped `rxnComps`/`geneComps`
  back onto `model.*` (the input) instead of `newModel.*` (the output), silently discarding
  the remap. Only `metComps` survived correctly. Fixed by switching both `isfield`/assignment
  targets to `newModel`.

- `analysis/randomSampling.m:110`: the zero-objective warning branched on `showProgress`,
  which is never defined anywhere in the function — causing an "undefined variable" error
  whenever `sol.f == 0`. Removed the `&& showProgress` guard so the warning always fires in
  that case.

- `solver/optimizeProb.m:104-107`: the `cobra` solver path contained a dead block
  (`if isfield(res,{'dual','rcost'}) … res.dual=res.dual … end`) that only assigned
  fields to themselves. Removed.

Note: the two "if kept" bugs from §7 (`getMD5Hash` certutil typo, `runPhenotypePhasePlane`
`close all force`) are not fixed here — they are in functions proposed for removal in §4.
