### PR TITLE
fix: do not require the Parallel Computing Toolbox for gurobi, or optional columns in task lists

### DIFF
--- a/solver/optimizeProb.m
+++ b/solver/optimizeProb.m
@@ -120,7 +120,10 @@ switch solver
         solverparams.FeasibilityTol = defaultparams.feasTol;
         solverparams.OptimalityTol  = defaultparams.optTol;
         solverparams.Presolve       = 2;
-        if ~isempty(getCurrentTask) % If run in parallel, then one thread per gurobi
+        % getCurrentTask requires the Parallel Computing Toolbox; without it
+        % the call itself errors, so guard it rather than requiring the
+        % toolbox for every gurobi solve.
+        if exist('getCurrentTask','file') && ~isempty(getCurrentTask) % If run in parallel, then one thread per gurobi
             solverparams.Threads=1;
         end
         solverparams = structUpdate(solverparams,params);

--- a/tasks/parseTaskList.m
+++ b/tasks/parseTaskList.m
@@ -139,6 +139,12 @@ columns={'ID';'DESCRIPTION';'IN';'IN LB';'IN UB';'OUT';'OUT LB';'OUT UB';'EQU';'
 %Match the columns
 [I, colI]=ismember(columns,raw(1,:));
 
+%Only ID is required. Columns that are absent get index 0 from ismember, which
+%cannot be used to index raw, so point them at a spare empty column instead:
+%every optional field then reads as empty and its default applies.
+raw(:,end+1)={[]};
+colI(colI==0)=size(raw,2);
+
 %If read from  a text file, the numbers will be strings - fix that
 if convNumeric % in theory, this if should not be needed, the code should do nothing if all are already numeric. But it is kept as a safeguard.
     numericColumns = [0 0 0 1 1 0 1 1 0 1 1 0 1 1 0 0 0] == 1;


### PR DESCRIPTION
Fixes #690 and #692. Both were found while writing the [RAVEN documentation guide](https://github.com/edkerk/raven-docs), which executes its MATLAB examples on a base MATLAB install in CI — so anything that quietly depends on an extra toolbox, or on an optional column being present, fails there immediately.

### `optimizeProb`: Gurobi required the Parallel Computing Toolbox (#690)

The gurobi branch called `getCurrentTask` unguarded, to give each parallel worker a single thread:

```matlab
if ~isempty(getCurrentTask) % If run in parallel, then one thread per gurobi
```

`getCurrentTask` ships with the Parallel Computing Toolbox, so on a MATLAB without it *every* gurobi solve failed with `Unrecognized function or variable 'getCurrentTask'` — including a plain single-threaded `solveLP`, where the branch has nothing to do. GLPK was unaffected. Now guarded with `exist(...)`, so the behaviour is unchanged wherever PCT is installed.

### `parseTaskList`: optional columns could not be omitted (#692)

The docstring says `ID` is the only required column, but `colI` was indexed directly for every optional one, and `ismember` returns `0` for a header that is not present. A task file without, say, `PRINT FLUX` or `EQU LB` failed with:

```
Index in position 2 is invalid. Array indices must be positive integers or logical values.
```

naming neither the file nor the column. The failure came from several places — the numeric-conversion block, and the direct `colI(15)`, `colI(16)`, `colI(17)` reads — so absent columns now map to a spare empty column, and each optional field reads as empty and takes its default.

### Verified

On R2024b with Gurobi 13.0.2:

- a task file with only `ID`, `DESCRIPTION`, `SHOULD FAIL`, `IN`, `IN LB`, `IN UB`, `OUT`, `OUT LB`, `OUT UB` now parses (2 tasks), and a file with the full column set still parses (2 tasks);
- the parsed tasks still run through `checkTasks` against a model;
- a gurobi `solveLP` still returns the expected objective with the guard in place.
