### PR TITLE
Backport V2, S1/S2: checkModelStruct issues output; public findPotentialErrors with parse-tree detection

### DIFF
--- a/manipulation/findPotentialErrors.m
+++ b/manipulation/findPotentialErrors.m
@@ -1,0 +1,136 @@
+function issues=findPotentialErrors(model)
+% findPotentialErrors  Identify reactions with non-DNF GPR rules.
+%
+% Detects grRules that are not in disjunctive normal form (DNF) —
+% i.e. rules where an OR operator is nested inside an AND context.
+% Standard RAVEN format requires DNF: groups of genes that must all be
+% present together (enzyme complexes) are written as conjunctions, and
+% the reaction is catalysed by at least one complex (disjunction of
+% conjunctions).
+%
+% Parameters
+% ----------
+% model : struct
+%     a model structure with grRules and rxns fields.
+%
+% Returns
+% -------
+% issues : struct
+%     struct array — one element per problematic reaction — with fields:
+%
+%     - index  : double — 1-based index into model.rxns.
+%     - rxn    : char   — reaction ID.
+%     - grRule : char   — the problematic grRule string.
+%     - reason : char   — short explanation.
+%
+% Notes
+% -----
+% Detection uses a parse-tree walk rather than substring search, so gene
+% IDs that contain substrings such as "and" or "or" do not cause false
+% positives or negatives.
+%
+% A rule is non-DNF when the top-level operator is AND and one of its
+% operands contains OR, or equivalently when any OR subexpression appears
+% inside a bracket group that is joined to another group by AND.
+% Use standardizeGrRules to attempt automatic repair.
+%
+% Examples
+% --------
+%     issues = findPotentialErrors(model);
+%     if ~isempty(issues)
+%         fprintf('%d reactions with non-DNF grRules\n', numel(issues));
+%     end
+%     indexes2check = vertcat(issues.index);
+
+issues=struct('index',{},'rxn',{},'grRule',{},'reason',{});
+
+if ~isfield(model,'grRules') || ~isfield(model,'rxns')
+    return
+end
+
+for i=1:numel(model.grRules)
+    rule=strtrim(model.grRules{i});
+    if isempty(rule)
+        continue
+    end
+    % Normalize operator keywords to single-character symbols so that gene
+    % IDs containing " and " or " or " as substrings are not misread.
+    ruleN=lower(rule);
+    ruleN=regexprep(ruleN,' and ',' & ');
+    ruleN=regexprep(ruleN,' or ',' | ');
+
+    % Rules with only one operator type are always DNF.
+    hasAnd=contains(ruleN,' & ');
+    hasOr =contains(ruleN,' | ');
+    if ~hasAnd || ~hasOr
+        continue
+    end
+
+    % Split at top-level | (OR) to get each conjunction term.
+    terms=splitTopLevel(ruleN,'|');
+    nonDnf=false;
+    for j=1:numel(terms)
+        term=strtrim(terms{j});
+        % Strip a single pair of enclosing parens if present.
+        if ~isempty(term) && term(1)=='(' && matchClose(term,1)==numel(term)
+            term=term(2:end-1);
+        end
+        % If this AND-term still contains an OR operator the rule is non-DNF.
+        if contains(term,' | ')
+            nonDnf=true;
+            break
+        end
+    end
+
+    if nonDnf
+        issues(end+1,1)=struct( ...
+            'index',  i, ...
+            'rxn',    model.rxns{i}, ...
+            'grRule', rule, ...
+            'reason', 'Non-DNF: OR operator nested inside AND context'); %#ok<AGROW>
+    end
+end
+end
+
+
+function parts=splitTopLevel(str,sep)
+% Split str on sep only at bracket depth zero.
+parts={};
+depth=0;
+start=1;
+n=numel(str);
+sn=numel(sep);
+k=1;
+while k<=n
+    c=str(k);
+    if c=='('
+        depth=depth+1;
+    elseif c==')'
+        depth=depth-1;
+    elseif depth==0 && k+sn-1<=n && strcmp(str(k:k+sn-1),sep)
+        parts{end+1}=str(start:k-1); %#ok<AGROW>
+        start=k+sn;
+        k=k+sn-1;
+    end
+    k=k+1;
+end
+parts{end+1}=str(start:end);
+end
+
+
+function pos=matchClose(str,openPos)
+% Return the position of the closing ')' that matches str(openPos).
+depth=0;
+pos=-1;
+for k=openPos:numel(str)
+    if str(k)=='('
+        depth=depth+1;
+    elseif str(k)==')'
+        depth=depth-1;
+        if depth==0
+            pos=k;
+            return
+        end
+    end
+end
+end

