### PR TITLE
Add error-path tests for getModelFromKEGG and getPhylDist

### DIFF
--- a/testing/function_tests/tReconstruction.m
+++ b/testing/function_tests/tReconstruction.m
@@ -58,11 +58,17 @@ classdef tReconstruction < RavenTestCase
         end
 
         function getModelFromKEGGNeedsData(testCase)
-            testCase.assumeFail('Requires keggModel.mat from raven-data.');
+            matFile = fullfile(testCase.ravenRoot, 'reconstruction', 'kegg', 'keggModel.mat');
+            testCase.assumeFalse(exist(matFile, 'file') == 2, ...
+                'keggModel.mat is present; skipping error-path test.');
+            testCase.verifyError(@() getModelFromKEGG(), 'getModelFromKEGG:noModel');
         end
 
         function getPhylDistNeedsData(testCase)
-            testCase.assumeFail('Requires keggPhylDist.mat from raven-data.');
+            distFile = fullfile(testCase.ravenRoot, 'reconstruction', 'kegg', 'keggPhylDist.mat');
+            testCase.assumeFalse(exist(distFile, 'file') == 2, ...
+                'keggPhylDist.mat is present; skipping error-path test.');
+            testCase.verifyError(@() getPhylDist(), 'getPhylDist:noData');
         end
 
     end


### PR DESCRIPTION
## Summary

- Replaces the always-skip stubs in `tReconstruction.m` for `getModelFromKEGGNeedsData` and `getPhylDistNeedsData` with tests that actually verify behavior.
- Each test skips (via `assumeFalse`) when the required `.mat` file is present, so environments with raven-data installed pass cleanly.
- When the file is absent (standard CI), the test verifies that the structured error ID is thrown: `getModelFromKEGG:noModel` and `getPhylDist:noData` respectively.

Follows up on #651 which rewrote these functions to load pre-built artefacts instead of building them.