### PR TITLE
fix: metabolite names starting with a number, and a spurious addRxns warning

### DIFF
--- a/manipulation/addRxns.m
+++ b/manipulation/addRxns.m
@@ -252,8 +252,10 @@ end
 %Parse the equations. This is done at this early stage since I need the
 %reversibility info
 [S, mets, badRxns, reversible]=constructS(rxnsToAdd.equations);
-EM='The following equations have one or more metabolites both as substrate and product. Only the net equations will be added:';
-warning('RAVEN:warning', '%s', ravenList(EM, rxnsToAdd.rxns(badRxns)));
+if any(badRxns)
+    EM='The following equations have one or more metabolites both as substrate and product. Only the net equations will be added:';
+    warning('RAVEN:warning', '%s', ravenList(EM, rxnsToAdd.rxns(badRxns)));
+end
 
 newModel.rev=[newModel.rev;reversible];
 newModel.rxns=[newModel.rxns;rxnsToAdd.rxns(:)];

--- a/queries/constructS.m
+++ b/queries/constructS.m
@@ -65,6 +65,10 @@ end
 equations=strtrim(equations);
 equations=fixEquations(equations);
 
+%A supplied list is authoritative, so an entry in it can be matched in full
+%before the leading number of "2 oxoglutarate" is read as a coefficient. A
+%list derived from the equations cannot disambiguate that.
+metsSupplied=~isempty(mets);
 if isempty(mets)
     mets=parseRxnEqu(equations);
 end
@@ -125,6 +129,11 @@ for i=1:numel(equations)
             %No coefficient
             coeff=1;
             name=metabolites{j};
+        elseif metsSupplied && any(strcmp(strtrim(metabolites{j}),mets))
+            %The whole entry is a known metabolite, so its leading number is
+            %part of its name ("2 oxoglutarate") rather than a coefficient
+            coeff=1;
+            name=strtrim(metabolites{j});
         else
             coeff=str2double(metabolites{j}(1:space(1)));
             

--- a/testing/function_tests/tManipulation.m
+++ b/testing/function_tests/tManipulation.m
@@ -85,6 +85,16 @@ classdef tManipulation < RavenTestCase
             testCase.verifyGreaterThan(numel(m2.rxns), numel(testCase.model.rxns));
         end
 
+        function addRxnsCleanEquationDoesNotWarn(testCase)
+            % The "metabolite on both sides" warning must only fire for the
+            % equations it names, not on every call.
+            rxnsToAdd.rxns      = {'newRxn'};
+            rxnsToAdd.equations = {[testCase.model.mets{1} ' => ' testCase.model.mets{2}]};
+            lastwarn('');
+            evalc('addRxns(testCase.model, rxnsToAdd, 1);');
+            testCase.verifyEmpty(strfind(lastwarn, 'both as substrate and product')); %#ok<STRIFY>
+        end
+
         function changeGrRulesUpdatesRule(testCase)
             m2 = changeGrRules(testCase.model, 'ACKr', 'b2296 and b1849', true);
             idx = strcmp(m2.rxns, 'ACKr');

--- a/testing/function_tests/tQueries.m
+++ b/testing/function_tests/tQueries.m
@@ -45,6 +45,24 @@ classdef tQueries < RavenTestCase
             testCase.verifyEqual(full(S), [-1;-1;1]);
         end
 
+        function constructSLeadingNumberIsPartOfName(testCase)
+            % A metabolite whose name starts with a number must not have that
+            % number read as a stoichiometric coefficient when the metabolite
+            % list says the whole entry is a metabolite.
+            mets = {'2 oxoglutarate';'succinate'};
+            [S, outMets] = constructS({'2 oxoglutarate => succinate'}, 'mets', mets);
+            testCase.verifyEqual(outMets, mets);
+            testCase.verifyEqual(full(S), [-1;1]);
+        end
+
+        function constructSLeadingNumberStillReadsCoefficient(testCase)
+            % With no such metabolite, the leading number is a coefficient.
+            mets = {'oxoglutarate';'succinate'};
+            [S, outMets] = constructS({'2 oxoglutarate => succinate'}, 'mets', mets);
+            testCase.verifyEqual(outMets, mets);
+            testCase.verifyEqual(full(S), [-2;1]);
+        end
+
         function getAllRxnsFromGenesType(testCase)
             % Use a reaction that has a gene association.
             withGpr = testCase.model.rxns(find(~cellfun(@isempty, ...


### PR DESCRIPTION
### Main improvements in this PR:

- fix:
  - `constructS` read the leading number of a metabolite whose name starts with a digit as a stoichiometric coefficient: `2 oxoglutarate => succinate` gave `S = [-2 1]` over a metabolite `oxoglutarate`. An entry that matches the supplied metabolite list in full is now taken as a name. Ordinary coefficients are unaffected.
  - `addRxns` raised its "metabolites both as substrate and product" warning on every call, with an empty list of reactions, because it never checked whether any equation had the problem.
- documentation:
  - Tests in `tQueries.m` and `tManipulation.m`.

#### Instructions on merging this PR:
- [X] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