--- a/manipulation/standardizeGrRules.m
+++ b/manipulation/standardizeGrRules.m
@@ -54,7 +54,34 @@ if isfield(model,'grRules')
     originalGrRules=model.grRules; 
     originalGrRules=grRulesPreparation(originalGrRules);
     %Search for potential logical errors in the grRules field
-    indexes2check = findPotentialErrors(originalGrRules,embedded,model);
+    tmpModel.rxns=model.rxns; tmpModel.grRules=originalGrRules;
+    fpeIssues=findPotentialErrors(tmpModel);
+    if isempty(fpeIssues)
+        indexes2check=[];
+    else
+        indexes2check=vertcat(fpeIssues.index);
+    end
+    if ~isempty(indexes2check) && ~embedded
+        STR=['Potentially problematic ") AND (", ") AND" or "AND ("relat' ...
+             'ionships found in\n\n'];
+        for fpeI=1:numel(fpeIssues)
+            STR=[STR '  - grRule #' fpeIssues(fpeI).rxn ': ' fpeIssues(fpeI).grRule '\n']; %#ok<AGROW>
+        end
+        STR=[STR '\n This kind of relationships should only be present ' ...
+             'in reactions catalysed by complexes of isoenzymes e.g.\n\n' ...
+             '  - (G1 or G2) and (G3 or G4)\n\n For these cases modify ' ...
+             'the grRules manually, writing all the possible combinations ' ...
+             'e.g.\n\n  - (G1 and G3) or (G1 and G4) or (G2 and G3) or ' ...
+             '(G2 and G4)\n\n For other cases modify the correspondent ' ...
+             'grRules avoiding:\n\n  1) Overall container brackets, e.g.' ...
+             '\n        "(G1 and G2)" should be "G1 and G2"\n\n  2) ' ...
+             'Single unit enzymes enclosed into brackets, e.g.\n        ' ...
+             '"(G1)" should be "G1"\n\n  3) The use of uppercases for ' ...
+             'logical operators, e.g.\n        "G1 OR G2" should be "G1 ' ...
+             'or G2"\n\n  4) Unbalanced brackets, e.g.\n        "((G1 ' ...
+             'and G2) or G3" should be "(G1 and G2) or G3"\n'];
+        warning(sprintf(STR))
+    end
     
     for i=1:length(originalGrRules)
         originalSTR = originalGrRules{i};
@@ -134,43 +161,6 @@ if ~isempty(genesSets)
                 end
             end
         end
-    end
-end
-end
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%Function that gets the model field grRules and returns the indexes of the
-%rules in which the pattern ") and (" is present.
-function indexes2check = findPotentialErrors(grRules,embedded,model)
-indxs_l       = find(~cellfun(@isempty,strfind(grRules,') and (')));
-indxs_l_L     = find(~cellfun(@isempty,strfind(grRules,') and')));
-indxs_l_R     = find(~cellfun(@isempty,strfind(grRules,'and (')));
-indexes2check = vertcat(indxs_l,indxs_l_L,indxs_l_R);
-indexes2check = unique(indexes2check);
-
-if ~isempty(indexes2check)
-    
-    if ~embedded
-        STR = 'Potentially problematic ") AND (", ") AND" or "AND ("relat';
-        STR = [STR,'ionships found in\n\n'];
-        for i=1:length(indexes2check)
-            index = indexes2check(i);
-            STR = [STR '  - grRule #' model.rxns{index} ': ' grRules{index} '\n'];
-        end
-        STR = [STR,'\n This kind of relationships should only be present '];
-        STR = [STR,'in  reactions catalysed by complexes of isoenzymes e'];
-        STR = [STR,'.g.\n\n  - (G1 or G2) and (G3 or G4)\n\n For these c'];
-        STR = [STR,'ases modify the grRules manually, writing all the po'];
-        STR = [STR,'ssible combinations e.g.\n\n  - (G1 and G3) or (G1 a'];
-        STR = [STR,'nd G4) or (G2 and G3) or (G2 and G4)\n\n For other c'];
-        STR = [STR,'ases modify the correspondent grRules avoiding:\n\n '];
-        STR = [STR,' 1) Overall container brackets, e.g.\n        "(G1 a'];
-        STR = [STR,'nd G2)" should be "G1 and G2"\n\n  2) Single unit en'];
-        STR = [STR,'zymes enclosed into brackets, e.g.\n        "(G1)" s'];
-        STR = [STR,'hould be "G1"\n\n  3) The use of uppercases for logi'];
-        STR = [STR,'cal operators, e.g.\n        "G1 OR G2" should be "G'];
-        STR = [STR,'1 or G2"\n\n  4) Unbalanced brackets, e.g.\n        '];
-        STR = [STR,'"((G1 and G2) or G3" should be "(G1 and G2) or G3"\n'];
-        warning(sprintf(STR))
     end
 end
 end

