### PR TITLE
fix: accept forward slashes in absolute Windows paths

### DIFF
--- a/io/checkFileExistence.m
+++ b/io/checkFileExistence.m
@@ -47,8 +47,8 @@ end
 filesOriginal = files;
 
 %Make all full paths before check of file existence
-if ispc % full path starts like "C:\"
-    inCurrDir = cellfun(@isempty,regexpi(files,'^[a-z]\:\\'));
+if ispc % full path starts like "C:\" or "C:/", or is a UNC path "\\server\share"
+    inCurrDir = cellfun(@isempty,regexpi(files,'^([a-z]\:[\\\/]|\\\\)'));
 else %isunix full path starts like "/"
     inCurrDir = cellfun(@isempty,regexpi(files,'^\/'));
 end

--- a/testing/function_tests/tIO.m
+++ b/testing/function_tests/tIO.m
@@ -142,6 +142,18 @@ classdef tIO < RavenTestCase
             testCase.verifyNotEmpty(out);
         end
 
+        function checkFileExistenceAcceptsForwardSlashes(testCase)
+            % An absolute Windows path may be written with forward slashes:
+            % MATLAB accepts them everywhere, and anything handing RAVEN a path
+            % built by another tool is likely to use them. Treating such a path
+            % as relative appends the working directory and turns
+            % "C:/data/model.mat" into "C:\somewhere\C:\data\model.mat".
+            f = fullfile(testCase.ravenRoot,'testing','function_tests', ...
+                'test_data','ecoli_textbook.mat');
+            out = checkFileExistence(strrep(f,'\','/'), 1, false, true);
+            testCase.verifyNotEmpty(out);
+        end
+
         function cleanSheetTrimsComments(testCase)
             raw = {'#comment', '#comment'; 'a', 'b'; '', ''};
             out = cleanSheet(raw);


### PR DESCRIPTION
`checkFileExistence` decides whether a path is already absolute with:

```matlab
inCurrDir = cellfun(@isempty,regexpi(files,'^[a-z]\:\'));
```

— a drive letter followed by a **backslash**. A valid absolute Windows path written with forward slashes fails that test, so the working directory is prepended:

```
File "C:\Work\GitHub\RAVEN\C:\Work\GitHub\RAVEN\testing\function_tests\test_data\ecoli_textbook.mat" cannot be found
```

MATLAB accepts forward slashes everywhere else, and a path arriving from another tool — a JSON config, a Python harness, a CI script — is likely to use them. I hit this feeding RAVEN paths from a cross-implementation test harness: every scenario failed on Windows for this reason alone, before any RAVEN code ran.

## The change

The regex now accepts either separator after the drive letter, and UNC paths (`\server\share`) too, since those were misread the same way:

```matlab
inCurrDir = cellfun(@isempty,regexpi(files,'^([a-z]\:[\\/]|\\)'));
```

Unix behaviour is untouched.

## Test

`tIO/checkFileExistenceAcceptsForwardSlashes` passes the same fixture path with forward slashes. Verified both ways on R2024b:

- with the fix: passes, alongside the existing `checkFileExistenceFindsFile`;
- with the fix reverted: fails with the doubled path above.
