### PR TITLE
fix: score HPA genes over the cell types they were measured in

### DIFF
--- a/INIT/scoreComplexModel.m
+++ b/INIT/scoreComplexModel.m
@@ -265,12 +265,19 @@ if ~all(I)
     EM = 'There are expression level categories that do not match to hpaLevelScores';
     error('RAVEN:badInput', '%s', EM);
 end
-[K, L, M] = find(hpaData.gene2Level);
+[K, ~, M] = find(hpaData.gene2Level);
 scores = hpaLevelScores.scores(J);
+% Reduce over the cell types each gene was actually measured in. Building a
+% sparse GENESxCELLTYPES matrix instead would put a numeric 0 at every
+% unmeasured (gene, cell type) pair, and 0 sits between 'Low' (10) and
+% 'Not detected' (-8): a gene not detected in one of two cell types would
+% score 0 rather than -8 under 'max', and would never be pruned. The
+% arrayData branch above likewise divides by the number of measurements.
+measured = reshape(scores(M), [], 1);
 if strcmpi(multipleCellScoring,'max')
-    hScores = max(sparse(K,L,scores(M),numel(hpaData.genes),numel(hpaData.tissues)),[],2);
+    hScores = accumarray(K(:), measured, [numel(hpaData.genes) 1], @max, 0);
 else
-    hScores = mean(sparse(K,L,scores(M),numel(hpaData.genes),numel(hpaData.tissues)),2);
+    hScores = accumarray(K(:), measured, [numel(hpaData.genes) 1], @mean, 0);
 end
 
 % Assign gene scores, prioritizing HPA (protein) data over arrayData (RNA)

--- a/testing/function_tests/tINIT.m
+++ b/testing/function_tests/tINIT.m
@@ -84,6 +84,31 @@ classdef tINIT < RavenTestCase
             testCase.verifyNumElements(rxnScores, numel(testCase.model.rxns));
         end
 
+        function scoreComplexModelHpaUnmeasuredCellTypeIsNotZero(testCase)
+            % A gene not detected in one cell type of a tissue and not
+            % measured in the other must keep its 'Not detected' score. An
+            % unmeasured cell type is not a measurement of zero, and zero
+            % ranks above 'Not detected' (-8), so scoring it as such would
+            % also keep the gene from ever being pruned.
+            m = testCase.model;
+            hpaData.genes      = m.genes(1);
+            hpaData.tissues    = {'liver';'liver'};
+            hpaData.celltypes  = {'hepatocyte';'kupffer'};
+            hpaData.levels     = {'Not detected'};
+            hpaData.gene2Level = sparse(1,2);
+            hpaData.gene2Level(1,1) = 1;   % not detected in hepatocyte
+                                           % not measured in kupffer
+
+            evalc(['[~,~,hpaScores] = scoreComplexModel(m, hpaData, [], ' ...
+                '''liver'', ''multipleCellScoring'', ''max'');']);
+            testCase.verifyEqual(hpaScores(1), -8, 'AbsTol', 1e-9);
+
+            % The average is likewise taken over the measurements that exist
+            evalc(['[~,~,hpaScores] = scoreComplexModel(m, hpaData, [], ' ...
+                '''liver'', ''multipleCellScoring'', ''average'');']);
+            testCase.verifyEqual(hpaScores(1), -8, 'AbsTol', 1e-9);
+        end
+
         function scoreComplexModelExactScores(testCase)
             % scoreComplexModel must reproduce the known reaction scores for
             % the reference model prepared by prepINITModel.


### PR DESCRIPTION
### Main improvements in this PR:

- fix:
  - `scoreComplexModel` scored an unmeasured cell type as 0, and 0 outranks 'Not detected' (-8). A gene not detected in one of two cell types therefore scored 0 under the default `'max'`, and was never pruned by `removeLowScoreGenes`, which only prunes below zero. `'average'` likewise divided by the number of cell types rather than the number of measurements. Both now reduce over the measurements that exist.
- documentation:
  - Test in `tINIT.m` for a gene measured in one of two cell types.

#### Instructions on merging this PR:
- [X] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