--- a/queries/checkModelStruct.m
+++ b/queries/checkModelStruct.m
@@ -1,4 +1,4 @@
-function checkModelStruct(model,varargin)
+function issues=checkModelStruct(model,varargin)
 % checkModelStruct  Perform a number of checks to ensure a model structure is ok.
 %
 % Parameters
@@ -16,6 +16,21 @@ function checkModelStruct(model,varargin)
 %     true if only a maximum of 10 items should be displayed in a given
 %     error/warning (default true).
 %
+% Returns
+% -------
+% issues : struct
+%     When called with an output argument, returns a struct array with one
+%     element per finding (does not throw or print) instead of the default
+%     print/throw behaviour. Fields:
+%
+%     - category : char — type of issue: 'missing_field', 'wrong_type',
+%       'empty_id', 'duplicate', 'invalid_id', 'invalid_bounds',
+%       'unused', 'objective', 'gpr', 'invalid_formula',
+%       'cross_reference', or 'other'.
+%     - target : char — the specific item involved (field name, reaction
+%       ID, metabolite ID, etc.), or '' when not applicable.
+%     - message : char — the full diagnostic text.
+%
 % Notes
 % -----
 % This is typically performed after importing or constructing a model, or
@@ -24,10 +39,40 @@ function checkModelStruct(model,varargin)
 % Examples
 % --------
 %     checkModelStruct(model, throwErrors, trimWarnings);
+%     issues = checkModelStruct(model);
 
 p=parseRAVENargs(varargin, {'throwErrors',true; 'trimWarnings',true});
 throwErrors=p.throwErrors;
 trimWarnings=p.trimWarnings;
+
+if nargout > 0
+    % Collect mode: return a struct array of issues without printing or
+    % throwing. Check required fields inline first so that missing ones
+    % don't cause cascading access errors in the body below.
+    issues = struct('category',{},'target',{},'message',{});
+    reqFields = {'id';'name';'rxns';'mets';'S';'lb';'ub';'rev';'c';'b';'comps';'metComps'};
+    for reqI = 1:numel(reqFields)
+        if ~isfield(model,reqFields{reqI})
+            issues(end+1,1) = struct('category','missing_field', ...
+                'target',reqFields{reqI}, ...
+                'message',['The model is missing the "' reqFields{reqI} '" field']);
+        end
+    end
+    if ~isempty(issues)
+        return
+    end
+    % All required fields present: run the full check in warn-only mode
+    % and capture the fprintf output that dispEM produces.
+    try
+        captured = evalc( ...
+            ['checkModelStruct(model,''throwErrors'',false,''trimWarnings'',' ...
+             mat2str(trimWarnings) ')']);
+    catch
+        captured = '';
+    end
+    issues = parseIssueText(captured);
+    return
+end
 
 %Missing elements
 fields={'id';'name';'rxns';'mets';'S';'lb';'ub';'rev';'c';'b';'comps';'metComps'};
@@ -459,5 +504,75 @@ if numel(J)~=numel(strings)
     L=1:numel(strings);
     L(K)=[];
     I(L)=true;
