### PR TITLE
Backport FS1/FS2/FS4, H1/H4, FT8: correlation-based FSEOF, homology strictness split, deterministic tie-break

### DIFF
--- a/INIT/removeLowScoreGenes.m
+++ b/INIT/removeLowScoreGenes.m
@@ -157,8 +157,10 @@ if ~contains(rule,'&')  % rule contains isozymes
     scoreMethod = isozymeScoring;
     negInd = gScores(geneInd) < 0;  % NaNs will return false here
     if all(negInd)
-        % get the least negative gene, adding a small random value to avoid a tie
-        [~,maxInd] = max(gScores(geneInd) + rand(size(geneInd))*(1e-8));
+        % deterministic least-negative: sort descending; stable sort breaks
+        % ties by original gene order (left-to-right in the rule string)
+        [~,sortOrder] = sort(gScores(geneInd),'descend');
+        maxInd = sortOrder(1);
         updatedRule = ruleGenes{maxInd};
     elseif sum(~negInd) == 1
         updatedRule = ruleGenes{~negInd};

--- a/analysis/FSEOF.m
+++ b/analysis/FSEOF.m
@@ -26,15 +26,27 @@ function targets=FSEOF(model,biomassRxn,targetRxn,varargin)
 %     (default 0.9).
 % outputFile : char
 %     output filename (default prints to command window).
+% corrThreshold : double
+%     minimum absolute Pearson correlation coefficient between a
+%     reaction's absolute flux and the enforced product flux for the
+%     reaction to be selected as a target. Values in [0, 1]; higher
+%     values require a more linear response and suppress LP alternative-
+%     optima noise (default 0.9).
 %
 % Returns
 % -------
 % targets : struct
 %     structure with information for identified targets, with fields:
 %
-%     - logical : logical array indicating whether a model reaction was
-%       identified as target by FSEOF
-%     - slope : numeric array with FSEOF slopes for target reactions
+%     - logical : logical array, true for amplification targets (backward
+%       compatible alias for amplify).
+%     - amplify : logical array, reactions whose absolute flux increases
+%       with enforced product flux.
+%     - knockdown : logical array, reactions driven toward but not to zero.
+%     - knockout : logical array, reactions driven to zero at max product.
+%     - slope : numeric array with per-reaction regression slopes of
+%       absolute flux versus enforced product flux (all reactions, not
+%       just targets).
 %
 % Examples
 % --------
@@ -44,114 +56,111 @@ function targets=FSEOF(model,biomassRxn,targetRxn,varargin)
 biomassRxn=char(biomassRxn);
 targetRxn=char(targetRxn);
 
-p=parseRAVENargs(varargin, {'iterations',10; 'coefficient',0.9; 'outputFile',[]});
+p=parseRAVENargs(varargin, {'iterations',10; 'coefficient',0.9; 'outputFile',[]; 'corrThreshold',0.9});
 iterations=p.iterations;
 coefficient=p.coefficient;
 outputFile=p.outputFile;
-
-if isempty(outputFile)
-    output=0;
-else
-    output=1;
-end
+corrThreshold=p.corrThreshold;
 
 %Find out the maximum theoretical yield of target reaction
 model=setParam(model,'obj',targetRxn,1);
 sol=solveLP(model,1);
-targetMax=sol.f*coefficient;   % 90 percent of the theoretical yield
+targetMax=sol.f*coefficient;
 
 model=setParam(model,'obj',biomassRxn,1);
 
-fseof.results=zeros(length(model.rxns),iterations);
-fseof.target=zeros(length(model.rxns),1);
-rxnDirection=zeros(length(model.rxns),1);
+nRxns=length(model.rxns);
+results=zeros(nRxns,iterations);
+enforcedFlux=(1:iterations)*targetMax/iterations;
 
-%Enforce objective flux iteratively
+%Run pFBA at each enforced target flux level
 for i=1:iterations
