### PR TITLE
fix: sampleCHRR returns NaN when the equality system is square

### DIFF
--- a/analysis/sampleCHRR.m
+++ b/analysis/sampleCHRR.m
@@ -85,10 +85,14 @@ end
 
 % Particular solution v0 and nullspace basis N: v = v0 + N*x.
 % v0 is ANY particular solution; the sampled flux distribution is invariant to
-% its choice and to the nullspace basis, so MATLAB's '\' (a sparse basic
-% solution) and the Python reference's lstsq (minimum-norm solution) sample the
-% same polytope despite returning different v0.
-v0 = Aeq \ beq;
+% its choice and to the nullspace basis, so the minimum-norm solution used here
+% and the Python reference's lstsq sample the same polytope.
+% lsqminnorm rather than '\': Aeq is square whenever the number of metabolites
+% plus the number of folded-in fixed reactions equals the number of reactions,
+% and it is then rank-deficient, for which '\' returns NaN. Those NaNs travel
+% into the polytope and surface much later as a misleading "empty interior"
+% error from sampleChebyshevCenter.
+v0 = lsqminnorm(Aeq, beq);
 N  = null(Aeq);
 d  = size(N, 2);
 


### PR DESCRIPTION
### Problem

`sampleCHRR` fails on a model as small as the one shipped with the documentation
site (52 metabolites, 53 reactions):

```
sampleChebyshevCenter: LP infeasible - flux polytope has empty interior.
```

The polytope is not empty. The error comes from NaNs created much earlier.

`sampleCHRR` folds implicitly-fixed reactions into the equality system:

```matlab
Aeq = [S; blk];          % blk: one row per reaction with ~zero FVA width
v0  = Aeq \ beq;         % particular solution
```

On this model exactly one reaction is fixed (`ethIN`, bounds `[0 0]`), so `Aeq`
is **53 x 53 — square — with rank 44**. For a rank-deficient *square* system
MATLAB's backslash returns `NaN`, where for a rectangular one it would return a
basic solution. The NaNs flow into `A_full`/`b_full`, and the failure only
surfaces later, in `sampleChebyshevCenter`, as an infeasible LP.

The trigger is therefore `nMets + nFixed == nRxns`, which is not exotic — it is
one arithmetic coincidence away on any model.

### Fix

```matlab
v0 = lsqminnorm(Aeq, beq);
```

`lsqminnorm` returns the minimum-norm solution for a rank-deficient system of
any shape. As the surrounding comment already notes, `v0` may be any particular
solution — the sampled distribution does not depend on the choice — so this
changes nothing except the degenerate case. It also matches the Python
implementation, which uses `lstsq`.

### Verification

On the same model, before: the error above at every `fixedWidthTol` tried
(1e-7, 1e-6, 1e-4). After:

```
9 dimensions, 1 fixed, 53 x 200 samples, no NaNs
growth mean 0.0460, range 0.0097..0.0992
```

The Python implementation reports **9 dimensions and 1 fixed reaction** for the
same model, so the two now agree on the geometry; the sampled growth
distribution matches too (0.0098..0.0911 there, a different RNG).

`randomSampling`'s default `achr` path is untouched and still returns NaN-free
samples.

Found while writing the sampling page of the new user guide.