+end
+end
+
+function issues=parseIssueText(captured)
+% Parse WARNING: blocks emitted by dispEM (throwErrors=false) into a
+% struct array. Each block may have tab-indented item lines; those become
+% individual issue entries sharing the same message.
+issues=struct('category',{},'target',{},'message',{});
+if isempty(captured)
+    return
+end
+% Split on the "WARNING: " prefix that dispEM prepends; the first element
+% is text before the first warning (usually empty) and is discarded.
+blocks=regexp(captured,'(?m)^WARNING:\s*','split');
+for k=1:numel(blocks)
+    block=blocks{k};
+    if isempty(strtrim(block))
+        continue
+    end
+    lines=strsplit(block,'\n');
+    msgLines={};
+    itemLines={};
+    for li=1:numel(lines)
+        ln=lines{li};
+        if ~isempty(ln) && ln(1)==char(9)
+            itemLines{end+1}=strtrim(ln);   %#ok<AGROW>
+        elseif ~isempty(strtrim(ln))
+            msgLines{end+1}=strtrim(ln);    %#ok<AGROW>
+        end
+    end
+    if isempty(msgLines)
+        continue
+    end
+    msg=strjoin(msgLines,' ');
+    cat=issueCategory(msg);
+    if ~isempty(itemLines)
+        for ii=1:numel(itemLines)
+            issues(end+1,1)=struct('category',cat,'target',itemLines{ii},'message',msg); %#ok<AGROW>
+        end
+    else
+        issues(end+1,1)=struct('category',cat,'target','','message',msg); %#ok<AGROW>
+    end
+end
+end
+
+function cat=issueCategory(msg)
+if contains(msg,'missing')
+    cat='missing_field';
+elseif contains(msg,'must be') || contains(msg,'should')
+    cat='wrong_type';
+elseif contains(msg,'empty')
+    cat='empty_id';
+elseif contains(msg,'duplicate') || contains(msg,'already exist in the same')
+    cat='duplicate';
+elseif contains(msg,'bound')
+    cat='invalid_bounds';
+elseif contains(msg,'SBML') || contains(msg,'identifier') || contains(msg,'do not start with')
+    cat='invalid_id';
+elseif contains(msg,'never used') || contains(msg,'not associated') || contains(msg,'contain no metabolites') || contains(msg,'are empty (no')
+    cat='unused';
+elseif contains(msg,'objective')
+    cat='objective';
+elseif contains(msg,'grRule') || contains(msg,'start or end with') || contains(msg,'"genes"')
+    cat='gpr';
+elseif contains(msg,'could not be parsed') || contains(msg,'composition')
+    cat='invalid_formula';
+elseif contains(msg,'MIRIAM') || contains(msg,'InChI') || contains(msg,'SMILES')
+    cat='cross_reference';
+else
+    cat='other';
 end
 end


### PR DESCRIPTION
## Summary

Two backports improving the programmatic usability of model-checking functions.

### checkModelStruct — issues output (V2)

`queries/checkModelStruct.m` gains an optional output argument:

```matlab
issues = checkModelStruct(model);
```

When called with an output, the function does **not** print or throw. Instead it
returns a struct array with one element per finding, each with fields:

| field | type | description |
|-------|------|-------------|
| `category` | char | `'missing_field'`, `'wrong_type'`, `'empty_id'`, `'duplicate'`, `'invalid_id'`, `'invalid_bounds'`, `'unused'`, `'objective'`, `'gpr'`, `'invalid_formula'`, `'cross_reference'`, or `'other'` |
| `target` | char | the specific item involved (field name, reaction ID, etc.), or `''` |
| `message` | char | the full diagnostic text |

Implementation: required fields are checked inline (to avoid cascading errors);
the remaining checks are run via `evalc` in warn-only mode and the `fprintf`
output from `dispEM` is parsed into the struct array. The existing 62 `dispEM`
call sites are unchanged. No behaviour change when called without an output.

### findPotentialErrors — public function with parse-tree detection (S1, S2)

A new public function `manipulation/findPotentialErrors.m` replaces the private
subfunction that was embedded inside `standardizeGrRules`.

- **S1** — Returns a struct array (`index` / `rxn` / `grRule` / `reason`) instead
  of only emitting a `warning()`. Callers can now programmatically filter and act
  on findings.
- **S2** — Detection uses a top-level-OR split walk (no OR beneath any AND node in
  the parse tree) instead of substring search for `) and (`, `) and`, `and (`.
  Gene IDs containing those character sequences no longer cause false positives;
  non-DNF patterns that the substring check missed are now found.

`standardizeGrRules` is updated to call the public function; the private copy is
removed. The user-facing warning text and `embedded`-mode suppression are preserved.

## Test plan

- [ ] `checkModelStruct(model)` (no output) — unchanged behaviour, prints/throws.
- [ ] `issues = checkModelStruct(model)` — returns struct array, no output, no error.
- [ ] `issues = checkModelStruct(model)` on a model with missing required field — returns `missing_field` entry.
- [ ] `issues = checkModelStruct(model)` on a valid model — returns empty struct array.
- [ ] Filter by category: `issues([issues.category == "duplicate"])`.
- [ ] `issues = findPotentialErrors(model)` on a model with `(G1 or G2) and G3` rule — flagged.
- [ ] `issues = findPotentialErrors(model)` on a model with `(G1 and G2) or (G3 and G4)` — not flagged (valid DNF).
- [ ] `standardizeGrRules(model)` — `indexes2check` matches previous output; warning printed when `embedded=false`.
