### PR TITLE
fix: drop stale compMiriams in mergeCompartments

### DIFF
--- a/manipulation/mergeCompartments.m
+++ b/manipulation/mergeCompartments.m
@@ -110,6 +110,12 @@ model.compNames={'System'};
 model.comps={'s'};
 model.compOutside={''};
 model.metComps=ones(numel(model.mets),1);
+%The per-compartment MIRIAM annotations no longer apply once every
+%compartment is merged into one, and leaving them would desync compMiriams
+%from the rebuilt comps. Drop them.
+if isfield(model,'compMiriams')
+    model=rmfield(model,'compMiriams');
+end
 
 %Add exchange mets to another compartment "b" with id "2"
 if keepUnconstrained==true

--- a/testing/function_tests/tManipulation.m
+++ b/testing/function_tests/tManipulation.m
@@ -236,6 +236,20 @@ classdef tManipulation < RavenTestCase
             testCase.verifyNumElements(m2.comps, 1);
         end
 
+        function mergeCompartmentsDropsStaleCompMiriams(testCase)
+            % Merging collapses every compartment into one, so any
+            % per-compartment MIRIAM annotation must not be left behind at the
+            % original length (which would desync compMiriams from comps).
+            m = testCase.model;
+            m.compMiriams = cell(numel(m.comps),1);
+            m.compMiriams{1}.name  = {'go'};
+            m.compMiriams{1}.value = {'GO:0005737'};
+            evalc('m2 = mergeCompartments(m);');
+            if isfield(m2,'compMiriams')
+                testCase.verifyNumElements(m2.compMiriams, numel(m2.comps));
+            end
+        end
+
         function mergeModelsReturnsStruct(testCase)
             modelB = removeReactions(testCase.model, testCase.model.rxns(1:5), true, true, true);
             evalc('merged = mergeModels({testCase.model; modelB});');


### PR DESCRIPTION
### Main improvements in this PR:

- fix:
  - `mergeCompartments` rebuilt `comps`/`compNames`/`compOutside` for the single merged compartment but left `compMiriams` at the original length, desyncing it from `comps` and breaking downstream `permuteModel`/`exportModel`/`writeYAMLmodel`. The per-compartment annotations no longer apply once everything is merged, so the field is dropped.
- documentation:
  - Test in `tManipulation.m`.

#### Instructions on merging this PR:
- [X] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
