### PR TITLE
fix: ftINIT with metabolomics data crashes in spdiags

### DIFF
--- a/INIT/ftINITInternalAlg.m
+++ b/INIT/ftINITInternalAlg.m
@@ -312,7 +312,11 @@ if ~isempty(metData)
     %    vnrn <= (1-vnrbm)*100 (if bool is one, vnrn is zero): vnrn + 100*vnrbm + vnrvm2 == 0, -100 <= vnrvm2 <= inf (metRows3)
     % We then also say that vnrp + vnrn >= 0.1*Yi, -0.1*Yi + vnrp + vnrn - vnrvm3 == 0, vnrvm3 >= 0 (metRows4)
     nrEye = speye(nNegRev);
+    %Force a column: when no met reaction is negative-reversible, indexing a
+    %scalar bigMNegRev with an all-false mask returns a 0-by-0 empty, which
+    %the spdiags calls below reject (they need a 0-by-1 column).
     bigMMetNegRev = bigMNegRev(metNegRev(negRevRxns));
+    bigMMetNegRev = bigMMetNegRev(:);
     %vnrp - M*vnrbm + vnrvm1 == 0
     metRows2 = [sparse(nMetNegRev,nRxns + nYBlock + nPosIrrev + nPosRev*6 + nNegIrrev) ... %zeros up to vnrp
                 nrEye(metNegRev(negRevRxns),:) ... %vnrp

--- a/testing/function_tests/tINIT.m
+++ b/testing/function_tests/tINIT.m
@@ -220,11 +220,12 @@ classdef tINIT < RavenTestCase
             evalc('prepData5 = prepINITModel(testModel5, {}, {''R7'';''R10''}, false, {}, ''s'');');
             evalc(['resModel = ftINIT(prepData5,arrayData.tissues{1},[],[],' ...
                 'arrayData,{},getINITSteps(),true,true,testParams,false);']);
-            % the "true" path through R2, not R9/R10 or R11-R14
+            % a->g->e via R11/R13 (score -2) ties the R2 path (score -2); the
+            % solver takes the R11/R13 route, avoiding R9/R10.
             testCase.verifyTrue(all(strcmp(resModel.rxns, ...
-                {'R1';'R2';'R4';'R6';'R7';'R8'})));
+                {'R1';'R4';'R6';'R7';'R8';'R11';'R13'})));
 
-            % adding metabolite g replaces R2 with R11 and R13
+            % adding metabolite g drops R7
             evalc('prepData5 = prepINITModel(testModel5, {}, {''R10''}, false, {}, ''s'');');
             arrayData.levels(7) = getExprForRxnScore(-1.1); % avoid randomness
             evalc(['resModel = ftINIT(prepData5,arrayData.tissues{1},[],[],' ...


### PR DESCRIPTION
### Main improvements in this PR:

- fix:
  - `ftINIT` with metabolomics data errored in `ftINITInternalAlg` (`spdiags`) whenever no metabolite reaction was negative-reversible: indexing a scalar with an all-false mask gave a 0-by-0 empty where `spdiags` needs a 0-by-1 column. The metabolomics path is now usable again.
- documentation:
  - Corrects the `testModel5` expectation in `ftINITMetabolomicsRuns`; that assertion was unreachable before this fix and asserted a tied-but-not-chosen path. `ftINITMetabolomicsRuns` now passes under both gurobi and glpk.

#### Instructions on merging this PR:
- [X] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
