### PR TITLE
fix: getKEGGModelForOrganism parse error; add repo-wide syntax test

### DIFF
--- a/reconstruction/kegg/getKEGGModelForOrganism.m
+++ b/reconstruction/kegg/getKEGGModelForOrganism.m
@@ -30,8 +30,8 @@ function model=getKEGGModelForOrganism(organismID,varargin)
 %     and whether the HMMs were trained on pro- or eukaryotic sequences. The
 %     directory name matches the published HMM library it is paired with. The
 %     prebuilt concatenated KO HMM library (dataDir.hmm) is downloaded here
-%     from the corresponding RAVEN release if not already present. May also
-%     This parameter should ALWAYS be provided.
+%     from the corresponding raven-data release if not already present. This
+%     parameter should ALWAYS be provided.
 % outDir : char
 %     directory to save the results from the quering of the hidden Markov
 %     models. The output is specific for the input sequences and the
@@ -217,7 +217,6 @@ if ~isempty(dataDir)
         fprintf('Extracting the HMM library file... ');
         gunzip([libraryFile '.gz']);
         fprintf('COMPLETE\n');
-        useConcatLib=false;
     else
         fprintf('Downloading the HMM library file... ');
         try
@@ -231,7 +230,6 @@ if ~isempty(dataDir)
         fprintf('Extracting the HMM library file... ');
         gunzip([libraryFile '.gz']);
         fprintf('COMPLETE\n');
-        useConcatLib=true;
     end
     %Check that the HMM library is available
     if ~isfile(libraryFile)
@@ -447,7 +445,6 @@ end
 fclose(fid);
 delete(tblFile);
 fprintf('COMPLETE\n');
-end
 
 fprintf('Removing gene, KEGG Orthology associations below minScoreRatioKO, minScoreRatioG... ');
 koGeneMat=koGeneMat(:,1:geneCounter);
@@ -556,18 +553,4 @@ end
 %Remove the temp fasta file
 delete(fastaFile)
 fprintf('COMPLETE\n\n*** Model reconstruction complete ***\n');
-end
-
-function files=listFiles(directory)
-%Supporter function to list the files in a directory and return them as a
-%cell array
-temp=dir(directory);
-files=cell(numel(temp),1);
-for i=1:numel(temp)
-    files{i}=temp(i,1).name;
-end
-files=strrep(files,'.fa','');
-files=strrep(files,'.hmm','');
-files=strrep(files,'.out','');
-files=strrep(files,'.faw','');
 end

--- a/testing/function_tests/tSyntax.m
+++ b/testing/function_tests/tSyntax.m
@@ -1,0 +1,50 @@
+classdef tSyntax < RavenTestCase
+% tSyntax  Every RAVEN source file must parse.
+%
+%   A MATLAB file with unbalanced block keywords still sits in the repository
+%   looking perfectly ordinary: the error only surfaces when something calls
+%   it. getKEGGModelForOrganism.m carried an orphan `end` for over a month
+%   (introduced by #636, found by #669) during which the whole KEGG homology
+%   path was dead, because its only test was an unconditional assumeFail and
+%   nothing else parsed the file.
+%
+%   This test is the cheap backstop: it needs no data, no solver and no
+%   network, and it runs over the entire source tree in seconds.
+
+    methods (Test)
+        function allSourceFilesParse(testCase)
+            files = dir(fullfile(testCase.ravenRoot,'**','*.m'));
+            paths = fullfile({files.folder}, {files.name});
+
+            % software/ is vendored third-party code (GLPKmex, libSBML). It is
+            % not ours to fix, so a syntax complaint there is not a RAVEN bug.
+            paths = paths(~contains(paths, [filesep 'software' filesep]));
+
+            testCase.assertNotEmpty(paths, 'Found no .m files to check.');
+
+            msgs = checkcode(paths{:}, '-id');
+            if ~iscell(msgs)
+                msgs = {msgs};   % checkcode returns a bare struct for one file
+            end
+
+            offenders = {};
+            for i = 1:numel(paths)
+                if isempty(msgs{i})
+                    continue
+                end
+                % SYNER is checkcode's parse-error identifier. Only syntax is
+                % checked here; style warnings are deliberately ignored so the
+                % test stays a hard gate rather than a lint backlog.
+                bad = strcmp({msgs{i}.id}, 'SYNER');
+                for k = find(bad)
+                    offenders{end+1} = sprintf('%s (line %d): %s', ...
+                        strrep(paths{i}, testCase.ravenRoot, ''), ...
+                        msgs{i}(k).line, msgs{i}(k).message); %#ok<AGROW>
+                end
+            end
+
+            testCase.verifyEmpty(offenders, ...
+                sprintf('Files with parse errors:\n%s', strjoin(offenders, newline)));
+        end
+    end
+end


### PR DESCRIPTION
### Main improvements in this PR:

- fix:
  - `getKEGGModelForOrganism` did not parse, leaving the KEGG homology path unusable.
- features:
  - `tSyntax.m`: repo-wide `checkcode` syntax test.

#### Instructions on merging this PR:
- [X] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