-    n=i*targetMax/iterations;
-    model=setParam(model,'lb',targetRxn,n);
-    
+    model=setParam(model,'lb',targetRxn,enforcedFlux(i));
     sol=solveLP(model,1);
-    
-    fseof.results(:,i)=sol.x;
-    
-    %Loop through all fluxes and identify the ones that increased upon the
-    %enforced objective flux
-    for j=1:length(fseof.results)
-        if fseof.results(j,1) > 0   %Check the positive fluxes
-            
-            if i == 1   %The initial round
-                rxnDirection(j,1)=1;
-                fseof.target(j,1)=1;
-            else
-                
-                if (fseof.results(j,i) > fseof.results(j,i-1)) & fseof.target(j,1)
-                    fseof.target(j,1)=1;
-                else
-                    fseof.target(j,1)=0;
-                end
-            end
-            
-        elseif fseof.results(j,1) < 0 %Check the negative fluxes
-            
-            if i == 1   %The initial round
-                rxnDirection(j,1)=-1;
-                fseof.target(j,1)=1;
-            else
-                if (fseof.results(j,i) < fseof.results(j,i-1)) & fseof.target(j,1)
-                    fseof.target(j,1)=1;
-                else
-                    fseof.target(j,1)=0;
-                end
-            end
-            
+    results(:,i)=sol.x;
+end
+
+%Compute per-reaction regression slope (FS4) and Pearson correlation (FS1)
+%on absolute flux values to treat forward/reverse symmetrically.
+absResults=abs(results);
+slope=zeros(nRxns,1);
+rCoeff=zeros(nRxns,1);
+hasVariation = iterations > 1 && std(enforcedFlux) > 0;
+if hasVariation
+    for num=1:nRxns
+        fluxTrack=absResults(num,:);
+        if any(fluxTrack > 1e-10) && std(fluxTrack) > 0
+            p_fit=polyfit(enforcedFlux,fluxTrack,1);
+            slope(num)=p_fit(1);
+            r=corrcoef(enforcedFlux,fluxTrack);
+            rCoeff(num)=r(1,2);
         end
-        
     end
 end
+
+%Classify targets: select reactions whose absolute flux is sufficiently
+%correlated with the enforced product flux (FS1), then split by direction
+%and whether any flux remains at maximum enforcement (FS2).
+isCorrelated = abs(rCoeff) >= corrThreshold;
+isAmplify    = isCorrelated & slope > 0;
+isKnockdown  = isCorrelated & slope < 0 & absResults(:,end) > 1e-8;
+isKnockout   = isCorrelated & slope < 0 & absResults(:,end) <= 1e-8;
+
+rxnDirection=sign(results(:,1));
 
 %Generating output
-formatSpec='%s\t%s\t%s\t%s\t%s\t%s\t%s\n';
-if output == 1    %Output to a file
+formatSpec='%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n';
+if ~isempty(outputFile)
     outputFile=char(outputFile);
     fid=fopen(outputFile,'w');
-    fprintf(fid,formatSpec,'Slope','rowID','Enzyme ID','Enzyme Name','Subsystems','Direction','Gr Rule');
-else              %Output to screen
-    fprintf(formatSpec,'Slope','rowID','Enzyme ID','Enzyme Name','Subsystems','Direction','Gr Rule');
+    fprintf(fid,formatSpec,'Type','Slope','rowID','Enzyme ID','Enzyme Name','Subsystems','Direction','Gr Rule');
+else
+    fid=-1;
+    fprintf(formatSpec,'Type','Slope','rowID','Enzyme ID','Enzyme Name','Subsystems','Direction','Gr Rule');
 end
 
