### PR TITLE
docs: indent struct-field descriptions to 4 spaces

### DIFF
--- a/analysis/sampleCHRR.m
+++ b/analysis/sampleCHRR.m
@@ -38,10 +38,10 @@ function [solutions, info] = sampleCHRR(model, nSamples, thinning, nBurnin, seed
 % -------
 % solutions : double
 %     nRxns-by-nSamples matrix of sampled flux distributions.
-% info : struct with fields:
-%   .nDimensions  — dimension of the sampled flux polytope
-%   .mveConverged — whether MVE rounding reached tolerance
-%   .fixedRxns    — IDs of reactions folded in as fixed
+% info : struct
+%     .nDimensions  — dimension of the sampled flux polytope
+%     .mveConverged — whether MVE rounding reached tolerance
+%     .fixedRxns    — IDs of reactions folded in as fixed
 %
 % See also
 % --------

--- a/gapfilling/gapFillTopological.m
+++ b/gapfilling/gapFillTopological.m
@@ -41,13 +41,13 @@ function result = gapFillTopological(model, universalModel, varargin)
 %
 % Returns
 % -------
-% result : struct with fields:
-%   .reachableMets   — logical vector (length nMets) marking producible mets
-%   .blockedMets     — cell array of metabolite IDs that cannot be reached
-%   .candidateRxns   — n-by-1 cell array of universal rxn ID lists, one
-%                      cell per blocked metabolite (same order as blockedMets)
-%   .pruningFraction — fraction of universal reactions pruned (not needed
-%                      for any blocked metabolite)
+% result : struct
+%     .reachableMets   — logical vector (length nMets) marking producible mets
+%     .blockedMets     — cell array of metabolite IDs that cannot be reached
+%     .candidateRxns   — n-by-1 cell array of universal rxn ID lists, one
+%                        cell per blocked metabolite (same order as blockedMets)
+%     .pruningFraction — fraction of universal reactions pruned (not needed
+%                        for any blocked metabolite)
 %
 % See also
 % --------


### PR DESCRIPTION
### Problem

Building the RAVEN documentation site emits 18 warnings of the form:

```
griffe: analysis/sampleCHRR.m:42: Confusing indentation for continuation line 41 in docstring, should be 4 spaces, not 2
griffe: gapfilling/gapFillTopological.m:45: Confusing indentation for continuation line 44 in docstring, should be 4 spaces, not 2
```

Both come from the same pattern — a struct-valued return whose fields are
listed at 2 spaces:

```matlab
% info : struct with fields:
%   .nDimensions  — dimension of the sampled flux polytope
```

In numpydoc style, a description continuation must be indented 4 spaces
relative to the entry name. At 2 spaces the field list is not reliably read as
part of the entry, so it can render outside it on the generated API page.

### Fix

Indent the field lines to 4 spaces, and give both entries the plain type
`struct`. That matches `analysis/compareFluxes.m`, which documents a struct
return the same way and produces no warnings:

```matlab
% result : struct
%     .turnedOn  — cell, rxn IDs newly active in fluxes2
```

Documentation only — no functional change.

### Verification

With these two files in place, `mkdocs build --strict` in the docs site reports
**zero** "Confusing indentation" warnings, down from 18.

Found while writing the flux-variability and gap-filling pages of the new
user guide.
