### PR TITLE
Backport parseRAVENargs hybrid mode, SAMP1, I4, FT3

### DIFF
--- a/INIT/ftINITInternalAlg.m
+++ b/INIT/ftINITInternalAlg.m
@@ -1,4 +1,4 @@
-function [deletedRxns,metProduction,res,turnedOnRxns,fluxes]=ftINITInternalAlg(model,rxnScores,metData,essentialRxns,prodWeight,allowExcretion,remPosRev,params,startVals,fluxes,verbose)
+function [deletedRxns,metProduction,res,turnedOnRxns,fluxes]=ftINITInternalAlg(model,rxnScores,metData,essentialRxns,prodWeight,allowExcretion,remPosRev,params,startVals,fluxes,verbose,forceOn)
 % ftINITInternalAlg
 %	This function runs the MILP for a step in ftINIT.
 %
@@ -54,6 +54,9 @@ function [deletedRxns,metProduction,res,turnedOnRxns,fluxes]=ftINITInternalAlg(m
 %           rxnScores,presentMets,essentialRxns,prodWeight,allowExcretion,...
 %           remPosRev,params)
 
+if nargin < 12 || isempty(forceOn)
+    forceOn = 0.1;
+end
 if isempty(essentialRxns)
     essentialRxns={};
 end
@@ -244,9 +247,20 @@ milpModel = model;
 %S row
 %When forcing on essential rxns, use the flux value of the previous run (set to 0.1 the first time)
 %Don't set it above 0.1, may starve something else out. Leave a margin of 1% from the last run.
-forceOnLim = 0.1;
+forceOnLim = forceOn;
 forceOnLimEss=min(abs(fluxes)*0.99,0.1);
 forceOnLimEss(essIrrevRxns) = min(forceOnLimEss(essIrrevRxns), milpModel.ub(essIrrevRxns));
+
+% Per-reaction big-M: use each reaction's own flux capacity (capped at 1000).
+% This replaces the fixed big-M=100, which underestimates capacity for standard
+% RAVEN models where ub=1000. Must be at least forceOnLim so the constraints are feasible.
+bigMCap = 1000;
+ubSafe = min(milpModel.ub, bigMCap); ubSafe(~isfinite(ubSafe)) = bigMCap;
+lbSafe = min(-milpModel.lb, bigMCap); lbSafe(~isfinite(lbSafe)) = bigMCap; lbSafe = max(lbSafe, 0);
+bigMPosRev   = max(max(ubSafe(posRevRxns),  lbSafe(posRevRxns)),  forceOnLim);
+bigMNegIrrev = max(ubSafe(negIrrevRxns), forceOnLim);
+bigMNegRev   = max(max(ubSafe(negRevRxns),  lbSafe(negRevRxns)),  forceOnLim);
+bigMEssRev   = max(max(ubSafe(essRevRxns),  lbSafe(essRevRxns)),  forceOnLim);
 
 varsPerNegRev = 3;
 