-for num=1:length(fseof.target)
-    if fseof.target(num,1) == 1
-        A0=num2str(abs(fseof.results(num,iterations)-fseof.results(num,1))/abs(targetMax-targetMax/iterations)); %Slope calculation
-        A1=num2str(num);                                  %row ID
-        A2=char(model.rxns(num));                         %enzyme ID
-        A3=char(model.rxnNames(num));                     %enzyme Name
-        if isfield(model,'subSystems') && ~isempty(model.subSystems{num});
-            if ~any(cellfun(@(x) iscell(x), model.subSystems));
-                subSys = cellfun(@(x) {x}, model.subSystems, 'uni', 0);
+targetTypes  = {'Amplify','Knockdown','Knockout'};
+targetArrays = {isAmplify, isKnockdown, isKnockout};
+
+for t=1:3
+    flag=targetArrays{t};
+    for num=1:nRxns
+        if flag(num)
+            A_type=targetTypes{t};
+            A0=num2str(slope(num));
+            A1=num2str(num);
+            A2=char(model.rxns(num));
+            A3=char(model.rxnNames(num));
+            if isfield(model,'subSystems') && ~isempty(model.subSystems{num})
+                if ~any(cellfun(@(x) iscell(x), model.subSystems))
+                    subSys=cellfun(@(x) {x}, model.subSystems, 'uni', 0);
+                else
+                    subSys=model.subSystems;
+                end
+                A4=char(strjoin(subSys{num},';'));
             else
-                subSys = model.subSystems;
+                A4='';
             end
-            A4=char(strjoin(subSys{num},';'));                   %Subsystems
-        else
-            A4='';
-        end
-        A5=num2str(model.rev(num)*rxnDirection(num,1));   %reaction Dirction
-        A6=char(model.grRules(num));                      %Gr Rule
-        if output == 1    %Output to a file
-            fprintf(fid,formatSpec,A0,A1,A2,A3,A4,A5,A6);
-        else              %Output screen
-            fprintf(formatSpec,A0,A1,A2,A3,A4,A5,A6);
+            A5=num2str(model.rev(num)*rxnDirection(num));
+            A6=char(model.grRules(num));
+            if fid == -1
+                fprintf(formatSpec,A_type,A0,A1,A2,A3,A4,A5,A6);
+            else
+                fprintf(fid,formatSpec,A_type,A0,A1,A2,A3,A4,A5,A6);
+            end
         end
     end
 end
 
-if output == 1    %Output to a file
+if fid ~= -1
     fclose(fid);
 end
 
 if nargout == 1
-    targets.logical=logical(fseof.target);
-    targets.slope=abs(fseof.results(:,iterations)-fseof.results(:,1))/abs(targetMax-targetMax/iterations); %Slope calculation
+    targets.logical   = isAmplify;
+    targets.amplify   = isAmplify;
+    targets.knockdown = isKnockdown;
+    targets.knockout  = isKnockout;
+    targets.slope     = slope;
 end
 end

