### PR TITLE
fix: surface CHRR rounding non-convergence through randomSampling

### DIFF
--- a/analysis/randomSampling.m
+++ b/analysis/randomSampling.m
@@ -1,4 +1,4 @@
-function [solutions, goodRxns]=randomSampling(model,varargin)
+function [solutions, goodRxns, info]=randomSampling(model,varargin)
 % randomSampling  Sample the flux solution space (entry point for all samplers).
 %
 % Dispatches to one of three sampling methods via the 'method' argument:
@@ -75,6 +75,10 @@ function [solutions, goodRxns]=randomSampling(model,varargin)
 %     [randomObjective] vector of indexes of those reactions that are not
 %     involved in loops or always carry zero flux and can be used as random
 %     objective functions. Empty ([]) for the 'achr' and 'chrr' methods.
+% info : struct
+%     [chrr] the diagnostics from sampleCHRR, including mveConverged (whether
+%     the maximum-volume ellipsoid rounding reached tolerance). Empty ([])
+%     for the 'achr' and 'randomObjective' methods.
 %
 % Notes
 % -----
@@ -111,6 +115,7 @@ seed=p.seed;
 method=p.method;
 thinning=p.thinning;
 nBurnin=p.nBurnin;
+info=[]; %only populated by the 'chrr' method
 if isempty(nSamples)
     nSamples=1000;
 end
@@ -129,7 +134,7 @@ switch lower(method)
         goodRxns = [];
         return;
     case 'chrr'
-        solutions = sampleCHRR(model, nSamples, thinning, nBurnin, seed);
+        [solutions, info] = sampleCHRR(model, nSamples, thinning, nBurnin, seed);
         goodRxns = [];
         return;
     case {'randomobjective', 'objective'}

--- a/analysis/sampleCHRR.m
+++ b/analysis/sampleCHRR.m
@@ -118,6 +118,11 @@ x0 = sampleChebyshevCenter(A_full, b_full);
 [center, E, converged] = sampleMaxVolEllipse(A_full, b_full, x0);
 info.nDimensions = d;
 info.mveConverged = converged;
+if ~converged
+    warning('RAVEN:warning', '%s', ['The maximum-volume ellipsoid rounding ' ...
+        'did not converge; the samples may be poorly mixed. Inspect the ' ...
+        'mveConverged field of the second output.']);
+end
 
 % Rounded polytope {y : A_r*y <= b_r}, which contains the unit ball.
 A_r = A_full * E;

--- a/testing/function_tests/tSampling.m
+++ b/testing/function_tests/tSampling.m
@@ -109,6 +109,14 @@ classdef tSampling < RavenTestCase
             testCase.verifyLessThan(max(abs(resid(:))), 1e-6);
         end
 
+        function randomSamplingCHRRExposesInfo(testCase)
+            % The CHRR convergence diagnostics must be reachable through the
+            % documented randomSampling entry point, not only sampleCHRR.
+            evalc(['[sols, gr, sInfo] = randomSampling(testCase.model, 10, ' ...
+                '''method'', ''chrr'', ''thinning'', 5, ''nBurnin'', 20, ''seed'', 1);']);
+            testCase.verifyTrue(isfield(sInfo, 'mveConverged'));
+        end
+
         function randomSamplingCHRRDeterministic(testCase)
             evalc(['s1 = randomSampling(testCase.model, 8, ''method'', ''chrr'', ' ...
                 '''thinning'', 5, ''nBurnin'', 20, ''seed'', 42);']);


### PR DESCRIPTION
### Main improvements in this PR:

- fix:
  - `sampleCHRR` computed `mveConverged` but never warned when the maximum-volume ellipsoid rounding failed to converge, and `randomSampling` discarded it (single output), so sampling via `randomSampling(...,'method','chrr')` gave no signal that the samples might be poorly mixed. `sampleCHRR` now warns on non-convergence, and `randomSampling` returns the CHRR `info` as a third output.
- documentation:
  - Test in `tSampling.m` that `info` is reachable through `randomSampling`.

#### Instructions on merging this PR:
- [X] This PR has `develop3` as target branch, and will be resolved with a *squash-merge*.