@@ -266,19 +280,19 @@ piRows = [sEye(posIrrevRxns,:) speye(nPosIrrev)*-forceOnLim sparse(nPosIrrev,nPo
 
 prRows1 = [sEye(posRevRxns,:) sparse(nPosRev,nYBlock + nPosIrrev) speye(nPosRev)*-1 speye(nPosRev) sparse(nPosRev,nPosRev*4+nNegIrrev+nNegRev*varsPerNegRev+nEssRev*6+nMetVars)];
 prRows2 = [sparse(nPosRev,nRxns + nPosIrrev) speye(nPosRev)*-forceOnLim sparse(nPosRev,nNegIrrev + nNegRev + nPosIrrev) speye(nPosRev) speye(nPosRev) sparse(nPosRev,nPosRev) speye(nPosRev)*-1 sparse(nPosRev,nPosRev*2+nNegIrrev+nNegRev*varsPerNegRev+nEssRev*6+nMetVars)];
-prRows3 = [sparse(nPosRev,nRxns + nYBlock + nPosIrrev) speye(nPosRev) sparse(nPosRev,nPosRev) speye(nPosRev)*-100 sparse(nPosRev,nPosRev) speye(nPosRev) sparse(nPosRev,nPosRev+nNegIrrev+nNegRev*varsPerNegRev+nEssRev*6+nMetVars)];
-prRows4 = [sparse(nPosRev,nRxns + nYBlock + nPosIrrev + nPosRev) speye(nPosRev) speye(nPosRev)*100 sparse(nPosRev,nPosRev*2) speye(nPosRev) sparse(nPosRev, nNegIrrev+nNegRev*varsPerNegRev+nEssRev*6+nMetVars)];
+prRows3 = [sparse(nPosRev,nRxns + nYBlock + nPosIrrev) speye(nPosRev) sparse(nPosRev,nPosRev) spdiags(-bigMPosRev,0,nPosRev,nPosRev) sparse(nPosRev,nPosRev) speye(nPosRev) sparse(nPosRev,nPosRev+nNegIrrev+nNegRev*varsPerNegRev+nEssRev*6+nMetVars)];
+prRows4 = [sparse(nPosRev,nRxns + nYBlock + nPosIrrev + nPosRev) speye(nPosRev) spdiags(bigMPosRev,0,nPosRev,nPosRev) sparse(nPosRev,nPosRev*2) speye(nPosRev) sparse(nPosRev, nNegIrrev+nNegRev*varsPerNegRev+nEssRev*6+nMetVars)];
 
-niRows = [sEye(negIrrevRxns,:) sparse(nNegIrrev,nPosIrrev + nPosRev) speye(nNegIrrev)*-100 sparse(nNegIrrev,nNegRev + nPosIrrev + nPosRev*6) speye(nNegIrrev) sparse(nNegIrrev,nNegRev*varsPerNegRev + nEssRev*6+nMetVars)];
+niRows = [sEye(negIrrevRxns,:) sparse(nNegIrrev,nPosIrrev + nPosRev) spdiags(-bigMNegIrrev,0,nNegIrrev,nNegIrrev) sparse(nNegIrrev,nNegRev + nPosIrrev + nPosRev*6) speye(nNegIrrev) sparse(nNegIrrev,nNegRev*varsPerNegRev + nEssRev*6+nMetVars)];
 
 nrRows1 = [sEye(negRevRxns,:) sparse(nNegRev,nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev) speye(nNegRev)*-1 speye(nNegRev) sparse(nNegRev,nNegRev + nEssRev*6+nMetVars)];
-nrRows2 = [sparse(nNegRev,nRxns + nPosIrrev + nPosRev + nNegIrrev) speye(nNegRev)*-100 sparse(nNegRev,nPosIrrev + nPosRev*6 + nNegIrrev) speye(nNegRev) speye(nNegRev) speye(nNegRev) sparse(nNegRev,nEssRev*6+nMetVars)];
+nrRows2 = [sparse(nNegRev,nRxns + nPosIrrev + nPosRev + nNegIrrev) spdiags(-bigMNegRev,0,nNegRev,nNegRev) sparse(nNegRev,nPosIrrev + nPosRev*6 + nNegIrrev) speye(nNegRev) speye(nNegRev) speye(nNegRev) sparse(nNegRev,nEssRev*6+nMetVars)];
 nrRows = [nrRows1;nrRows2];
 
 erRows1 = [sEye(essRevRxns,:) sparse(nEssRev,nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev*varsPerNegRev) speye(nEssRev)*-1 speye(nEssRev) sparse(nEssRev, nEssRev*4+nMetVars)];
 erRows2 = [sparse(nEssRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev*varsPerNegRev) speye(nEssRev) speye(nEssRev) speye(nEssRev)*-1 sparse(nEssRev, nEssRev*3+nMetVars)];
-erRows3 = [sparse(nEssRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev*varsPerNegRev) speye(nEssRev) sparse(nEssRev, nEssRev*2) speye(nEssRev)*-100 speye(nEssRev) sparse(nEssRev, nEssRev+nMetVars)];
-erRows4 = [sparse(nEssRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev*varsPerNegRev + nEssRev) speye(nEssRev) sparse(nEssRev, nEssRev) speye(nEssRev)*100 sparse(nEssRev, nEssRev) speye(nEssRev) sparse(nEssRev, nMetVars)];
+erRows3 = [sparse(nEssRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev*varsPerNegRev) speye(nEssRev) sparse(nEssRev, nEssRev*2) spdiags(-bigMEssRev,0,nEssRev,nEssRev) speye(nEssRev) sparse(nEssRev, nEssRev+nMetVars)];
+erRows4 = [sparse(nEssRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev*varsPerNegRev + nEssRev) speye(nEssRev) sparse(nEssRev, nEssRev) spdiags(bigMEssRev,0,nEssRev,nEssRev) sparse(nEssRev, nEssRev) speye(nEssRev) sparse(nEssRev, nMetVars)];
 
 %now the mets
 if ~isempty(metData)
@@ -298,18 +312,19 @@ if ~isempty(metData)
     %    vnrn <= (1-vnrbm)*100 (if bool is one, vnrn is zero): vnrn + 100*vnrbm + vnrvm2 == 0, -100 <= vnrvm2 <= inf (metRows3)
     % We then also say that vnrp + vnrn >= 0.1*Yi, -0.1*Yi + vnrp + vnrn - vnrvm3 == 0, vnrvm3 >= 0 (metRows4)
     nrEye = speye(nNegRev);
-    %vnrp - 100*vnrbm + vnrvm1 == 0
+    bigMMetNegRev = bigMNegRev(metNegRev(negRevRxns));
+    %vnrp - M*vnrbm + vnrvm1 == 0
     metRows2 = [sparse(nMetNegRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev) ... %zeros up to vnrp
-                nrEye(metNegRev(negRevRxns),:) ... %vnrp 
+                nrEye(metNegRev(negRevRxns),:) ... %vnrp
                 sparse(nMetNegRev, nNegRev*(varsPerNegRev-1) + nEssRev*6 + nMetabolMets*2) ... %zeros up to vnrbm
-                speye(nMetNegRev)*-100 ... %vnrbm
+                spdiags(-bigMMetNegRev,0,nMetNegRev,nMetNegRev) ... %vnrbm
                 speye(nMetNegRev) ... % vnrvm1
                 sparse(nMetNegRev, nMetNegRev*2 + nMetNegIrrev)];%fill up the rest with zeros
-    %vnrn + 100*vnrbm + vnrvm2 == 0
+    %vnrn + M*vnrbm + vnrvm2 == 0
     metRows3 = [sparse(nMetNegRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev) ... %zeros up to vnrn
-                nrEye(metNegRev(negRevRxns),:) ... %vnrp 
+                nrEye(metNegRev(negRevRxns),:) ... %vnrp
                 sparse(nMetNegRev, nNegRev*(varsPerNegRev-2) + nEssRev*6 + nMetabolMets*2) ... %zeros up to vnrbm
-                speye(nMetNegRev)*100 ... %vnrbm
+                spdiags(bigMMetNegRev,0,nMetNegRev,nMetNegRev) ... %vnrbm
                 sparse(nMetNegRev, nMetNegRev) ... %zeros up to vnrvm2
                 speye(nMetNegRev) ... % vnrvm2
                 sparse(nMetNegRev, nMetNegRev + nMetNegIrrev)];%fill up the rest with zeros
@@ -337,7 +352,7 @@ if ~isempty(metData)
     %-100 <= vnrvm2 <= inf
     % vnrvm3 >= 0
     %0 <= vnim <= Inf
-    metLb = [zeros(nMetabolMets*2 + 2*nMetNegRev,1);ones(nMetNegRev,1)*-100;zeros(nMetNegRev + nMetNegIrrev,1)];
+    metLb = [zeros(nMetabolMets*2 + 2*nMetNegRev,1);-bigMMetNegRev;zeros(nMetNegRev + nMetNegIrrev,1)];
     metUb = [ones(nMetabolMets,1);inf(nMetabolMets,1);ones(nMetNegRev,1);inf(3*nMetNegRev + nMetNegIrrev,1)];
     metVartype = [repmat('C', 1, nMetabolMets*2), ...
                   repmat('B', 1, nMetNegRev), ...
@@ -355,7 +370,7 @@ prob.a = [sRow;piRows;prRows1;prRows2;prRows3;prRows4;niRows;nrRows;erRows1;erRo
 prob.A = prob.a;
 prob.b = zeros(size(prob.A,1),1);
 prob.c = [zeros(nRxns,1);rxnScores(posIrrevRxns)*-1;rxnScores(posRevRxns)*-1;rxnScores(negIrrevRxns)*-1;rxnScores(negRevRxns)*-1;zeros(nPosIrrev + nPosRev*6 + nNegIrrev + nNegRev*varsPerNegRev + nEssRev*6,1);metVarC];
-prob.lb = [milpModel.lb;zeros(nYBlock + nPosIrrev + 5*nPosRev,1);ones(nPosRev,1)*-100;zeros(nNegIrrev+nNegRev*varsPerNegRev+nEssRev*2,1);ones(nEssRev,1)*forceOnLim;zeros(nEssRev*2,1);ones(nEssRev,1)*-100;metLb];
+prob.lb = [milpModel.lb;zeros(nYBlock + nPosIrrev + 5*nPosRev,1);-bigMPosRev;zeros(nNegIrrev+nNegRev*varsPerNegRev+nEssRev*2,1);ones(nEssRev,1)*forceOnLim;zeros(nEssRev*2,1);-bigMEssRev;metLb];
 prob.lb(essIrrevRxns) = forceOnLimEss(essIrrevRxns);%force flux for the ess irrev rxns - this is the only way these are handled
 prob.ub = [milpModel.ub;ones(nYBlock,1);inf(nPosIrrev+nPosRev*2,1);ones(nPosRev,1);inf(3*nPosRev+nNegIrrev+varsPerNegRev*nNegRev+3*nEssRev,1);ones(nEssRev,1);inf(2*nEssRev,1);metUb];
 

--- a/INIT/runINIT.m
+++ b/INIT/runINIT.m
@@ -67,7 +67,7 @@ function [outModel, deletedRxns, metProduction, fValue]=runINIT(model,varargin)
 %     objective value (sum of (the negative of) reaction scores for the
 %     included reactions and prodWeight*number of produced metabolites).
 
-p=parseRAVENargs(varargin, {'rxnScores',[]; 'presentMets',[]; 'essentialRxns',[]; 'prodWeight',[]; 'allowExcretion',false; 'noRevLoops',false; 'params',[]});
+p=parseRAVENargs(varargin, {'rxnScores',[]; 'presentMets',[]; 'essentialRxns',[]; 'prodWeight',[]; 'allowExcretion',false; 'noRevLoops',false; 'params',[]; 'eps',1});
 rxnScores=p.rxnScores;
 presentMets=p.presentMets;
 essentialRxns=p.essentialRxns;
@@ -75,6 +75,7 @@ prodWeight=p.prodWeight;
 allowExcretion=p.allowExcretion;
 noRevLoops=p.noRevLoops;
 params=p.params;
+initEps=p.eps;
 if isempty(rxnScores)
     rxnScores=zeros(numel(model.rxns),1);
 end
@@ -186,6 +187,10 @@ nRxns=numel(irrevModel.rxns);
 nEssential=numel(essentialIndex);
 nNonEssential=nRxns-nEssential;
 nonEssentialIndex=setdiff(1:nRxns,essentialIndex);
+% Per-reaction big-M: use each reaction's own upper bound, capped at 1000.
+% Must be at least initEps so the inclusion constraint is feasible.
+nonEssUBs = min(irrevModel.ub(nonEssentialIndex), 1000);
+nonEssUBs = max(nonEssUBs(:), initEps);
 S=irrevModel.S;
 
 %Add so that each non-essential reaction produces one unit of a fake
@@ -196,7 +201,7 @@ S=[S;temp];
 
 %Add another set of reactions (will be binary) which also produce these
 %fake metabolites, but with a stoichiometry of 1000
-temp=sparse(1:nNonEssential,1:nNonEssential,1000);
+temp=sparse(1:nNonEssential,1:nNonEssential,nonEssUBs);
 temp=[sparse(nMets,nNonEssential);temp];
 S=[S temp];
 
@@ -243,7 +248,7 @@ end
 %binary ones (and net-production reactions) may have zero flux. The integer
 %reactions for reversible reactions have [0 1]
 prob.blx=[irrevModel.lb;zeros(nNonEssential+nNetProd+nRevBounds*2,1)];
-prob.blx(essentialIndex)=max(0.1,prob.blx(essentialIndex));
+prob.blx(essentialIndex)=min(max(initEps,prob.blx(essentialIndex)),irrevModel.ub(essentialIndex));
 
 %Add so that the binary ones and net-production reactions can have at the
 %most flux 1.0
@@ -252,7 +257,7 @@ prob.bux=[irrevModel.ub;ones(nNonEssential+nNetProd+nRevBounds*2,1)];
 %Add that the fake metabolites must be produced in a small amount and that
 %the A and B metabolites for reversible reactions can be [0 999.9] and C
 %metabolites [-1 0]
-prob.blc=[irrevModel.b(:,1);ones(nNonEssential,1);zeros(nRevBounds*2,1);ones(nRevBounds,1)*-1];
+prob.blc=[irrevModel.b(:,1);ones(nNonEssential,1)*initEps;zeros(nRevBounds*2,1);ones(nRevBounds,1)*-1];
 
 %Add that normal metabolites can be freely excreted if
 %allowExcretion==true, and that the fake ones can be excreted 1000 units at
@@ -270,7 +275,7 @@ if allowExcretion==true
 else
     metUB=irrevModel.b(:,min(size(irrevModel.b,2),2));
 end
-prob.buc=[metUB;ones(nNonEssential,1)*1000;ones(nRevBounds*2,1)*999.9;revUB];
+prob.buc=[metUB;nonEssUBs;ones(nRevBounds*2,1)*999.9;revUB];
 
 %Add objective coefficients for the binary reactions. The negative is used
 %since we're minimizing. The negative is taken for the prodWeight as well,

--- a/analysis/randomSampling.m
+++ b/analysis/randomSampling.m
@@ -128,33 +128,15 @@ nRxns = numel(model.rxns);
 %on the original bounded model so that loop detection is meaningful
 %(Inf-bounded reactions would always reach the threshold).
 if isempty(goodRxns)
-    revRxns = transpose(find(model.lb < 0));
-    fwdRxns = transpose(find(model.ub > 0));
-    rxnList = [fwdRxns,revRxns];
-    objList = [ones(numel(fwdRxns),1);-ones(numel(revRxns),1)];
-    testSol = zeros(numel(objList),1);
-    PB = progressReport(nRxns,'Prepare goodRxns not involved in loops');
-
-    parfor (i = 1:numel(objList), nW)
-        testModel=setParam(model,'obj',rxnList(i),objList(i));
-        sol=solveLP(testModel,0);
-        if ~isempty(sol.f)
-            testSol(i) = sol.x(rxnList(i));
-        end
-        count(PB);
-    end
-    testSol  = testSol.*objList;
-    goodRxns = true(nRxns,1);
-    % Filter out reactions that can reach (-)1000 (= involved in loop)
-    goodRxns(fwdRxns(testSol(1:numel(fwdRxns)) > 999)) = false;
-    goodRxns(revRxns(testSol(numel(fwdRxns)+1:end) > 999)) = false;
-    testSol(revRxns) = testSol(revRxns) + testSol(numel(fwdRxns)+1:end);
-    % Filter out reactions that cannot carry flux
-    goodRxns(testSol(1:nRxns) == 0) = false;
+    [minF, maxF] = getAllowedBounds(model, 'runParallel', runParallel);
+    goodRxns = true(nRxns, 1);
+    % Reactions that reach ±1000 are involved in loops
+    goodRxns(maxF > 999 | minF < -999) = false;
+    % Reactions that cannot carry any non-zero flux
+    goodRxns(~(maxF > 0 | minF < 0)) = false;
     % In ecModels do not sample from usage_prot reactions
     if isfield(model,'ec')
-        usageRxns = startsWith(model.rxns,'usage_prot_');
-        goodRxns(usageRxns) = false;
+        goodRxns(startsWith(model.rxns,'usage_prot_')) = false;
     end
     goodRxns = find(goodRxns);
 end

--- a/testing/function_tests/tAnalysis.m
+++ b/testing/function_tests/tAnalysis.m
@@ -75,9 +75,9 @@ classdef tAnalysis < RavenTestCase
         end
 
         function randomSamplingDeterministicWithSeed(testCase)
-            evalc('[~, gR] = randomSampling(testCase.model, ''nSamples'', 0, ''runParallel'', false);');
-            evalc('s1 = randomSampling(testCase.model, ''nSamples'', 5, ''seed'', 42, ''runParallel'', false, ''goodRxns'', gR);');
-            evalc('s2 = randomSampling(testCase.model, ''nSamples'', 5, ''seed'', 42, ''runParallel'', false, ''goodRxns'', gR);');
+            evalc('[~, gR] = randomSampling(testCase.model, 0, ''runParallel'', false);');
+            evalc('s1 = randomSampling(testCase.model, 5, ''seed'', 42, ''runParallel'', false, ''goodRxns'', gR);');
+            evalc('s2 = randomSampling(testCase.model, 5, ''seed'', 42, ''runParallel'', false, ''goodRxns'', gR);');
             testCase.verifyEqual(s1, s2);
         end
 

--- a/utils/parseRAVENargs.m
+++ b/utils/parseRAVENargs.m
@@ -2,7 +2,8 @@ function args = parseRAVENargs(rawArgs, spec)
 % parseRAVENargs  Resolve optional arguments passed positionally or by name.
 %
 % Helper that lets a RAVEN function accept its optional arguments either in
-% the traditional positional order or as name-value pairs. The required
+% the traditional positional order, as name-value pairs, or as a mix of
+% leading positional values followed by name-value pairs. The required
 % leading arguments stay explicit in the function signature; the optional
 % tail is collected into varargin and passed here together with a
 % specification of the optional parameters.
@@ -29,14 +30,27 @@ function args = parseRAVENargs(rawArgs, spec)
 %
 % Notes
 % -----
-% The calling convention is detected from rawArgs: it is treated as name-
-% value pairs only when it has an even number of elements AND every element
-% in a name position is a string matching one of the declared parameter
-% names. Otherwise it is treated as positional and assigned in the order of
-% the spec. A call therefore uses either the positional or the name-value
-% form for the optional tail, not a mix of the two. When an optional tail
-% value could itself be a string equal to a parameter name, use the explicit
-% name-value form to remove the ambiguity.
+% Calling convention is resolved as follows:
+%
+%   1. If rawArgs is empty, all parameters take their defaults.
+%   2. The first element in rawArgs that is a string matching a known
+%      parameter name marks position k. Everything before k is treated
+%      as positional (assigned left-to-right by the order in spec).
+%      Everything from k onward must form valid name-value pairs: an even
+%      count where every name-position element is a known parameter name.
+%   3. If no such position exists (no element is a matching string), or the
+%      trailing section from k does not form valid name-value pairs, the
+%      entire rawArgs is treated as positional.
+%
+% This means three styles are accepted interchangeably:
+%
+%     f(model, v1, v2)                   % purely positional
+%     f(model, 'p1', v1, 'p2', v2)       % purely named
+%     f(model, v1, 'p2', v2, 'p3', v3)   % hybrid: v1 positional, rest named
+%
+% When a positional value could itself be a string that equals a parameter
+% name, use the explicit name-value form for that argument to avoid
+% ambiguity.
 %
 % Examples
 % --------
@@ -47,9 +61,10 @@ function args = parseRAVENargs(rawArgs, spec)
 %     fileName = p.fileName;
 %     sortIds  = p.sortIds;
 %
-%     % the caller may then use either form:
-%     exportToExcelFormat(model, 'model.xlsx', true)     % positional
-%     exportToExcelFormat(model, 'sortIds', true)        % named
+%     % the caller may use any of these:
+%     exportToExcelFormat(model, 'model.xlsx', true)              % positional
+%     exportToExcelFormat(model, 'sortIds', true)                 % named
+%     exportToExcelFormat(model, 'model.xlsx', 'sortIds', true)   % hybrid
 
 if nargin < 2 || isempty(spec)
     error('parseRAVENargs:noSpec', 'A parameter specification is required.');
@@ -66,15 +81,41 @@ for i = 1:numel(names)
 end
 
 if ~isempty(rawArgs)
-    isNameValue = mod(numel(rawArgs), 2) == 0 && ...
-        all(cellfun(@(x) (ischar(x) || isstring(x)) && isscalar(string(x)) && ...
-        any(strcmpi(x, names)), rawArgs(1:2:end)));
+    % Find which elements are strings matching a known parameter name.
+    isParamName = cellfun(@(x) (ischar(x) || isstring(x)) && isscalar(string(x)) && ...
+                          any(strcmpi(x, names)), rawArgs);
 
-    if isNameValue
-        for k = 1:2:numel(rawArgs)
-            args.(names{strcmpi(rawArgs{k}, names)}) = rawArgs{k + 1};
+    % Position of the first parameter-name string — where name-value begins.
+    nvStart = find(isParamName, 1);
+
+    nvOK = false;
+    if ~isempty(nvStart)
+        nv = rawArgs(nvStart:end);
+        % Valid name-value section: even count, all name-position elements
+        % are known parameter names.
+        nvOK = mod(numel(nv), 2) == 0 && ...
+               all(cellfun(@(x) (ischar(x) || isstring(x)) && isscalar(string(x)) && ...
+                   any(strcmpi(x, names)), nv(1:2:end)));
+    end
+
+    if ~isempty(nvStart) && nvOK
+        % Assign leading positional arguments (may be zero when nvStart == 1).
+        nPos = nvStart - 1;
+        if nPos > numel(names)
+            error('parseRAVENargs:tooManyArgs', ...
+                'Too many positional arguments: expected at most %d, got %d.', ...
+                numel(names), nPos);
+        end
+        for k = 1:nPos
+            args.(names{k}) = rawArgs{k};
+        end
+        % Assign name-value pairs.
+        nv = rawArgs(nvStart:end);
+        for k = 1:2:numel(nv)
+            args.(names{strcmpi(nv{k}, names)}) = nv{k + 1};
         end
     else
+        % Purely positional.
         if numel(rawArgs) > numel(names)
             error('parseRAVENargs:tooManyArgs', ...
                 'Too many positional arguments: expected at most %d, got %d.', ...


### PR DESCRIPTION
## Summary

- **parseRAVENargs hybrid mode**: rewrites argument parsing to support mixing leading positional values with trailing name-value pairs (e.g. `f(model, 5, 'seed', 42)`). Fixes `randomSamplingDeterministicWithSeed` CI failure and makes any odd-count hybrid call work correctly instead of falling through to positional-only parsing.

- **SAMP1 — randomSampling FVA refactor**: replaces the per-reaction `parfor` goodRxns detection (2xnRxns separate LPs) with a single `getAllowedBounds` FVA call. Produces identical results; removes ~25 lines of bespoke loop code.

- **I4 — runINIT per-reaction big-M**: replaces the fixed big-M of 1000 in the fake-metabolite trick with each non-essential reaction's own upper bound (capped at 1000). Adds `eps` parameter (default 1) for the minimum flux of included reactions. Clamps essential reaction lower bounds to not exceed their upper bounds.

- **FT3 — ftINITInternalAlg per-reaction big-M**: replaces all six occurrences of the fixed big-M of 100 (posRev, negIrrev, negRev, essRev, metNegRev constraints) with per-reaction bounds from `max(ub, -lb)`, capped at 1000. The fixed 100 incorrectly capped flux for any reaction with `ub > 100` (the standard RAVEN default is 1000). Adds `forceOn` parameter (default 0.1).

## Test plan

- [ ] `tUtils/parseRAVENargsHybrid` -- hybrid calling convention
- [ ] `tAnalysis/randomSamplingDeterministicWithSeed` -- seed reproducibility with natural hybrid call
- [ ] `tAnalysis/randomSamplingRuns` -- basic sampling smoke test
- [ ] `tINIT` suite -- verify MILP still solves correctly with per-reaction big-M