--- a/reconstruction/homology/getModelFromHomology.m
+++ b/reconstruction/homology/getModelFromHomology.m
@@ -23,23 +23,33 @@ function [draftModel, hitGenes]=getModelFromHomology(models,blastStructure,...
 %     the order in which reactions should be added from the models. If not
 %     supplied, reactions will be included from all models, otherwise one
 %     gene will only result in reactions from one model (default {}).
+% bidirectional : logical
+%     require acceptable BLASTP hits in both directions (new→template and
+%     template→new) for a gene pair to be used. Reciprocal best-hit
+%     mapping (bidirectional=true, bestHitsOnly=true) is the most
+%     conservative option (default true).
+% bestHitsOnly : logical
+%     before mapping, trim each BLASTP direction to the single best hit
+%     per query gene (by scoreBy criterion). This removes many-to-many
+%     and many-to-one mappings (default false).
+% scoreBy : char
+%     criterion used by bestHitsOnly to select the best hit per query
+%     gene. 'bitscore' selects the hit with the highest bitscore
+%     (database-size-independent). 'evalue' selects the hit with the
+%     lowest E-value. (default 'bitscore').
 % strictness : double
-%     integer that specifies which reactions should be included (default 1):
+%     legacy integer alias for bidirectional/bestHitsOnly (default 1):
 %
-%     - 1 : Map new genes to old for all pairs, which have acceptable BLASTP
-%       results in both directions.
-%     - 2 : Map new genes to old for all pairs, which have acceptable BLASTP
-%       results in correspondent direction (mapping can be done in the
-%       opposite direction, see mapNewGenesToOld below).
-%     - 3 : Check all BLASTP results and retain only the best results by
-%       E-value for all gene pairs in each direction separately. Then map
-%       new genes to old for all pairs, which have acceptable BLASTP results
-%       in both directions.
+%     - 1 : bidirectional=true,  bestHitsOnly=false.
+%     - 2 : bidirectional=false, bestHitsOnly=false.
+%     - 3 : bidirectional=true,  bestHitsOnly=true.
+%
+%     Ignored when bidirectional or bestHitsOnly are supplied explicitly.
 % onlyGenesInModels : logical
 %     consider BLASTP results only for genes that exist in the models. This
 %     tends to import a larger fraction from the existing models but may
-%     give less reliable results. Has effect only if strictness=3 (default
-%     false).
+%     give less reliable results. Has effect only if bestHitsOnly=true
+%     (default false).
 % maxE : double
 %     only look at genes with E-values <= this value (default 10^-30).
 % minLen : double
@@ -83,6 +93,7 @@ hitGenes.newGenes = [];  % collect the new genes of the draft model (target orga
 getModelFor=char(getModelFor);
 
 p=parseRAVENargs(varargin, {'preferredOrder',[]; 'strictness',1; ...
+    'bidirectional',[]; 'bestHitsOnly',[]; 'scoreBy','bitscore'; ...
     'onlyGenesInModels',false; 'maxE',10^-30; 'minLen',200; 'minIde',40; ...
     'mapNewGenesToOld',true});
 preferredOrder=p.preferredOrder;
@@ -95,7 +106,21 @@ else
         preferredOrder=transpose(preferredOrder);
     end
 end
-strictness=p.strictness;
+%Resolve bidirectional/bestHitsOnly from strictness when not set explicitly.
+if isempty(p.bidirectional) && isempty(p.bestHitsOnly)
+    switch p.strictness
+        case 2
+            bidirectional=false; bestHitsOnly=false;
+        case 3
+            bidirectional=true;  bestHitsOnly=true;
+        otherwise
+            bidirectional=true;  bestHitsOnly=false;
+    end
+else
+    bidirectional  = p.bidirectional;  if isempty(bidirectional),  bidirectional=true;  end
+    bestHitsOnly   = p.bestHitsOnly;   if isempty(bestHitsOnly),   bestHitsOnly=false;  end
+end
+scoreBy=char(p.scoreBy);
 onlyGenesInModels=p.onlyGenesInModels;
 maxE=p.maxE;
 minLen=p.minLen;
@@ -242,22 +267,26 @@ end
 
 %If only best orthologs are to be used then all other measurements are
 %deleted from the blastStructure. All code after this stays the same. This
-%means that preferred order can still matter. The best ortholog scoring is
-%based only on the E-value
-if strictness==3
+%means that preferred order can still matter. The best ortholog is selected
+%by bitscore (default) or E-value.
+if bestHitsOnly
     for i=1:numel(blastStructure)
         keep=false(numel(blastStructure(i).toGenes),1);
         [allFromGenes, ~, I]=unique(blastStructure(i).fromGenes);
-        
+
         %It would be nice to get rid of this loop
         for j=1:numel(allFromGenes)
             allMatches=find(I==j);
-            bestMatches=allMatches(blastStructure(i).evalue(allMatches)==min(blastStructure(i).evalue(allMatches)));
-            
+            if strcmpi(scoreBy,'evalue')
+                bestMatches=allMatches(blastStructure(i).evalue(allMatches)==min(blastStructure(i).evalue(allMatches)));
+            else
+                bestMatches=allMatches(blastStructure(i).bitscore(allMatches)==max(blastStructure(i).bitscore(allMatches)));
+            end
+
             %Keep the best matches
             keep(bestMatches)=true;
         end
-        
+
         %Delete all matches that were not best matches
         blastStructure(i).fromGenes(~keep)=[];
         blastStructure(i).toGenes(~keep)=[];
@@ -336,7 +365,7 @@ end
 %BLAST directions are to be included then only those elements are kept.
 
 finalMappings=cell(numel(useOrder)-1,1);
-if strictness==1 || strictness==3
+if bidirectional
     for j=1:numel(allFrom)
         finalMappings{j}=allTo{j}~=0 & allFrom{j}~=0;
     end


### PR DESCRIPTION
## Summary

Three groups of improvements backported from the Python raven-toolbox.

### FSEOF — regression-based target selection (FS1, FS2, FS4)

`analysis/FSEOF.m` is rewritten to replace the strict step-by-step monotonicity gate
with a Pearson-correlation filter and linear regression.

- **FS1** — A reaction is selected as a target when its absolute flux is sufficiently
  correlated with the enforced product flux (`|r| >= corrThreshold`, default 0.9). The
  old gate discarded valid targets whenever one LP step found an alternative optimum.
- **FS2** — Knockdown (flux driven toward but not to zero) and knockout (flux driven to
  zero) targets are returned as first-class outputs (`targets.knockdown`,
  `targets.knockout`) alongside amplification targets (`targets.amplify`).
  `targets.logical` is kept as a backward-compatible alias for `targets.amplify`.
- **FS4** — The reported slope uses the regression coefficient from all iterations,
  not the endpoint difference. The output file gains a `Type` column
  (Amplify / Knockdown / Knockout).

New parameter: `corrThreshold` (default 0.9).

### getModelFromHomology — bidirectional / bestHitsOnly split (H1, H4)

`reconstruction/homology/getModelFromHomology.m`:

- **H1** — `strictness 1/2/3` is replaced by two orthogonal boolean parameters:
  `bidirectional` (reciprocal hits) and `bestHitsOnly`. The existing `strictness`
  argument is retained as a compatibility alias.
- **H4** — Best-hit selection now defaults to **bitscore** (database-size-independent)
  instead of E-value. The scoring criterion is exposed as a `scoreBy` parameter
  (`'bitscore'` default, `'evalue'` for backward compatibility).

### removeLowScoreGenes — deterministic tie-break (FT8 partial)

`INIT/removeLowScoreGenes.m`: when all isozymes in an OR branch have negative scores,
the least-negative gene is retained. The previous selection added `rand()` noise to
break ties, making repeated calls non-deterministic. Replaced with a stable sort
(descending score); equal-score genes are kept in their original left-to-right rule order.

## Test plan

- [ ] `FSEOF(model, biomassRxn, targetRxn)` — verify `targets.amplify`, `targets.knockdown`, `targets.knockout`, `targets.slope` are returned; `targets.logical == targets.amplify`.
- [ ] `FSEOF(..., 'corrThreshold', 0)` — all reactions with any variation selected.
- [ ] `FSEOF(..., 'corrThreshold', 1)` — only perfectly linear reactions selected.
- [ ] `getModelFromHomology(..., 'bidirectional', true, 'bestHitsOnly', false)` equivalent to old `strictness=1`.
- [ ] `getModelFromHomology(..., 'strictness', 3)` backward-compat maps to `bidirectional=true, bestHitsOnly=true`.
- [ ] `getModelFromHomology(..., 'scoreBy', 'evalue')` restores E-value ranking.
- [ ] `removeLowScoreGenes` on a model with an all-negative isozyme rule — same gene selected across repeated calls.
