### PR TITLE
CI: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ steps.tag.outputs.tag }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: R2024b
 
       - name: Run function tests
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         env:
           # Batch licensing token for running MATLAB on a GitHub-hosted
           # runner. Request one from MathWorks and store it as the
@@ -87,12 +87,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: R2024b
 
       - name: Test on-demand binary download
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         env:
           MLM_LICENSE_TOKEN: ${{ secrets.MATLAB_BATCH_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

Bumps GitHub Actions to versions that run on the **Node 24** runtime. The `v2`/`v5` majors of these actions declare the now-deprecated Node 20 runtime, so GitHub forces them onto Node 24 and emits a deprecation warning on every run:

- `matlab-actions/setup-matlab@v2` → `@v3`
- `matlab-actions/run-command@v2` → `@v3`
- `actions/setup-python@v5` → `@v6`

`actions/checkout` is already `@v5` (Node 24), and `EnricoMi/publish-unit-test-result-action@v2` is a Docker action (unaffected). Action inputs (`release`, `command`, `python-version`) are unchanged across these majors, so no other edits are needed. The `Tests` workflow runs on this PR and exercises the bumped MATLAB actions.
