### PR TITLE
fix: lower getModelFromHomology minLen default to 100

### DIFF
--- a/reconstruction/homology/getModelFromHomology.m
+++ b/reconstruction/homology/getModelFromHomology.m
@@ -53,9 +53,15 @@ function [draftModel, hitGenes]=getModelFromHomology(models,blastStructure,...
 % maxE : double
 %     only look at genes with E-values <= this value (default 10^-30).
 % minLen : double
-%     only look at genes with alignment length >= this value (default 200).
+%     only look at genes with alignment length >= this value (default 100).
+%     Measured against KEGG and OMA orthology across four organisms: any
+%     value at or below 150 performs the same, while the previous 200
+%     discarded real orthologs without reducing the number of wrong ones.
 % minIde : double
 %     only look at genes with identity >= this value (default 40 (%)).
+%     The filter that decides the outcome, and 40 is the measured optimum
+%     once a wrongly transferred reaction is treated as worse than a missing
+%     one. maxE, by contrast, changes nothing between 10^-4 and 10^-50.
 % mapNewGenesToOld : logical
 %     determines how to match genes if not looking at only 1-1 orthologs.
 %     Either map the new genes to the old or old genes to new. The default
@@ -94,7 +100,7 @@ getModelFor=char(getModelFor);
 
 p=parseRAVENargs(varargin, {'preferredOrder',[]; 'strictness',1; ...
     'bidirectional',[]; 'bestHitsOnly',[]; 'scoreBy','bitscore'; ...
-    'onlyGenesInModels',false; 'maxE',10^-30; 'minLen',200; 'minIde',40; ...
+    'onlyGenesInModels',false; 'maxE',10^-30; 'minLen',100; 'minIde',40; ...
     'mapNewGenesToOld',true});
 preferredOrder=p.preferredOrder;
 if isempty(preferredOrder)


### PR DESCRIPTION
`getModelFromHomology` filters homology hits on three thresholds — `maxE`, `minLen`, `minIde` — and none of them had ever been measured. `minLen` at 200 turns out to discard real orthologs without reducing the number of wrong ones.

## What was measured

Four organisms reconstructed from an *S. cerevisiae* template across a range of settings, with every surviving match checked against two independent sources: KEGG's gene annotations and OMA's ortholog assignments. Wrong matches count double, because a wrong reaction is worse than a missing one — gap-filling can add what is absent, while something wrong is hard to notice and harder to remove.

| `minLen` | *K. lactis* | *Y. lipolytica* | *A. nidulans* | *E. coli* |
|---|---|---|---|---|
| 50 | 0.933 | 0.871 | 0.815 | 0.618 |
| **100** | **0.933** | **0.871** | **0.815** | **0.618** |
| 150 | 0.932 | 0.869 | 0.813 | 0.615 |
| 200 *(current)* | 0.923 | 0.860 | 0.804 | 0.598 |
| 300 | 0.885 | 0.816 | 0.764 | 0.571 |

Anything at or below 150 performs the same; the loss appears between 150 and 200. Dropping to 100 recovers 3–4% more real matches on every organism while the wrong-match rate moves by at most 0.6 of a percentage point. 50 and 100 are indistinguishable, so 100 is the less permissive of two equal choices.

## Two findings recorded in the help text, not acted on

- **`minIde` is the filter that decides the outcome**, and 40 is the measured optimum under this weighting. Left unchanged.
- **`maxE` makes no difference at all** between 10^-4 and 10^-50 — identity and length have already removed whatever it would remove. Only at 10^-100 does it start discarding good matches. Left at 10^-30, but it is not worth tuning.

## Checked

- `tReconstruction`: 7 passed, 0 failed (2 skipped for missing binaries).
- Behaviour confirmed directly: with 150 aa alignments, 13 reactions transfer under the new default and none under the old one.

The same change is in [raven-toolbox#92](https://github.com/SysBioChalmers/raven-toolbox/pull/92), which carries the full study — including the finding that DIAMOND reaches the same optimum as BLAST, so both aligners can keep sharing these defaults.
